### PR TITLE
feat: pilot frontmatter facts enrichment for journal entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,3 +188,7 @@ tests/*.progress.json
 journal_*.txt
 journal_*_enhanced.txt
 journal_*_facts.txt
+# Frontmatter facts cache
+cache/facts/
+# Firecrawl CLI data
+.firecrawl/

--- a/.gitignore
+++ b/.gitignore
@@ -184,11 +184,14 @@ cython_debug/
 tests/*.txt
 tests/*.json
 tests/*.progress.json
-# Ignore journal files
+# Ignore journal files at repo root (examples/ is versioned)
 journal_*.txt
 journal_*_enhanced.txt
 journal_*_facts.txt
+!examples/**/*
 # Frontmatter facts cache
 cache/facts/
+examples/uncle-frank/cache/
+examples/uncle-frank/*.log
 # Firecrawl CLI data
 .firecrawl/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: journal enhance test test-integration clean test-enhance facts test-facts
+.PHONY: journal enhance test test-integration clean test-enhance facts test-facts enrich-facts
 
 # Default journal ID - can be overridden: make journal JOURNAL_ID=12345
 JOURNAL_ID ?= 10467
@@ -59,6 +59,14 @@ test-facts: $(VENV)/bin/activate
 	@echo "\nGenerated facts:"
 	@cat $(TEST_FACTS)
 
+# Enrich journal with YAML frontmatter facts (rule-based, no AWS required)
+enrich-facts: $(VENV)/bin/activate
+	@if [ ! -f "$(JOURNAL_FILE)" ]; then \
+		echo "Error: $(JOURNAL_FILE) not found. Run 'make journal' first."; \
+		exit 1; \
+	fi
+	$(PYTHON) scripts/enrich_facts.py $(JOURNAL_FILE) --output journal_$(JOURNAL_ID)_facts.txt --cache cache/facts --limit 10
+
 # Run all tests except integration
 test: $(VENV)/bin/activate
 	PYTHONPATH=. $(PYTHON) -m pytest -v -m "not integration"
@@ -84,6 +92,7 @@ help:
 	@echo "  make journal [JOURNAL_ID=12345]  - Extract journal entries (default ID: 10467)"
 	@echo "  make enhance                     - Enhance journal with AI context and trail facts"
 	@echo "  make test-enhance                - Test enhancement on a small sample file"
+	@echo "  make enrich-facts                - Add YAML frontmatter facts (no AWS needed)"
 	@echo "  make test                        - Run unit tests"
 	@echo "  make test-integration            - Run integration tests (requires AWS setup)"
 	@echo "  make clean                       - Remove generated files"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: journal enhance test test-integration clean test-enhance facts test-facts enrich-facts
+.PHONY: journal enhance test test-integration clean test-enhance facts test-facts enrich-facts uncle-frank uncle-frank-facts
 
 # Default journal ID - can be overridden: make journal JOURNAL_ID=12345
 JOURNAL_ID ?= 10467
@@ -7,6 +7,12 @@ JOURNAL_ID ?= 10467
 VENV = venv
 PYTHON = $(VENV)/bin/python
 PIP = $(VENV)/bin/pip
+
+# Uncle Frank example (journal 10467)
+UNCLE_FRANK_DIR = examples/uncle-frank
+UNCLE_FRANK_JOURNAL = $(UNCLE_FRANK_DIR)/journal.txt
+UNCLE_FRANK_FACTS = $(UNCLE_FRANK_DIR)/journal_facts.txt
+UNCLE_FRANK_CACHE = $(UNCLE_FRANK_DIR)/cache/facts
 
 # File paths
 JOURNAL_FILE = journal_$(JOURNAL_ID).txt
@@ -66,6 +72,21 @@ enrich-facts: $(VENV)/bin/activate
 		exit 1; \
 	fi
 	$(PYTHON) scripts/enrich_facts.py $(JOURNAL_FILE) --output journal_$(JOURNAL_ID)_facts.txt --cache cache/facts --limit 10
+
+# Extract and enrich the Uncle Frank example journal (full run)
+uncle-frank:
+	@mkdir -p $(UNCLE_FRANK_DIR)
+	PYTHONPATH=. python3 scripts/extract_journal_firecrawl.py 10467 -o $(UNCLE_FRANK_JOURNAL) --workers 8
+
+uncle-frank-facts:
+	@if [ ! -f "$(UNCLE_FRANK_JOURNAL)" ]; then \
+		echo "Error: $(UNCLE_FRANK_JOURNAL) not found. Run 'make uncle-frank' first."; \
+		exit 1; \
+	fi
+	PYTHONPATH=. python3 scripts/enrich_facts.py $(UNCLE_FRANK_JOURNAL) \
+		--output $(UNCLE_FRANK_FACTS) \
+		--cache $(UNCLE_FRANK_CACHE) \
+		--use-firecrawl
 
 # Run all tests except integration
 test: $(VENV)/bin/activate

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ These are automatically installed when setting up the virtual environment.
 
 ## Future Plans
 
+- [x] Add support for YAML frontmatter facts enrichment (see `examples/uncle-frank/`)
 - [ ] Add support for image extraction
 - [ ] Implement different output formats (e.g., PDF, EPUB)
 - [ ] Add progress saving/resume capability

--- a/data/at_locations.json
+++ b/data/at_locations.json
@@ -1,0 +1,282 @@
+[
+  {
+    "name": "Amicalola Falls State Park",
+    "lat": 34.5583,
+    "lon": -84.2285,
+    "state": "GA",
+    "at_mile": -8.8,
+    "is_town": false
+  },
+  {
+    "name": "Hike Inn",
+    "lat": 34.5759,
+    "lon": -84.2178,
+    "state": "GA",
+    "at_mile": -5.0,
+    "is_town": false
+  },
+  {
+    "name": "Springer Mountain",
+    "lat": 34.6272,
+    "lon": -84.1930,
+    "state": "GA",
+    "at_mile": 0.0,
+    "is_town": false
+  },
+  {
+    "name": "Springer Mountain Shelter",
+    "lat": 34.6278,
+    "lon": -84.1955,
+    "state": "GA",
+    "at_mile": 0.2,
+    "is_town": false
+  },
+  {
+    "name": "Stover Creek Shelter",
+    "lat": 34.6556,
+    "lon": -84.1797,
+    "state": "GA",
+    "at_mile": 2.9,
+    "is_town": false
+  },
+  {
+    "name": "Three Forks",
+    "lat": 34.6500,
+    "lon": -84.1772,
+    "state": "GA",
+    "at_mile": 2.6,
+    "is_town": false
+  },
+  {
+    "name": "Hawk Mountain Shelter",
+    "lat": 34.6899,
+    "lon": -84.1540,
+    "state": "GA",
+    "at_mile": 8.1,
+    "is_town": false
+  },
+  {
+    "name": "Cooper Gap",
+    "lat": 34.7088,
+    "lon": -84.1586,
+    "state": "GA",
+    "at_mile": 11.5,
+    "is_town": false
+  },
+  {
+    "name": "Gooch Mountain Shelter",
+    "lat": 34.7399,
+    "lon": -84.1547,
+    "state": "GA",
+    "at_mile": 15.8,
+    "is_town": false
+  },
+  {
+    "name": "Woody Gap",
+    "lat": 34.7572,
+    "lon": -84.1048,
+    "state": "GA",
+    "at_mile": 19.7,
+    "is_town": false
+  },
+  {
+    "name": "Lance Creek Campsite",
+    "lat": 34.7693,
+    "lon": -84.0640,
+    "state": "GA",
+    "at_mile": 23.5,
+    "is_town": false
+  },
+  {
+    "name": "Blood Mountain Shelter",
+    "lat": 34.7983,
+    "lon": -84.0007,
+    "state": "GA",
+    "at_mile": 30.7,
+    "is_town": false
+  },
+  {
+    "name": "Neel Gap",
+    "lat": 34.7416,
+    "lon": -83.9297,
+    "state": "GA",
+    "at_mile": 31.7,
+    "is_town": false
+  },
+  {
+    "name": "Neel Gap Hostel",
+    "lat": 34.7416,
+    "lon": -83.9297,
+    "state": "GA",
+    "at_mile": 31.7,
+    "is_town": false
+  },
+  {
+    "name": "Walasi-Yi Center",
+    "lat": 34.7416,
+    "lon": -83.9297,
+    "state": "GA",
+    "at_mile": 31.7,
+    "is_town": false
+  },
+  {
+    "name": "Whitley Gap Shelter",
+    "lat": 34.7960,
+    "lon": -83.9296,
+    "state": "GA",
+    "at_mile": 35.4,
+    "is_town": false
+  },
+  {
+    "name": "Low Gap Shelter",
+    "lat": 34.8345,
+    "lon": -83.9050,
+    "state": "GA",
+    "at_mile": 38.5,
+    "is_town": false
+  },
+  {
+    "name": "Unicoi Gap",
+    "lat": 34.8401,
+    "lon": -83.7430,
+    "state": "GA",
+    "at_mile": 46.4,
+    "is_town": false
+  },
+  {
+    "name": "Blue Mountain Shelter",
+    "lat": 34.8501,
+    "lon": -83.6985,
+    "state": "GA",
+    "at_mile": 49.1,
+    "is_town": false
+  },
+  {
+    "name": "Tray Mountain Shelter",
+    "lat": 34.8618,
+    "lon": -83.6551,
+    "state": "GA",
+    "at_mile": 54.5,
+    "is_town": false
+  },
+  {
+    "name": "Dicks Creek Gap",
+    "lat": 34.8879,
+    "lon": -83.5906,
+    "state": "GA",
+    "at_mile": 59.5,
+    "is_town": false
+  },
+  {
+    "name": "Helen GA",
+    "lat": 34.7005,
+    "lon": -83.7300,
+    "state": "GA",
+    "at_mile": null,
+    "is_town": true
+  },
+  {
+    "name": "Hiawassee GA",
+    "lat": 34.9510,
+    "lon": -83.7565,
+    "state": "GA",
+    "at_mile": null,
+    "is_town": true
+  },
+  {
+    "name": "Deep Gap Shelter",
+    "lat": 34.9333,
+    "lon": -83.5547,
+    "state": "GA",
+    "at_mile": 61.8,
+    "is_town": false
+  },
+  {
+    "name": "Bly Gap",
+    "lat": 34.9771,
+    "lon": -83.5050,
+    "state": "GA",
+    "at_mile": 68.1,
+    "is_town": false
+  },
+  {
+    "name": "Standing Indian Shelter",
+    "lat": 35.0370,
+    "lon": -83.5279,
+    "state": "NC",
+    "at_mile": 70.2,
+    "is_town": false
+  },
+  {
+    "name": "Carter Gap Shelter",
+    "lat": 35.0683,
+    "lon": -83.5104,
+    "state": "NC",
+    "at_mile": 75.2,
+    "is_town": false
+  },
+  {
+    "name": "Rock Gap Shelter",
+    "lat": 35.0836,
+    "lon": -83.5065,
+    "state": "NC",
+    "at_mile": 79.5,
+    "is_town": false
+  },
+  {
+    "name": "Winding Stair Gap",
+    "lat": 35.1562,
+    "lon": -83.3812,
+    "state": "NC",
+    "at_mile": 84.1,
+    "is_town": false
+  },
+  {
+    "name": "Franklin NC",
+    "lat": 35.1832,
+    "lon": -83.3813,
+    "state": "NC",
+    "at_mile": null,
+    "is_town": true
+  },
+  {
+    "name": "Cold Spring Shelter",
+    "lat": 35.2112,
+    "lon": -83.3237,
+    "state": "NC",
+    "at_mile": 88.4,
+    "is_town": false
+  },
+  {
+    "name": "Wayah Bald Shelter",
+    "lat": 35.1919,
+    "lon": -83.2882,
+    "state": "NC",
+    "at_mile": 91.6,
+    "is_town": false
+  },
+  {
+    "name": "Siler Bald Shelter",
+    "lat": 35.2225,
+    "lon": -83.2387,
+    "state": "NC",
+    "at_mile": 98.6,
+    "is_town": false
+  },
+  {
+    "name": "Wesser NOC",
+    "lat": 35.3152,
+    "lon": -83.5768,
+    "state": "NC",
+    "at_mile": 137.1,
+    "is_town": false
+  },
+  {
+    "name": "Nantahala Outdoor Center",
+    "lat": 35.3152,
+    "lon": -83.5768,
+    "state": "NC",
+    "at_mile": 137.1,
+    "is_town": false
+  }
+]

--- a/data/at_locations.json
+++ b/data/at_locations.json
@@ -18,7 +18,7 @@
   {
     "name": "Springer Mountain",
     "lat": 34.6272,
-    "lon": -84.1930,
+    "lon": -84.193,
     "state": "GA",
     "at_mile": 0.0,
     "is_town": false
@@ -41,7 +41,7 @@
   },
   {
     "name": "Three Forks",
-    "lat": 34.6500,
+    "lat": 34.65,
     "lon": -84.1772,
     "state": "GA",
     "at_mile": 2.6,
@@ -50,7 +50,7 @@
   {
     "name": "Hawk Mountain Shelter",
     "lat": 34.6899,
-    "lon": -84.1540,
+    "lon": -84.154,
     "state": "GA",
     "at_mile": 8.1,
     "is_town": false
@@ -82,7 +82,7 @@
   {
     "name": "Lance Creek Campsite",
     "lat": 34.7693,
-    "lon": -84.0640,
+    "lon": -84.064,
     "state": "GA",
     "at_mile": 23.5,
     "is_town": false
@@ -121,7 +121,7 @@
   },
   {
     "name": "Whitley Gap Shelter",
-    "lat": 34.7960,
+    "lat": 34.796,
     "lon": -83.9296,
     "state": "GA",
     "at_mile": 35.4,
@@ -130,7 +130,7 @@
   {
     "name": "Low Gap Shelter",
     "lat": 34.8345,
-    "lon": -83.9050,
+    "lon": -83.905,
     "state": "GA",
     "at_mile": 38.5,
     "is_town": false
@@ -138,7 +138,7 @@
   {
     "name": "Unicoi Gap",
     "lat": 34.8401,
-    "lon": -83.7430,
+    "lon": -83.743,
     "state": "GA",
     "at_mile": 46.4,
     "is_town": false
@@ -170,14 +170,14 @@
   {
     "name": "Helen GA",
     "lat": 34.7005,
-    "lon": -83.7300,
+    "lon": -83.73,
     "state": "GA",
     "at_mile": null,
     "is_town": true
   },
   {
     "name": "Hiawassee GA",
-    "lat": 34.9510,
+    "lat": 34.951,
     "lon": -83.7565,
     "state": "GA",
     "at_mile": null,
@@ -194,14 +194,14 @@
   {
     "name": "Bly Gap",
     "lat": 34.9771,
-    "lon": -83.5050,
+    "lon": -83.505,
     "state": "GA",
     "at_mile": 68.1,
     "is_town": false
   },
   {
     "name": "Standing Indian Shelter",
-    "lat": 35.0370,
+    "lat": 35.037,
     "lon": -83.5279,
     "state": "NC",
     "at_mile": 70.2,
@@ -277,6 +277,950 @@
     "lon": -83.5768,
     "state": "NC",
     "at_mile": 137.1,
+    "is_town": false
+  },
+  {
+    "name": "** A cabin (Hot Springs, NC)",
+    "lat": 35.8873086,
+    "lon": -82.8325637,
+    "state": "US",
+    "at_mile": null,
+    "is_town": true
+  },
+  {
+    "name": "** A cabin (NOC)",
+    "lat": 35.3320031,
+    "lon": -83.5927636,
+    "state": "US",
+    "at_mile": null,
+    "is_town": true
+  },
+  {
+    "name": "** A cabin (Pearisburg, VA)",
+    "lat": 37.3328976,
+    "lon": -80.7578723,
+    "state": "US",
+    "at_mile": null,
+    "is_town": true
+  },
+  {
+    "name": "** A pavillion (Lee, MA)",
+    "lat": 42.3193008,
+    "lon": -73.1653942,
+    "state": "US",
+    "at_mile": null,
+    "is_town": true
+  },
+  {
+    "name": "** Augusta's Appalachian Inn (Damascus, VA)",
+    "lat": 36.6344797,
+    "lon": -81.7917876,
+    "state": "US",
+    "at_mile": null,
+    "is_town": true
+  },
+  {
+    "name": "** Back Home Again Hostel (Rutland, VT)",
+    "lat": 43.6181003,
+    "lon": -72.8204645,
+    "state": "US",
+    "at_mile": null,
+    "is_town": true
+  },
+  {
+    "name": "** Bailey Gap Shelter",
+    "lat": 37.4008725,
+    "lon": -80.577011,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "** Bemis Mountain Lean-to",
+    "lat": 44.810181,
+    "lon": -70.7559071,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "** Blackburn Trail Center",
+    "lat": 39.1875578,
+    "lon": -77.7980399,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "** Bob Boon's Home (Hanover, NH)",
+    "lat": 43.704847,
+    "lon": -72.2296981,
+    "state": "US",
+    "at_mile": null,
+    "is_town": true
+  },
+  {
+    "name": "** Brown Fork Gap Shelter",
+    "lat": 35.3743019,
+    "lon": -83.7339199,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "** Campbell Shelter",
+    "lat": 37.3908393,
+    "lon": -80.0292308,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "** Chairback Gap Lean-to",
+    "lat": 45.4531531,
+    "lon": -69.2623006,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "** Church of the Mountain Hostel (Delaware-Water Gap)",
+    "lat": 40.9499331,
+    "lon": -75.1502172,
+    "state": "US",
+    "at_mile": null,
+    "is_town": true
+  },
+  {
+    "name": "** Clyde Smith Shelter",
+    "lat": 36.1484857,
+    "lon": -82.1611563,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "** Cooper Brook Falls Lean-to",
+    "lat": 45.6404021,
+    "lon": -69.0873765,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "** Cosby Knob Shelter",
+    "lat": 35.7282786,
+    "lon": -83.1820772,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "** Cove Mountain Shelter",
+    "lat": 37.5117097,
+    "lon": -79.6507825,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "** Curley Maple Gap Shelter",
+    "lat": 36.1043382,
+    "lon": -82.3968108,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "** Deer Park Shelter",
+    "lat": 35.8759904,
+    "lon": -82.861288,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "** Derrick Knob Shelter",
+    "lat": 35.5665514,
+    "lon": -83.641946,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "** Double Spring Shelter",
+    "lat": 35.5652675,
+    "lon": -83.5426357,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "** Fontana Dam Shelter",
+    "lat": 35.4485442,
+    "lon": -83.7939517,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "** Fullhardt Knob Shelter",
+    "lat": 37.3985665,
+    "lon": -79.8536873,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "** Goddard Shelter",
+    "lat": 42.9741481,
+    "lon": -73.0722474,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "** Hikers Paradise Hostel (Gorham, NH)",
+    "lat": 44.4579636,
+    "lon": -71.0844318,
+    "state": "US",
+    "at_mile": null,
+    "is_town": true
+  },
+  {
+    "name": "** Horns Pond Lean-to",
+    "lat": 45.1441538,
+    "lon": -70.3301055,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "** Icewater Spring Shelter",
+    "lat": 35.6298206,
+    "lon": -83.3863279,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "** Jenkins Shelter",
+    "lat": 37.0934084,
+    "lon": -81.2475848,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "** Jerry Cabin Shelter",
+    "lat": 36.0565109,
+    "lon": -82.6571879,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "** Linden Motel pool house (Greenwood Lake, NY)",
+    "lat": 41.271927,
+    "lon": -74.1673711,
+    "state": "US",
+    "at_mile": null,
+    "is_town": true
+  },
+  {
+    "name": "** Minerva-Hinchey Shelter",
+    "lat": 43.4876924,
+    "lon": -72.9245154,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "** Muskrat Creek Shelter",
+    "lat": 35.0206085,
+    "lon": -83.5814845,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "** Next to VT Route 11 (Manchester Center, VT)",
+    "lat": 43.1525516,
+    "lon": -73.0072313,
+    "state": "US",
+    "at_mile": null,
+    "is_town": true
+  },
+  {
+    "name": "** Next to a road (Pomfret, VT)",
+    "lat": 43.6810828,
+    "lon": -72.5137229,
+    "state": "US",
+    "at_mile": null,
+    "is_town": true
+  },
+  {
+    "name": "** Niday Shelter",
+    "lat": 37.3876901,
+    "lon": -80.264074,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "** No Business Knob Shelter",
+    "lat": 36.0666228,
+    "lon": -82.4336836,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "** On the side of the road (U.S. 442)",
+    "lat": 29.8433725,
+    "lon": -98.1001069,
+    "state": "US",
+    "at_mile": null,
+    "is_town": true
+  },
+  {
+    "name": "** Peters Mountain Shelter",
+    "lat": 40.4257174,
+    "lon": -76.8793809,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "** Rausch Gap Shelter",
+    "lat": 40.4986596,
+    "lon": -76.6002427,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "** Rendezevous Motel (Pearisburg, VA)",
+    "lat": 37.3328976,
+    "lon": -80.7578723,
+    "state": "US",
+    "at_mile": null,
+    "is_town": true
+  },
+  {
+    "name": "** Roaring Fork Shelter",
+    "lat": 35.804968,
+    "lon": -82.9499168,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "** Sapphire Inn (Franklin, NC)",
+    "lat": 44.7686524,
+    "lon": -70.7691791,
+    "state": "US",
+    "at_mile": null,
+    "is_town": true
+  },
+  {
+    "name": "** Spaulding Mountain Lean-to",
+    "lat": 44.9957605,
+    "lon": -70.3414303,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "** Spring Mountain Shelter",
+    "lat": 35.9518292,
+    "lon": -82.7901239,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "** Stewart Hollow Brook Lean-to",
+    "lat": 41.779304,
+    "lon": -73.4185583,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "** Stony Brook Shelter",
+    "lat": 43.6916885,
+    "lon": -72.7301035,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "** The Cabin (Andover, ME)",
+    "lat": 44.642151,
+    "lon": -70.889237,
+    "state": "US",
+    "at_mile": null,
+    "is_town": true
+  },
+  {
+    "name": "** The Pavilion (Port Clinton, PA)",
+    "lat": 40.5762228,
+    "lon": -76.0232955,
+    "state": "US",
+    "at_mile": null,
+    "is_town": true
+  },
+  {
+    "name": "** The Place (Damascus, VA)",
+    "lat": 36.6344797,
+    "lon": -81.7917876,
+    "state": "US",
+    "at_mile": null,
+    "is_town": true
+  },
+  {
+    "name": "** Tom Levardi's home (Dalton, MA)",
+    "lat": 42.4596422,
+    "lon": -73.1646145,
+    "state": "US",
+    "at_mile": null,
+    "is_town": true
+  },
+  {
+    "name": "** Tom's Run Shelters",
+    "lat": 40.0341226,
+    "lon": -77.3566789,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "** Travelodge Motel (Daleville, VA)",
+    "lat": 37.3898461,
+    "lon": -79.9154658,
+    "state": "US",
+    "at_mile": null,
+    "is_town": true
+  },
+  {
+    "name": "** Tumbling Run Shelters",
+    "lat": 39.8049651,
+    "lon": -77.4779216,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "** U.S. 58",
+    "lat": 41.9822553,
+    "lon": -73.4068538,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "** Wadleigh Stream Lean-to",
+    "lat": 45.747145,
+    "lon": -69.1446592,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "** Wesley's frat house (Charlottesville, VA)",
+    "lat": 38.066845,
+    "lon": -78.7984475,
+    "state": "US",
+    "at_mile": null,
+    "is_town": true
+  },
+  {
+    "name": "** Wilson Valley Lean-to",
+    "lat": 45.3978342,
+    "lon": -69.4595003,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "** Wise Shelter",
+    "lat": 36.6539509,
+    "lon": -81.4983811,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "A cabin (Hot Springs, NC)",
+    "lat": 35.8873086,
+    "lon": -82.8325637,
+    "state": "US",
+    "at_mile": null,
+    "is_town": true
+  },
+  {
+    "name": "A cabin (NOC)",
+    "lat": 35.3320031,
+    "lon": -83.5927636,
+    "state": "US",
+    "at_mile": null,
+    "is_town": true
+  },
+  {
+    "name": "A cabin (Pearisburg, VA)",
+    "lat": 37.3328976,
+    "lon": -80.7578723,
+    "state": "US",
+    "at_mile": null,
+    "is_town": true
+  },
+  {
+    "name": "A pavillion (Lee, MA)",
+    "lat": 42.3193008,
+    "lon": -73.1653942,
+    "state": "US",
+    "at_mile": null,
+    "is_town": true
+  },
+  {
+    "name": "Augusta's Appalachian Inn (Damascus, VA)",
+    "lat": 36.6344797,
+    "lon": -81.7917876,
+    "state": "US",
+    "at_mile": null,
+    "is_town": true
+  },
+  {
+    "name": "Back Home Again Hostel (Rutland, VT)",
+    "lat": 43.6181003,
+    "lon": -72.8204645,
+    "state": "US",
+    "at_mile": null,
+    "is_town": true
+  },
+  {
+    "name": "Bailey Gap Shelter",
+    "lat": 37.4008725,
+    "lon": -80.577011,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "Bemis Mountain Lean-to",
+    "lat": 44.810181,
+    "lon": -70.7559071,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "Blackburn Trail Center",
+    "lat": 39.1875578,
+    "lon": -77.7980399,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "Bob Boon's Home (Hanover, NH)",
+    "lat": 43.704847,
+    "lon": -72.2296981,
+    "state": "US",
+    "at_mile": null,
+    "is_town": true
+  },
+  {
+    "name": "Brown Fork Gap Shelter",
+    "lat": 35.3743019,
+    "lon": -83.7339199,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "Campbell Shelter",
+    "lat": 37.3908393,
+    "lon": -80.0292308,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "Chairback Gap Lean-to",
+    "lat": 45.4531531,
+    "lon": -69.2623006,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "Church of the Mountain Hostel (Delaware-Water Gap)",
+    "lat": 40.9499331,
+    "lon": -75.1502172,
+    "state": "US",
+    "at_mile": null,
+    "is_town": true
+  },
+  {
+    "name": "Clyde Smith Shelter",
+    "lat": 36.1484857,
+    "lon": -82.1611563,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "Cooper Brook Falls Lean-to",
+    "lat": 45.6404021,
+    "lon": -69.0873765,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "Cosby Knob Shelter",
+    "lat": 35.7282786,
+    "lon": -83.1820772,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "Cove Mountain Shelter",
+    "lat": 37.5117097,
+    "lon": -79.6507825,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "Curley Maple Gap Shelter",
+    "lat": 36.1043382,
+    "lon": -82.3968108,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "Deer Park Shelter",
+    "lat": 35.8759904,
+    "lon": -82.861288,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "Derrick Knob Shelter",
+    "lat": 35.5665514,
+    "lon": -83.641946,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "Doc's front porch (Gorham, NH)",
+    "lat": 44.4579636,
+    "lon": -71.0844318,
+    "state": "US",
+    "at_mile": null,
+    "is_town": true
+  },
+  {
+    "name": "Fontana Dam Shelter",
+    "lat": 35.4485442,
+    "lon": -83.7939517,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "Fullhardt Knob Shelter",
+    "lat": 37.3985665,
+    "lon": -79.8536873,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "Goddard Shelter",
+    "lat": 42.9741481,
+    "lon": -73.0722474,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "Hikers Paradise Hostel (Gorham, NH)",
+    "lat": 44.4579636,
+    "lon": -71.0844318,
+    "state": "US",
+    "at_mile": null,
+    "is_town": true
+  },
+  {
+    "name": "Horns Pond Lean-to",
+    "lat": 45.1441538,
+    "lon": -70.3301055,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "Icewater Spring Shelter",
+    "lat": 35.6298206,
+    "lon": -83.3863279,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "Jenkins Shelter",
+    "lat": 37.0934084,
+    "lon": -81.2475848,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "Jerry Cabin Shelter",
+    "lat": 36.0565109,
+    "lon": -82.6571879,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "Linden Motel pool house (Greenwood Lake, NY)",
+    "lat": 41.271927,
+    "lon": -74.1673711,
+    "state": "US",
+    "at_mile": null,
+    "is_town": true
+  },
+  {
+    "name": "Minerva-Hinchey Shelter",
+    "lat": 43.4876924,
+    "lon": -72.9245154,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "Moreland Gap Shelter",
+    "lat": 36.2201619,
+    "lon": -82.0883344,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "Muskrat Creek Shelter",
+    "lat": 35.0206085,
+    "lon": -83.5814845,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "Next to VT Route 11 (Manchester Center, VT)",
+    "lat": 43.1525516,
+    "lon": -73.0072313,
+    "state": "US",
+    "at_mile": null,
+    "is_town": true
+  },
+  {
+    "name": "Next to a road (Pomfret, VT)",
+    "lat": 43.6810828,
+    "lon": -72.5137229,
+    "state": "US",
+    "at_mile": null,
+    "is_town": true
+  },
+  {
+    "name": "Niday Shelter",
+    "lat": 37.3876901,
+    "lon": -80.264074,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "No Business Knob Shelter",
+    "lat": 36.0666228,
+    "lon": -82.4336836,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "On the side of the road (U.S. 442)",
+    "lat": 29.8433725,
+    "lon": -98.1001069,
+    "state": "US",
+    "at_mile": null,
+    "is_town": true
+  },
+  {
+    "name": "Peters Mountain Shelter",
+    "lat": 40.4257174,
+    "lon": -76.8793809,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "Rausch Gap Shelter",
+    "lat": 40.4986596,
+    "lon": -76.6002427,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "Rendezevous Motel (Pearisburg, VA)",
+    "lat": 37.3328976,
+    "lon": -80.7578723,
+    "state": "US",
+    "at_mile": null,
+    "is_town": true
+  },
+  {
+    "name": "Roaring Fork Shelter",
+    "lat": 35.804968,
+    "lon": -82.9499168,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "Sapphire Inn (Franklin, NC)",
+    "lat": 44.7686524,
+    "lon": -70.7691791,
+    "state": "US",
+    "at_mile": null,
+    "is_town": true
+  },
+  {
+    "name": "Spaulding Mountain Lean-to",
+    "lat": 44.9957605,
+    "lon": -70.3414303,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "Spring Mountain Shelter",
+    "lat": 35.9518292,
+    "lon": -82.7901239,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "Stewart Hollow Brook Lean-to",
+    "lat": 41.779304,
+    "lon": -73.4185583,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "Stony Brook Shelter",
+    "lat": 43.6916885,
+    "lon": -72.7301035,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "The Cabin (Andover, ME)",
+    "lat": 44.642151,
+    "lon": -70.889237,
+    "state": "US",
+    "at_mile": null,
+    "is_town": true
+  },
+  {
+    "name": "The Pavilion (Port Clinton, PA)",
+    "lat": 40.5762228,
+    "lon": -76.0232955,
+    "state": "US",
+    "at_mile": null,
+    "is_town": true
+  },
+  {
+    "name": "The Place (Damascus, VA)",
+    "lat": 36.6344797,
+    "lon": -81.7917876,
+    "state": "US",
+    "at_mile": null,
+    "is_town": true
+  },
+  {
+    "name": "Tom Levardi's home (Dalton, MA)",
+    "lat": 42.4596422,
+    "lon": -73.1646145,
+    "state": "US",
+    "at_mile": null,
+    "is_town": true
+  },
+  {
+    "name": "Tom's Run Shelters",
+    "lat": 40.0341226,
+    "lon": -77.3566789,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "Travelodge Motel (Daleville, VA)",
+    "lat": 37.3898461,
+    "lon": -79.9154658,
+    "state": "US",
+    "at_mile": null,
+    "is_town": true
+  },
+  {
+    "name": "Tumbling Run Shelters",
+    "lat": 39.8049651,
+    "lon": -77.4779216,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "Wadleigh Stream Lean-to",
+    "lat": 45.747145,
+    "lon": -69.1446592,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "Wesley's frat house (Charlottesville, VA)",
+    "lat": 38.066845,
+    "lon": -78.7984475,
+    "state": "US",
+    "at_mile": null,
+    "is_town": true
+  },
+  {
+    "name": "Wilson Valley Lean-to",
+    "lat": 45.3978342,
+    "lon": -69.4595003,
+    "state": "US",
+    "at_mile": null,
+    "is_town": false
+  },
+  {
+    "name": "Wise Shelter",
+    "lat": 36.6539509,
+    "lon": -81.4983811,
+    "state": "US",
+    "at_mile": null,
     "is_town": false
   }
 ]

--- a/data/at_segment_guides.json
+++ b/data/at_segment_guides.json
@@ -1,0 +1,245 @@
+[
+  {
+    "mile_start": -10,
+    "mile_end": 8,
+    "region": "Georgia",
+    "name": "Springer Mountain approach",
+    "summary": "The southernmost AT miles climb from Amicalola Falls through the Approach Trail to Springer Mountain, often in late-winter snow and ice.",
+    "terrain": "Steep approach-trail climbing, icy hardwood forest, and the emotional start of a northbound thru-hike.",
+    "notable": ["Amicalola Falls", "Springer Mountain", "Hawk Mountain Shelter"]
+  },
+  {
+    "mile_start": 8,
+    "mile_end": 32,
+    "region": "Georgia",
+    "name": "Georgia Blue Ridge — early ridges",
+    "summary": "Rolling Blue Ridge ridgelines with frequent shelters, creek crossings, and the first sustained mountain walking of the hike.",
+    "terrain": "Rocky tread, rhododendron tunnels, and climbs toward Blood Mountain — Georgia's highest AT peak.",
+    "notable": ["Gooch Mountain", "Woody Gap", "Blood Mountain", "Neels Gap"]
+  },
+  {
+    "mile_start": 32,
+    "mile_end": 78,
+    "region": "Georgia",
+    "name": "Georgia — Blood Mountain to Bly Gap",
+    "summary": "Classic Georgia AT: long climbs, mountain laurel, and trail-town access near Helen and Hiawassee before the NC border.",
+    "terrain": "Sustained ups and downs along the Blue Ridge; often muddy in spring; famous steep pitches leaving NOC later.",
+    "notable": ["Neels Gap", "Unicoi Gap", "Tray Mountain", "Bly Gap"]
+  },
+  {
+    "mile_start": 78,
+    "mile_end": 137,
+    "region": "North Carolina",
+    "name": "Southern North Carolina high country",
+    "summary": "High southern Appalachians with Standing Indian, Franklin resupply, and the long climb toward the Nantahala gorge.",
+    "terrain": "Big elevation change, open balds, and remote ridge walking south of the Smokies.",
+    "notable": ["Standing Indian", "Franklin", "Wayah Bald", "Nantahala Outdoor Center"]
+  },
+  {
+    "mile_start": 137,
+    "mile_end": 170,
+    "region": "North Carolina",
+    "name": "Nantahala gorge to Fontana Dam",
+    "summary": "One of the steepest climbs on the entire trail leaves the NOC river gorge; hikers then traverse the Smokies approach to Fontana.",
+    "terrain": "Brutal climb out of the gorge (3,000+ ft), then ridge walking toward the 'Fontana Hilton' shelter at the dam.",
+    "notable": ["NOC", "Fontana Dam", "Fontana Dam Shelter"]
+  },
+  {
+    "mile_start": 170,
+    "mile_end": 210,
+    "region": "Tennessee / Great Smoky Mountains",
+    "name": "Great Smoky Mountains National Park (south)",
+    "summary": "Inside GSMNP: sustained climbing, crowded shelters, bear cables, and mandatory backcountry permits define this iconic section.",
+    "terrain": "Dense spruce-fir near treeline, icy spring conditions, and some of the highest elevations on the entire AT.",
+    "notable": ["Clingmans Dome", "Mollies Ridge", "Icewater Spring"]
+  },
+  {
+    "mile_start": 210,
+    "mile_end": 275,
+    "region": "Tennessee / North Carolina",
+    "name": "Smokies exit to Hot Springs",
+    "summary": "Northbound hikers leave the Smokies at Davenport Gap and cross into the balds-and-river country around Hot Springs.",
+    "terrain": "Post-Smokies fatigue is common; Max Patch bald offers huge views; trail softens into pastoral TN/NC border country.",
+    "notable": ["Davenport Gap", "Max Patch", "Hot Springs"]
+  },
+  {
+    "mile_start": 275,
+    "mile_end": 350,
+    "region": "North Carolina / Tennessee",
+    "name": "Cherokee National Forest balds",
+    "summary": "Ridge walking through grassy balds and forested gaps between Hot Springs and the Roan Highlands approach.",
+    "terrain": "Exposed ridges, spring snow squalls, and increasing trail community as hikers settle into mileage.",
+    "notable": ["Roaring Fork", "Groundhog Creek", "Big Bald"]
+  },
+  {
+    "mile_start": 350,
+    "mile_end": 420,
+    "region": "Tennessee / North Carolina",
+    "name": "Roan Highlands",
+    "summary": "The Roan Highlands feature treeless 6,000-foot balds, rhododendron gardens, and some of the most scenic ridge walking on the AT.",
+    "terrain": "Wide-open balds with punishing winds; spectacular views when clouds lift; very exposed in storms.",
+    "notable": ["Roan High Knob", "Carvers Gap", "Overmountain Shelter"]
+  },
+  {
+    "mile_start": 420,
+    "mile_end": 470,
+    "region": "Tennessee / Virginia",
+    "name": "TN–VA high country to Damascus",
+    "summary": "Crossing into Virginia, hikers descend toward the Holston River and the legendary trail town of Damascus.",
+    "terrain": "Long ridge traverses giving way to river valleys; spring green tunnels and increasing horse/equestrian trail overlap in places.",
+    "notable": ["Damascus", "The Place", "Kincora Hostel"]
+  },
+  {
+    "mile_start": 470,
+    "mile_end": 550,
+    "region": "Virginia",
+    "name": "Southwest Virginia — Grayson Highlands",
+    "summary": "Virginia's high country: wild ponies at Grayson Highlands, open balds, and the rhythm of 20-mile days many hikers adopt.",
+    "terrain": "Frequent 4,000-foot knobs, meadow walking, and reliable spring water; notorious spring mud in gaps.",
+    "notable": ["Grayson Highlands", "Mount Rogers", "Partnership Shelter"]
+  },
+  {
+    "mile_start": 550,
+    "mile_end": 650,
+    "region": "Virginia",
+    "name": "Central Virginia Blue Ridge",
+    "summary": "The long Virginia grind begins in earnest — hundreds of miles of Blue Ridge walking with road crossings and small towns.",
+    "terrain": "Pine forest, PUDs (pointless ups and downs), and creek valleys; psychologically challenging monotony.",
+    "notable": ["Pearisburg", "Dragon's Tooth", "McAfee Knob"]
+  },
+  {
+    "mile_start": 650,
+    "mile_end": 750,
+    "region": "Virginia",
+    "name": "Central Virginia — McAfee Knob and Tye River",
+    "summary": "Home to McAfee Knob and Dragon's Tooth — two of the most iconic photo ops on the entire trail.",
+    "terrain": "Rocky scrambles, knife-edge overlooks, and steep descents into the James River gorge.",
+    "notable": ["McAfee Knob", "Dragon's Tooth", "James River Foot Bridge"]
+  },
+  {
+    "mile_start": 750,
+    "mile_end": 850,
+    "region": "Virginia",
+    "name": "Virginia — Blue Ridge to Shenandoah approach",
+    "summary": "Approaching Shenandoah National Park through rolling Blue Ridge country and Civil War-era landscape.",
+    "terrain": "Gradual climbs, horse trails, and increasing signs of proximity to the DC metro exurbs.",
+    "notable": ["Blacksburg area", "Bluff City", "Shenandoah south entrance"]
+  },
+  {
+    "mile_start": 850,
+    "mile_end": 1010,
+    "region": "Virginia",
+    "name": "Shenandoah National Park",
+    "summary": "Shenandoah offers relatively gentle graded walking, black bears, waysides with pie, and Skyline Drive crossings.",
+    "terrain": "Broad, well-maintained trail on ridgecrest; frequent deer; summer heat and crowded park traffic.",
+    "notable": ["Skyline Drive", "Big Meadows", "Bearfence Mountain"]
+  },
+  {
+    "mile_start": 1010,
+    "mile_end": 1100,
+    "region": "Virginia / West Virginia / Maryland",
+    "name": "Harpers Ferry to Maryland",
+    "summary": "The psychological midpoint at Harpers Ferry leads through the historic Potomac and into rocky Maryland.",
+    "terrain": "River corridors, towpath connectors, and the first northern rockiness in Maryland's roller-coaster ridges.",
+    "notable": ["Harpers Ferry", "ATC Headquarters", "Annapolis Rocks"]
+  },
+  {
+    "mile_start": 1100,
+    "mile_end": 1200,
+    "region": "Maryland / Pennsylvania",
+    "name": "Maryland and Pennsylvania south",
+    "summary": "Short but rocky Maryland yields to Pennsylvania's infamous jagged quartzite and long farm-country walking.",
+    "terrain": "Ankle-rolling rocks become the dominant story; boots begin failing; town stops every few days.",
+    "notable": ["Pen Mar Park", "Pine Grove Furnace", "Appalachian Trail Museum"]
+  },
+  {
+    "mile_start": 1200,
+    "mile_end": 1300,
+    "region": "Pennsylvania",
+    "name": "Pennsylvania rocks — mid state",
+    "summary": "Pennsylvania's endless talus fields and flat-topped ridges test ankles and patience through the long middle of the state.",
+    "terrain": "Sharp rocks, little elevation change but exhausting footing; spring can be very wet.",
+    "notable": ["Boiling Springs", "Duncannon", "Palmerton"]
+  },
+  {
+    "mile_start": 1300,
+    "mile_end": 1400,
+    "region": "Pennsylvania / New Jersey / New York",
+    "name": "PA to Delaware Water Gap",
+    "summary": "Hikers cross into New Jersey's surprisingly rugged ridges and approach the Delaware Water Gap.",
+    "terrain": "Boardwalks, bogs, and sudden steep climbs; increasing proximity to New York City exurbs.",
+    "notable": ["Delaware Water Gap", "Kirkridge", "Pochuck Boardwalk"]
+  },
+  {
+    "mile_start": 1400,
+    "mile_end": 1500,
+    "region": "New York / Connecticut",
+    "name": "Hudson Highlands and southern New England approach",
+    "summary": "Spectacular Hudson River views, steep scrambles, and the transition into New England footpath culture.",
+    "terrain": "Steep pinewoods, rock scrambles, and suburban trail crossings; black bears common.",
+    "notable": ["Bear Mountain", "West Point views", "Kent CT"]
+  },
+  {
+    "mile_start": 1500,
+    "mile_end": 1600,
+    "region": "Connecticut / Massachusetts",
+    "name": "Southern New England",
+    "summary": "Rolling New England ridgelines through Connecticut and the Berkshires of western Massachusetts.",
+    "terrain": "Muddy spring tread, stone walls, and frequent town access; trail clubs maintain steep, rocky paths.",
+    "notable": ["Sages Ravine", "Mount Greylock", "Dalton MA"]
+  },
+  {
+    "mile_start": 1600,
+    "mile_end": 1700,
+    "region": "Massachusetts / Vermont",
+    "name": "Berkshires to southern Vermont",
+    "summary": "The AT crosses Massachusetts into Vermont's Green Mountains — mud season and maple country.",
+    "terrain": "Rooty, muddy tread; long climbs; increasing alpine feel heading toward Killington and beyond.",
+    "notable": ["Killington Peak", "Manchester Center", "Stratton Mountain"]
+  },
+  {
+    "mile_start": 1700,
+    "mile_end": 1800,
+    "region": "Vermont / New Hampshire",
+    "name": "Vermont to White Mountains approach",
+    "summary": "Vermont's Green Mountains yield to the serious alpine country of the White Mountains in New Hampshire.",
+    "terrain": "Mud, moose, and then sudden exposure above treeline; weather becomes a primary hazard.",
+    "notable": ["Hanover NH", "Dartmouth", "Mount Moosilauke"]
+  },
+  {
+    "mile_start": 1800,
+    "mile_end": 1900,
+    "region": "New Hampshire",
+    "name": "White Mountains",
+    "summary": "The White Mountains are the AT's alpine crucible: above-treeline exposure, hut system, and killer ascents.",
+    "terrain": "Boulder scrambles, ferocious winds, and mandatory careful weather timing; falls can be fatal.",
+    "notable": ["Franconia Ridge", "Presidential Range", "Lakes of the Clouds Hut"]
+  },
+  {
+    "mile_start": 1900,
+    "mile_end": 2010,
+    "region": "New Hampshire / Maine",
+    "name": "New Hampshire north to Mahoosuc",
+    "summary": "Northern NH and the Mahoosuc Notch — the slowest mile on the AT — lead into Maine.",
+    "terrain": "Brutal boulder caves in Mahoosuc; knee-wrecking; then big Maine woods and first 100-mile wilderness approach.",
+    "notable": ["Mahoosuc Notch", "Gorham NH", "Speck Pond"]
+  },
+  {
+    "mile_start": 2010,
+    "mile_end": 2150,
+    "region": "Maine",
+    "name": "100 Mile Wilderness",
+    "summary": "Maine's legendary 100 Mile Wilderness: remote lakes, ford crossings, and no resupply for over a week.",
+    "terrain": "Root ladders, river fords, black flies in June, and profound remoteness; carry enough food or you suffer.",
+    "notable": ["Monson ME", "Shaw's Boarding House", "Barren-Chairlift Lean-tos"]
+  },
+  {
+    "mile_start": 2150,
+    "mile_end": 2195,
+    "region": "Maine",
+    "name": "Baxter State Park — Katahdin",
+    "summary": "The final miles in Baxter State Park climb Katahdin via the Hunt Trail — knife-edge exposure and the northern terminus.",
+    "terrain": "Alpine boulder scramble on the Hunt Trail; weather windows are short; summit fog is common in June.",
+    "notable": ["The Birches", "Baxter Peak", "Katahdin sign"]
+  }
+]

--- a/docs/superpowers/plans/2026-07-09-journal-frontmatter-facts.md
+++ b/docs/superpowers/plans/2026-07-09-journal-frontmatter-facts.md
@@ -1,0 +1,567 @@
+# Journal Frontmatter Facts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add YAML frontmatter `facts` blocks to each journal entry with validated, location- and date-specific details (trail section character, historical weather, town events) produced by a multi-pass subagent research pipeline.
+
+**Architecture:** An orchestrator script parses journal entries and dispatches specialized subagents per entry (or per geographic batch). Each entry flows through four research passes—draft, validate, enrich (weather + town events), compile—before frontmatter is injected. All intermediate results are cached to JSON so the pipeline is resumable and auditable.
+
+**Tech Stack:** Python 3, existing `parse_entry_metadata()` from `scripts/enhance_entries.py`, AWS Bedrock (draft/synthesis), Firecrawl CLI (web validation), Open-Meteo Historical Weather API (free, no key), optional Visual Crossing for backup weather, PyYAML, pytest.
+
+---
+
+## Problem Statement
+
+The current `enhance_entries.py` appends unvalidated LLM prose (`Trail Facts: ...`) at the **end** of each entry. The book project needs **frontmatter** at the **top** of each entry with structured, verifiable facts:
+
+```markdown
+---
+date: 2010-02-07
+start: Hike Inn
+destination: Hawk Mountain Shelter
+miles_today: 9
+trip_miles: 9
+facts:
+  weather: "High 42°F, low 26°F. Snow and ice; aftermath of a recent ice storm."
+  trail_section: "Northern Georgia approach to Springer. Rhododendron ravines and 300-year-old hemlocks. Steep, rocky descent to Hawk Mountain."
+  town_events: null
+  confidence: high
+  sources:
+    - "Open-Meteo archive, coords 34.62,-84.19"
+    - "AT Guide: Springer to Hawk Mountain section"
+---
+
+# Sunday, February 07, 2010 — Hawk Mountain Shelter
+**Start Location:** Hike Inn
+...
+```
+
+Each fact must be **researched**, not hallucinated. The pipeline uses subagents with narrow scopes.
+
+---
+
+## Subagent Architecture
+
+```mermaid
+flowchart TB
+    subgraph orchestrator [Orchestrator Agent]
+        Parse[Parse journal entries]
+        Batch[Batch by region / dispatch]
+        Merge[Merge + write output]
+    end
+
+    subgraph per_entry [Per-Entry Pipeline - sequential]
+        Draft[1. Section Draft Agent]
+        Validate[2. Validation Agent]
+        Weather[3. Weather Agent]
+        Town[4. Town Events Agent]
+        Compile[5. Facts Compiler Agent]
+    end
+
+    Parse --> Batch
+    Batch --> Draft
+    Draft --> Validate
+    Draft --> Weather
+    Draft --> Town
+    Validate --> Compile
+    Weather --> Compile
+    Town --> Compile
+    Compile --> Merge
+```
+
+### Agent Roles
+
+| Agent | Input | Output | Tools |
+|-------|-------|--------|-------|
+| **Orchestrator** | `journal_10467.txt` | `journal_10467_facts.txt` + cache dir | Python, progress JSON |
+| **Section Draft** | `{date, start, destination, miles}` | Structured draft JSON with trail claims | Bedrock (structured JSON mode) |
+| **Validation** | Draft claims list | Verified/rejected claims + source URLs | Firecrawl search/scrape |
+| **Weather** | `{date, lat, lon}` or nearest town | `{high_f, low_f, conditions, precip}` | Open-Meteo Historical API |
+| **Town Events** | `{date, town_name}` (if town day) | Event string or null | Firecrawl search |
+| **Facts Compiler** | All pass outputs | Final frontmatter YAML block | Bedrock or template merge |
+
+### Parallelization Strategy
+
+| Parallelism | Scope | Why |
+|-------------|-------|-----|
+| **Across entries** | Up to 10 concurrent entry pipelines | Entries are independent; cache keyed by `entry_key` |
+| **Within entry** | Weather ∥ Town Events ∥ Validation (after draft) | No shared state between these three |
+| **Across regions** | Section Draft batches share AT section context | GA entries can warm-cache "Springer approach" lore |
+
+**Do NOT parallelize:** Draft → Validation (validation needs draft claims). Compiler must wait for all three enrichers.
+
+### Subagent Dispatch Pattern
+
+Each subagent receives a **self-contained prompt** with:
+1. The entry metadata JSON
+2. Its specific task and output JSON schema
+3. Constraints ("only return claims you found a source for")
+4. Cache file path to read/write
+
+Example dispatch (Validation Agent):
+
+```
+You are the Validation Agent for AT journal fact-checking.
+
+Entry:
+  date: 2010-02-07
+  start: Hike Inn
+  destination: Hawk Mountain Shelter
+
+Draft claims to verify:
+  - "Hawk Mountain Shelter is 9 miles north of Springer Mountain"
+  - "Section features old-growth hemlocks over 300 years old"
+  - "Trail had ice storm debris in February 2010"
+
+For each claim:
+1. Search TrailJournals, Wikipedia, ATC, AWOL guide, hiking blogs via firecrawl
+2. Mark verified (with URL) or unverified
+3. Suggest corrected wording if partially true
+
+Return JSON only:
+{
+  "verified": [{"claim": "...", "source": "https://...", "confidence": "high"}],
+  "rejected": [{"claim": "...", "reason": "no source found"}],
+  "corrections": [{"original": "...", "corrected": "..."}]
+}
+```
+
+---
+
+## Multi-Pass Research Pipeline (Per Entry)
+
+### Pass 0: Prerequisites (Orchestrator, once)
+
+- [ ] Extract journal: `make journal JOURNAL_ID=10467`
+- [ ] Build AT location resolver: map shelter/town names → approximate lat/lon
+- [ ] Detect "town days" via regex/heuristic (see Town Detection below)
+
+### Pass 1: Section Draft (Section Draft Agent)
+
+**Purpose:** Generate *candidate* facts from LLM trail knowledge. These are hypotheses, not final copy.
+
+**Prompt focus:**
+- Geographic context (state, elevation range, notable landmarks between A and B)
+- Section reputation ("known for rock scrambles", "notorious PUDs")
+- Seasonal context for that date (early Feb in GA = winter conditions, short days)
+- Output as structured JSON, not prose
+
+**Output schema (`draft.json`):**
+```json
+{
+  "trail_section_summary": "2-3 sentence draft",
+  "claims": [
+    {"type": "landmark", "text": "Springer Mountain southern terminus plaque"},
+    {"type": "terrain", "text": "steep icy descent from Springer in winter"},
+    {"type": "flora", "text": "old-growth hemlock ravine between shelters"}
+  ],
+  "at_mile_start": 0.0,
+  "at_mile_end": 9.0,
+  "state": "GA",
+  "nearest_town": "Dahlonega"
+}
+```
+
+### Pass 2: Validation (Validation Agent)
+
+**Purpose:** Verify or reject each claim from Pass 1 using web sources.
+
+**Search targets (priority order):**
+1. `site:appalachiantrail.org` + landmark name
+2. `site:trailjournals.com` + shelter name
+3. AWOL / White Blaze / hiking blogs
+4. Wikipedia for towns and peaks
+
+**Rules:**
+- Drop claims with no corroborating source
+- Prefer ATC and established guide sources over random blogs
+- Record source URL for every surviving claim
+- Flag `confidence: low` if only one weak source
+
+### Pass 3a: Weather (Weather Agent)
+
+**Purpose:** Historical weather for the hike date at the trail section.
+
+**Steps:**
+1. Resolve coordinates: midpoint of start/end locations (from location resolver)
+2. Query Open-Meteo Historical API:
+   ```
+   GET https://archive-api.open-meteo.com/v1/archive
+     ?latitude={lat}&longitude={lon}
+     &start_date={date}&end_date={date}
+     &daily=temperature_2m_max,temperature_2m_min,precipitation_sum,weathercode
+     &temperature_unit=fahrenheit
+     &precipitation_unit=inch
+   ```
+3. Map WMO weather codes to human text ("snow and rain mix", "clear and cold")
+4. Note station distance caveat if coords are approximate
+
+**Fallback:** Visual Crossing or NOAA GHCN if Open-Meteo returns gaps.
+
+**Output:**
+```json
+{
+  "high_f": 42,
+  "low_f": 26,
+  "precip_in": 0.3,
+  "conditions": "snow and rain mix",
+  "source": "open-meteo",
+  "coords": [34.62, -84.19],
+  "caveat": "Grid cell midpoint; nearest town Dahlonega ~15mi"
+}
+```
+
+### Pass 3b: Town Events (Town Events Agent, conditional)
+
+**Trigger:** `is_town_day(entry)` returns true.
+
+**Town detection heuristics:**
+- Destination or start contains: `Motel`, `Hostel`, `Inn`, `Lodge`, `Hotel`, `town`, `village`
+- Parenthetical town name: `EconoLodge Motel (Helen, GA)`
+- `miles_today == 0` (zero days often = town stay)
+
+**Search queries:**
+- `"{town} {state}" "{Month Day Year}" events`
+- `"{town}" parade OR festival OR "town event" 2010`
+- Local newspaper archives if findable
+
+**Rules:**
+- Return `null` if nothing found (don't invent parades)
+- Include event only with a dated source
+- For 2010, expect sparse results—`confidence: low` is acceptable
+
+### Pass 4: Compile (Facts Compiler Agent)
+
+**Purpose:** Merge validated outputs into concise frontmatter strings.
+
+**Inputs:** `draft.json`, `validation.json`, `weather.json`, `town_events.json`
+
+**Output rules:**
+- `facts.weather`: one sentence, e.g. `"High 76°F, low 33°F. Snow and rain mix."`
+- `facts.trail_section`: 1-2 sentences from **verified** claims only
+- `facts.town_events`: string or `null`
+- `facts.confidence`: `high` | `medium` | `low` (lowest of component confidences)
+- `facts.sources`: deduplicated URL list
+
+**Template (no LLM needed if structured):**
+```python
+def compile_facts(validation, weather, town_events) -> dict:
+    weather_str = f"High {weather['high_f']}°F, low {weather['low_f']}°F. {weather['conditions']}."
+    trail_str = " ".join(c["text"] for c in validation["verified"] if c["type"] != "weather"])
+    return {
+        "weather": weather_str,
+        "trail_section": trail_str[:500],  # cap length
+        "town_events": town_events.get("event"),
+        "confidence": min_confidence(validation, weather, town_events),
+        "sources": collect_sources(validation, weather, town_events),
+    }
+```
+
+LLM compiler optional for prose polish—but only after facts are locked.
+
+---
+
+## File Structure
+
+```
+scripts/
+  enhance_entries.py          # existing; keep for context mode
+  enrich_facts.py             # NEW: orchestrator CLI
+  facts/
+    __init__.py
+    models.py                 # EntryMetadata, DraftFacts, ValidatedFacts, Frontmatter
+    location_resolver.py      # shelter/town → lat/lon (static JSON + fuzzy match)
+    draft_agent.py              # Bedrock structured draft
+    validate_agent.py           # Firecrawl validation wrapper
+    weather_agent.py            # Open-Meteo client
+    town_events_agent.py        # Firecrawl town search
+    compiler.py                 # Merge → frontmatter YAML
+    frontmatter.py              # inject YAML into entry text
+    cache.py                    # read/write per-entry pass cache
+    orchestrator.py             # batch dispatch, resume, parallel limits
+
+data/
+  at_locations.json             # ~200 common AT shelters/towns with lat/lon
+
+tests/
+  test_facts_models.py
+  test_location_resolver.py
+  test_weather_agent.py
+  test_compiler.py
+  test_frontmatter.py
+  fixtures/
+    sample_entry.txt
+    sample_draft.json
+    sample_weather_response.json
+
+cache/facts/                    # gitignored
+  {entry_key}/
+    draft.json
+    validation.json
+    weather.json
+    town_events.json
+    frontmatter.yaml
+```
+
+---
+
+## Location Resolver Design
+
+Static JSON keyed by normalized shelter/town names from your journal. Source data:
+- ATC shelter list
+- AWOL AT guide mile markers (manual seed for journal-specific locations)
+
+```json
+{
+  "hawk mountain shelter": {"lat": 34.72, "lon": -84.12, "state": "GA", "at_mile": 8.1},
+  "hike inn": {"lat": 34.68, "lon": -84.05, "state": "GA", "at_mile": 0},
+  "helens, ga": {"lat": 34.70, "lon": -83.73, "state": "GA", "at_mile": 75.2, "is_town": true}
+}
+```
+
+Fuzzy match: strip parentheticals, lowercase, remove "shelter"/"hostel" suffixes for lookup.
+
+---
+
+## Caching & Resume
+
+Cache key: `{date}_{normalized_start}_{normalized_destination}` (reuse `get_entry_key()`).
+
+Each pass writes atomically to `cache/facts/{entry_key}/{pass}.json`.
+
+Orchestrator on restart:
+1. List entries from journal
+2. Skip entries where `frontmatter.yaml` exists and `--force` not set
+3. Resume incomplete entries from last completed pass
+
+Progress file: `cache/facts/progress.json` with `{completed: [...], failed: [...], last_index: N}`
+
+---
+
+## Output Format
+
+**Enhanced journal file:** `journal_10467_facts.txt`
+
+Each entry:
+```markdown
+---
+date: 2010-02-07
+start: Hike Inn
+destination: Hawk Mountain Shelter
+miles_today: 9
+trip_miles: 9
+facts:
+  weather: "High 42°F, low 26°F. Snow and ice on trail."
+  trail_section: "Northern Georgia, Springer approach. Old-growth hemlock ravines. First-day section for 2010 NOBO hikers."
+  town_events: null
+  confidence: medium
+  sources:
+    - https://archive-api.open-meteo.com/v1/archive?...
+    - https://www.appalachiantrail.org/...
+---
+
+# Sunday, February 07, 2010 — Hawk Mountain Shelter
+...
+```
+
+---
+
+## Implementation Tasks
+
+### Task 1: Data Models & Location Resolver
+
+**Files:**
+- Create: `scripts/facts/models.py`
+- Create: `scripts/facts/location_resolver.py`
+- Create: `data/at_locations.json` (seed ~30 locations from journal index)
+- Create: `tests/test_location_resolver.py`
+
+- [ ] **Step 1:** Define Pydantic-style dataclasses or TypedDicts for pipeline stages
+- [ ] **Step 2:** Seed `at_locations.json` from journal entry table (Hike Inn through Katahdin)
+- [ ] **Step 3:** Implement fuzzy lookup + town extraction from `"Motel (Helen, GA)"` patterns
+- [ ] **Step 4:** Write tests for known journal locations
+- [ ] **Step 5:** Commit
+
+### Task 2: Weather Agent
+
+**Files:**
+- Create: `scripts/facts/weather_agent.py`
+- Create: `tests/test_weather_agent.py`
+- Create: `tests/fixtures/sample_weather_response.json`
+
+- [ ] **Step 1:** Implement Open-Meteo client with weathercode → text mapping
+- [ ] **Step 2:** Test with 2010-02-07 coords near Springer (mock HTTP)
+- [ ] **Step 3:** Integration test hitting real API for one date (mark `@pytest.mark.integration`)
+- [ ] **Step 4:** Commit
+
+### Task 3: Section Draft Agent
+
+**Files:**
+- Create: `scripts/facts/draft_agent.py`
+- Modify: reuse Bedrock client pattern from `enhance_entries.py`
+
+- [ ] **Step 1:** Write structured JSON prompt (not prose)
+- [ ] **Step 2:** Parse response into `DraftFacts` model
+- [ ] **Step 3:** Unit test with mocked Bedrock response
+- [ ] **Step 4:** Commit
+
+### Task 4: Validation Agent
+
+**Files:**
+- Create: `scripts/facts/validate_agent.py`
+
+- [ ] **Step 1:** Wrap Firecrawl CLI (`firecrawl search "{claim}" --scrape -o ...`)
+- [ ] **Step 2:** Parse results, score source quality
+- [ ] **Step 3:** Test with mocked firecrawl output
+- [ ] **Step 4:** Commit
+
+### Task 5: Town Events Agent
+
+**Files:**
+- Create: `scripts/facts/town_events_agent.py`
+
+- [ ] **Step 1:** Implement `is_town_day()` heuristic
+- [ ] **Step 2:** Firecrawl search for town + date
+- [ ] **Step 3:** Return null when no sourced event found
+- [ ] **Step 4:** Commit
+
+### Task 6: Facts Compiler & Frontmatter Injection
+
+**Files:**
+- Create: `scripts/facts/compiler.py`
+- Create: `scripts/facts/frontmatter.py`
+- Create: `tests/test_compiler.py`, `tests/test_frontmatter.py`
+
+- [ ] **Step 1:** Template-based compiler (deterministic, testable)
+- [ ] **Step 2:** YAML frontmatter generator with `---` delimiters
+- [ ] **Step 3:** Inject frontmatter before `# {date}` header
+- [ ] **Step 4:** Round-trip test: parse → inject → parse metadata unchanged
+- [ ] **Step 5:** Commit
+
+### Task 7: Cache Layer
+
+**Files:**
+- Create: `scripts/facts/cache.py`
+
+- [ ] **Step 1:** Per-entry pass read/write with atomic temp files
+- [ ] **Step 2:** Resume logic (skip completed passes)
+- [ ] **Step 3:** Test resume after simulated crash
+- [ ] **Step 4:** Commit
+
+### Task 8: Orchestrator & CLI
+
+**Files:**
+- Create: `scripts/facts/orchestrator.py`
+- Create: `scripts/enrich_facts.py`
+- Modify: `Makefile` (add `make enrich-facts`)
+- Modify: `.gitignore` (add `cache/facts/`, `.firecrawl/`)
+
+- [ ] **Step 1:** CLI: `python scripts/enrich_facts.py journal_10467.txt --cache cache/facts`
+- [ ] **Step 2:** Sequential pipeline for one entry (debug mode)
+- [ ] **Step 3:** Parallel entry dispatch with `--workers 5`
+- [ ] **Step 4:** Makefile target + README section
+- [ ] **Step 5:** Commit
+
+### Task 9: Pilot Run (10 entries)
+
+- [ ] **Step 1:** Run on first 10 journal entries
+- [ ] **Step 2:** Human review sample output for accuracy
+- [ ] **Step 3:** Tune prompts and town detection based on review
+- [ ] **Step 4:** Commit prompt/config adjustments
+
+### Task 10: Full Journal Run
+
+- [ ] **Step 1:** Run all ~133 entries with `--workers 8`
+- [ ] **Step 2:** Review low-confidence entries
+- [ ] **Step 3:** Produce `journal_10467_facts.txt`
+- [ ] **Step 4:** Commit cache is NOT committed; output file optional in repo
+
+---
+
+## Subagent Execution Schedule (Runtime)
+
+When running the full journal, the **Orchestrator** dispatches subagents in waves:
+
+| Wave | Subagents | Count | Notes |
+|------|-----------|-------|-------|
+| W0 | Location Resolver (batch) | 1 | Pre-resolve all 133 start/end → coords |
+| W1 | Section Draft | 10 parallel | One per entry batch of 13 |
+| W2 | Validation + Weather + Town | 30 parallel | 3 per entry × 10 entries |
+| W3 | Facts Compiler | 10 parallel | After W2 completes per entry |
+| W4 | Review Agent | 1 | Spot-check 5 random entries for quality |
+
+**Estimated API calls:** ~133 entries × (1 Bedrock draft + 3-5 Firecrawl searches + 1 weather + 0-1 town) ≈ 700-900 calls.
+
+**Rate limits:** 1s sleep between Bedrock calls; Firecrawl up to concurrency limit from `firecrawl --status`.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| LLM invents facts | Validation pass required; compiler drops unverified claims |
+| 2010 weather unavailable at exact trail coords | Use nearest grid point; add caveat in sources |
+| Town events not findable for 2010 | Return `null`; don't fabricate |
+| 133 entries × Firecrawl = cost/time | Cache aggressively; `--entries 1-10` for pilot |
+| Shelter name ambiguity ("A cabin (NOC)") | Location resolver fuzzy match + manual overrides file |
+| Bedrock unavailable | Fall back to draft-only mode with `confidence: low` flag |
+
+---
+
+## Testing Strategy
+
+| Level | What |
+|-------|------|
+| Unit | Each agent with mocked HTTP/Bedrock/Firecrawl |
+| Integration | One real entry end-to-end (Feb 7 2010) |
+| Snapshot | Frontmatter YAML structure stable across runs |
+| Human | Review pilot 10 for factual accuracy |
+
+---
+
+## Makefile Addition
+
+```makefile
+enrich-facts: $(VENV)/bin/activate
+	@if [ ! -f "$(JOURNAL_FILE)" ]; then \
+		echo "Error: $(JOURNAL_FILE) not found. Run 'make journal' first."; \
+		exit 1; \
+	fi
+	$(PYTHON) scripts/enrich_facts.py $(JOURNAL_FILE) \
+		--output journal_$(JOURNAL_ID)_facts.txt \
+		--cache cache/facts \
+		--workers 5
+```
+
+---
+
+## Self-Review (Spec Coverage)
+
+| Requirement | Task |
+|-------------|------|
+| Frontmatter on each post | Task 6 |
+| Location/time-specific facts | Tasks 1, 3, 4 |
+| Weather (high/low, conditions) | Task 2 |
+| Town events when passing through | Task 5 |
+| Draft from training data | Task 3 |
+| Validate then search | Task 4 |
+| Extra searches | Tasks 4, 5 |
+| Many steps / resumable | Tasks 7, 8 |
+| Subagent architecture | This document § Subagent Architecture |
+
+No placeholder tasks. All file paths specified.
+
+---
+
+## Execution Handoff
+
+**Plan complete and saved to `docs/superpowers/plans/2026-07-09-journal-frontmatter-facts.md`.**
+
+**Two execution options:**
+
+1. **Subagent-Driven (recommended)** — Dispatch a fresh subagent per implementation task (Tasks 1–10), with review between tasks. Best for building the pipeline incrementally with quality gates.
+
+2. **Pilot-First** — Implement Tasks 1–8 minimally, then run Task 9 (10 entries) before completing Task 10. Validates the research quality before burning API credits on all 133 entries.
+
+**Recommended first step:** Task 1 (location resolver) + Task 2 (weather agent), then a manual pilot on your Feb 7, 2010 entry to validate output quality before building validation/town agents.

--- a/examples/uncle-frank/README.md
+++ b/examples/uncle-frank/README.md
@@ -1,0 +1,45 @@
+# Uncle Frank — 2010 Appalachian Trail Journal
+
+Example output from the trail journal facts enrichment pipeline.
+
+| File | Description |
+|------|-------------|
+| `metadata.json` | Journal metadata (author, trail, dates, source URL) |
+| `journal.txt` | Raw extracted entries from [TrailJournals.com](https://www.trailjournals.com/journal/10467) |
+| `journal_facts.txt` | Enriched entries with YAML `facts` frontmatter on each post |
+
+## Frontmatter format
+
+Each entry is prefixed with structured facts:
+
+```yaml
+---
+date: '2010-02-07'
+start: Hike Inn
+destination: Hawk Mountain Shelter
+miles_today: 9.0
+trip_miles: 9.0
+facts:
+  weather: High 40°F, low 23°F. Slight snow.
+  trail_section: Northern Georgia approach to Springer...
+  town_events: null
+  confidence: high
+  sources:
+    - AT location database
+    - Open-Meteo archive
+---
+```
+
+## Regenerate
+
+```bash
+make uncle-frank          # Extract all ~133 entries via Firecrawl
+make uncle-frank-facts    # Enrich with weather + trail facts (+ town events)
+```
+
+## About
+
+- **Trail name:** Uncle Frank
+- **Author:** Ford Prior
+- **Hike:** Northbound AT thru-hike, January–June 2010
+- **Finish:** Baxter Peak, Mount Katahdin (2,179.5 miles)

--- a/examples/uncle-frank/README.md
+++ b/examples/uncle-frank/README.md
@@ -20,12 +20,18 @@ destination: Hawk Mountain Shelter
 miles_today: 9.0
 trip_miles: 9.0
 facts:
-  weather: High 40°F, low 23°F. Slight snow.
-  trail_section: Northern Georgia approach to Springer...
-  town_events: null
+  segment: Smokies exit to Hot Springs
+  at_mile_start: 263.3
+  at_mile_end: 274.8
+  region: Tennessee / North Carolina
+  weather: High 44°F, low 23°F. Overcast.
+  trail_section: >
+    Smokies exit to Hot Springs (AT miles 263–275): Northbound hikers leave
+    the Smokies at Davenport Gap and cross into balds-and-river country.
+    Post-Smokies fatigue is common; Max Patch bald offers huge views.
   confidence: high
   sources:
-    - AT location database
+    - AT segment guide
     - Open-Meteo archive
 ---
 ```

--- a/examples/uncle-frank/journal.txt
+++ b/examples/uncle-frank/journal.txt
@@ -1,0 +1,5421 @@
+# Thursday, January 21, 2010 — Pre-Hike Planning
+**Start Location:** Gear List
+**Miles Today:** 0
+**Trip Miles:** 0
+
+I'm loading my pack and thinking of Lewis & Clark. Hell, how do you pack for an 5,000-plus march into the unknown? Start with alot of meat, apparently: the Corps packed "a ton of dried pork." Maybe I should bring a baggy of deer jerky.
+
+Food, fuel, shoes, and H20 aside, here's my gear list so far. Keep in mind, I'm going "ultra-light", which basically means I'm trying really hard to keep my pack as light as possible. Duh, right? That's called "common sense", not "ultra-light". Either way, I've slashed significant poundage, leaving my total weight at a skimpy 13.8 lbs!
+
+Anyways, please, give me feedback! Too much? Too little? Missing something?
+
+I-The Big Stuff
+
+Pack (Gossamer Gear Gorilla): 23.3 oz.
+
+Sleeping bag (0-degree GoLite Women's): 45 oz.
+
+Poncho/shelter (Sea-to-Summit): 12.7 oz.
+
+Thermarest (Thermarest ProLite Rig): 16.2 oz.
+
+II-Non-Clothes
+
+Stove (homemade alcohol): 2.1 oz.
+
+Bowl (silicone, 16 fl. oz.): 2.3 oz.
+
+Spork (LightMyFire): 0.5 oz
+
+Tent stakes (4): 2.8 oz.
+
+Latrine digger (MSR): 0.7 oz.
+
+Knife (Gerber): 7.8 oz.
+
+Headlamp (Petzl): 0.7 oz.
+
+Bible (ESV): 9.2 oz.
+
+Journal:
+
+Toothbrush & Floss: 1.5 oz.
+
+Mini-lighter: 1 oz.
+
+First Aid kit (8 BandAids, needle & thread, clothespin, Anti-biotic ointment, .5" medical tape, 5 ft. duct tape, 8 Advil, Moleskin, Gauze): 3.5 oz.
+
+Water bladder (Platypus): 3.5 oz.
+
+50 ft. parachute cord: 2.8 oz.
+
+Harmonica: 2.1 oz.
+
+Pipe & Tobacco: 6 oz.
+
+ID, cash, etc.: 2 oz.
+
+Bags (garbage, zip-lock):
+
+Compass: 1 oz.
+
+1 liter water bottle (Dasani): 1.5 oz.
+
+III-Clothes
+
+Baclava (Seirus): 2.8 oz.
+
+Long underwear bottoms (SmartWool, Merino): 7.8 oz.
+
+Long underwear top (Icebreaker, Merino): 13.5 oz.
+
+Rain shell pants (Marmot Precip): 12 oz.
+
+Rain shell jacket (North Face Venture): 13.5 oz.
+
+Gloves (REI): 2.1 oz.
+
+Down jacket (MontBell Alpine): 11.3 oz.
+
+Wool socks (REI, 3 pairs): 8.5 oz.
+
+Down booties (North Face): 12 oz.
+
+Beanie (normal): 2.8 oz.
+
+Liner socks (1 pair, Merino wool):
+
+It's a long list, indeed. Yet amazingly, it only comes out to only 13.8 lbs! I've still got a couple pounds to add...but still! Technology these days.
+
+First Previous [Next](https://www.trailjournals.com/journal/entry/301866) [Last](https://www.trailjournals.com/journal/entry/318948)
+---
+
+# Saturday, February 06, 2010 — Hike Inn
+**Start Location:** Amicalola Falls State Park
+**Miles Today:** 0
+**Trip Miles:** 0
+
+In the darkness we trudged on without words. After a late start, at 3:45pm, the trail took us up Amicalola Falls and higher into Frosty Mountain as dusk drew near. And Frosty it was, thanks to an ice storm that blew in the previous night, leaving the forest glassy and white. The ices thawed, shattered down from the trees overhead, and buried the trail in 2 inches of shards. Rain had fallen below at Amicalola State Park HQ where we set off, but up here the world was gripped in ice. the foul weather slowed progress - not only did we have to march through ice but detour around splintered branches and trees fallen across the trail. So by nightfall, there I was. Trudging by flashlight along the blue-blazed "approach trail", feeling tired of walking even before the white blazes began.
+
+I expected a damp and dismal shelter that night, but we stumbled across a glowing refuge in the middle of the woods: The Hiker Inn. the situation that night was by no means an emergency, but with my Dad and Morgan it seemed like one for some reason. Morgan was having knee problems and looked on the verge of tears, branches and trees were falling all around us, my hands were numb and it was pitch black for a cloud-covered moon. Emergency or not, we saw a trail sign for The Hiker Inn and decided to pull off. I expected a cold night on the front porch or in an old shed. What I found was a lone innkeeper offering a lamp-lit dwelling warmed by woodstove. All's well that ends well.
+
+Let's go back to where it all begins, to my weeping mother by the car in front of the house. I forget sometimes, how much I mean to people. I forget that I have the power to bring great joy and great sadness, that me going actually matters to someone. So when I put my arms around my mother and she started to cry, I was filled with this incredible sense that I was home, the only place in the world where I really mean something. There I was crucial. I guess it all comes back to love, something I've never really been able to put into words. All I can do is point to my mother and father, my two best friends in the whole world, without whom I would just be a scared little boy. They've brought me here. They've made me a man. and although I didn't think any of this at the time, it was painted so perfectly as I held my weeping mother by the car.
+
+That night we drove to South Carolina and stayed at a hotel. I stayed up late that night reading Thoreau out of my sister's Lit book. He rambles alot, but I liked the marrow part: "When I would recreate myself, I seek the darkest wood and most interminable swamp, and enter it as a sacred place, a sanctum sanctorum. Three is strength, the marrow of nature." I'm about to enter a dark season on an interminable trail, I said to myself, so the suffering is all to shine on that marrow. there is the heart of God. We ate at Cracker Barrel at 6:30 the next morning and then drove to Springer Mountain, "Southern Terminus to the Applachian Trail". I fell asleep in the backseat and awoke to the Amicalola State Park HQ, gateway to the Springer Mountain trail. I registered, weighed my pack, and hit the blue-blazed approach trail to the Springer's summit. 8.8 miles. It was 3:45pm. the trail led into ice, night fell, and we ended up in The Hikers Inn warm log-cabin lobby. We met Stanley, the innkeeper and former A.T. thru-hiker himself, who started up the wood stove and offered me advice for my own hike. I was so fortunate to be there with my father and sister, really enjoying our time together. That was the only thing on my mind that night before I began my 2,000 mile trek to Maine.
+---
+
+# Sunday, February 07, 2010 — Hawk Mountain Shelter
+**Start Location:** Hike Inn
+**Miles Today:** 9
+**Trip Miles:** 9
+
+We parted ways at 10:00am. My father and sister walked out the door like I’ve seen them do so many times this past month, but this time I wouldn’t wee them return that evening. This was different. It was hard saying goodbye at what I knew was an exit from their lives for the next six months, before I’d go off and live my life and they’d go off and live theirs. As they walked out the door and out of view, I felt just about as lonely as I’d ever felt. I kind of wanted to chase them but that would be too embarrassing. So I sat there, trying to nap but unable. I think it was because I was alone now and knew it, making me uncomfortable and on edge. From here on out it’ll be like that, more or less, with my guard up full-time. I need to stop writing about this or it’ll get to me.
+
+By 10:30 I was at it, trudging through the aftermath of the ice storm, slipping and sliding in the snow and ice and trying not to yell curse words at the huge limbs blocking the trail. It was slow and painful to the summit of Springer Mountain, by 1:00 I was there, wiping snow off the plaque that read, “Southern Terminus of the Appalachian Trail”. It was too cold and windy to relish the moment, so I marched down to the gap for a break. From there to the shelter, elevation decreased and trail conditions improved. No more ice. No more debris to climb over. Just 2” of snow to stomp down. My spirits immediately brightened as well.
+
+At a shelter, I took a nap and ate. It was only 3:00 by then, so I decided to hoof it to the next shelter, 5.5 miles away. This leg turned out to be in perfect shape. I shot through at a steady 3 mph, descending into an amazing ravine of rhododendron and amazing old growth hemlocks. Some were 300 years old and 5 feet thick, I later learned.
+
+Walking through those holy trees was the highlight of my day. I reached Hawk Mountain shelter before sundown, totaling 9 miles that day. I ran down to the stream to get water, cooked, strung up a bear bag, and wrote for an hour by candlelight. I drifted off and had a strange demon dream where Satan was in my head and barking at me so I couldn’t think, and then I flooded him out by begging God to intervene and jerked awake. After that I was spooked and couldn’t drift off. The mice, in their audacious fashion, ran all over me and all over my stuff, flatly ignoring both my yells and the beams of my flashlight. I slept well that night.
+---
+
+# Monday, February 08, 2010 — Gooch Mountain Shelter
+**Start Location:** Hawk Mountain Shelter
+**Miles Today:** 14
+**Trip Miles:** 23
+
+I woke up at 8:30 and saw a huge red woodpecker which made me smile. By 9:15, I was on the trail strong and fast to my destination 20 miles away. The trail was gradual and I was happy to be on it, hoofing towards Maine. About an hour passed wuntil I realized I was going in the wrong direction. I cursed aloud. I cursed aloud again. And you know how I realized it? “Cool, that guy’s shoe tracks look just like mine. I wonder if he has the same ….oh shit.”
+
+So after logging a total of 6 idiot miles, I was once again back at the shelter. It was 11:15. I took a nap had breakfast, dressed a blister, then set off again towards the next shelter 8 miles away (I gave up on 20 miles after losing so much daylight). And this time I was going North.
+
+Still, the mountain was white out – all white in snow, fog, and sky – and the temperature was still 23F from that morning. But very quickly, the bad weather lifted. The sky cleared, temperatures rose, and somehow the trail was 100% cleared for the nearly all 8 miles. The sun out and surrounding mountains visible, I stopped for a second and though about how they chase the phrase “Appalachian Scenic Trail”: this was no forced march like I’d been treating it that day. It was a scenic route, carved for the likes of Thoreau’s saunterer traveling to the Holy Land. Then I thought of how fortunate I was to be there on that mountain. I could’ve been a lot of other places – like stuck at work or school, in a wheelchair, or in the twisted metal of a car on the side of River Road- like should’ve happened so many times. So here’s to a blessing. “I’m goin’ to Maine!” I said laughing. “I’m goin’ to Maine!”
+
+At dusk, at the shelter, I finished dinner and let the fire die down to dull embers. In his classic hiker’s manual, The Walker’s Handbook, Colin Fletcher let it die from time to time, to let the darkness surround you. There’s nothing as pure and powerful he said, as darkness deep in the woods. So I stood on the porch of the shelter and let everything go black around me. The wind blew in the trees and it was eerily quiet. “Say something” I said to God. I didn’t know whether to expect something good to happen or something bad, because I’ve found that he’s speaking all the time in the strangest ways, and he’s found in both the happy and the hard. I stood there for a long time, dreaming not thinking about all the blackness. It was addicting. It cozied the mind and numbed it over, like the way you cease when you finally arrive home. I was at home, in the wooded blackness. After half an hour, I retired to my sleeping bag and fell asleep.
+---
+
+# Tuesday, February 09, 2010 — Neel Gap Hostel
+**Start Location:** Gooch Mountain Shelter
+**Miles Today:** 15.50
+**Trip Miles:** 38.50
+
+In the morning, I awoke before 8:00 and prepared to leave. It was very cold, but off I went towards Neels Gap. After several hours I passed through Woody Gap, where I met a middle-aged couple on a geo mission. The man took my photo with his iphone and emailed it to my mom and dad. They lady kept looking at me like she wished she had a son of her own. My first run in with Trail Magic!
+
+It was 11:00 and I continued on up to the ominously titled Blood Mountain. Cherokee and Creek warriors met head to head on these slopes, leaving so many dead that the streams ran red with blood. On the way up, I passed homeless and unemployed, two 2001 thru-hikers on a stroll for the day. Two of the nicest hippies I’ve ever met. The man really wanted to give me tips and advice and the woman was beaming at me the whole time. I’m not entirely sure why, but that couple filled me up with so much positive energy.
+
+Down into the next gap, I began to micro-nap. I don’t know how long it lasted, but I continued to twist my ankle and walk off the trail, and even hallucinate (I saw my dad’s face in a poplar tree, even double-taking to make sure) until, at last, I threw down my pack and collapsed trailside for a deep, hour long nap.
+
+Blood Mountain wasn’t too difficult. It climbed up and over several false summits and finally wound up into a rocky, rhododendron covered peak. The wind was steady and snow was still on the ground. I Exploded off the trail and shot down the mountain (small birds for once played in the rhododendron). I found cougar tracks. An ornery, cantankerous skunk was said to occupy the mountaintop shelter, and a bear had reportedly been “hanging out” around the summit. To accentuate the sense of wildness was the narrow trail itself, which tunneled through the rhododendron and crawled over mossy rocks. On the summit’s main rocky outcrop, I saw the entire North Georgia Mountains rolling out and a pink and purple sunset over them. The CCC constructed shelter, a 2 room stone edifice complete with windows and a fireplace. Still, drafts of cold wind kept the shelter far from cozy, so I gambled on finding a free place to stay and moved on down the mountain to Neels Gap.
+
+I reached Neels Gap outfitter by 5 o’clock, closing time, but fortunately the Hiker Hostel was open. There were several men milling about, all with foot-long gray beards and long hair. A long beard means one thing in the mountains - experience- so, naturally, I was excited to spend a night with the experts. The price was only $15, said one bearded man, with the possibility of working it off. I sat down inside and wrote while another bearded man prepared tacos and rambled on about how “everything was going to shit” thanks to an enforcement of state ordinances. Two more bearded men walked in the door and dissappeared out the back. “Can you shoot a cougar?” I asked. “Sure, I don’t see why not. But if they catch you they’ll throw you in jail”, said one of the gnarliest of the bunch. Then he let out a long calm laugh and started talking to the cats. “Come get dinner,” he said after awhile, “or the cats’ll get to it. Actually, they already have.” He laughed at that.
+
+After dinner I boiled some tea and sat by the heater to write in my journal. In ten minutes I was curled up in the chair asleep. It was so nice being warm.
+---
+
+# Wednesday, February 10, 2010 — Low Gap Shelter
+**Start Location:** Neel Gap Hostel
+**Miles Today:** 11
+**Trip Miles:** 49.50
+
+In the morning I got up at 6:15 to get a hot shower before the others did, then sat by the heater and read a book about trees. At 9:00, I packed up, and walked up to the outfitters. I asked to do some work to pay off my stay, but the owner wasn’t there so I settled up to save time. I hit the trail just before 10, just as the rains came.
+
+That day was divided sharply between great and God-awful. The first half, the great part, flew past as I hoofed without stopping through the wind and rain. 6 miles over to Tesnatee Gap. I went hard and strong and felt like a champ. But after a short stop at Tesnatee, things fell apart. During the stop, I’d quickly lost all doby and hand heart and became a numb-fingered, shivering - and , not to mention, dripping wet – mess. My hands lost the benign feeling of numbness and began to hurt like someone was bending them back. Groaning aloud and cursing, I began to march. I won’t go into details because the next 4 hours was a drama of the most boring kind. I’ll just say it really sucked and skip to the moment with God, which occurred near the end of the ordeal. I was mouthing off at him again (aloud, mind you), not really making a case but just pissed at the day’s suffering. I had to yell at someone. I told h im to make it okay, or at least give me the big picture so I could at least calm down. All of the sudden, I said it aloud, “This is all part of it”. This is part of the Good, the adventure, the chase after an elusive Spirit. This very moment of numb hands, wet clothes and stabbing blisters was the very reason I set off. Because this is Thoreau’s “marrow of life”, and in it I will find my God.
+
+I went to sleep that night with no idea what to do about my blisters for the next day. The wind picked up and a fog rolled in and the night was all dense blackness and I thought to myself about the old proverb “When I saw I stumbled.”
+---
+
+# Thursday, February 11, 2010 — EconoLodge Motel (Helen, GA)
+**Start Location:** Low Gap Shelter
+**Miles Today:** 13.50
+**Trip Miles:** 63
+
+That was a rough night. The temperature plummeted, freezing to rock everything in the shelter I thought was safe – my water bottles, my boots, my clothes. Snow flurries blew in while I slept and covered my down sleeping bag, soaking into the goosedown inside and forming a shell of ice on the surface. As a result, my feet went numb. I awoke cold and discouraged. I fumbled with numb hands to gather my gear and apply my moleskin. My boots were too frozen to put on so I screamed at God in the ravine “What the hell am I supposed to do??” I put on my down booties and started walking.
+
+To my surprise, the down booties did an excellent job. By the time I reached the Blue Mountain Shelter, I had marched through 8 miles of snow and ice and my feet felt great. Close to the summit the wind blasted through the trees. It filled the ears like deafening static. “C’mon! C’mon!” I yelled exhilarated by the struggle against the elements. At the summit shelter, I found an old-timer with his dog and Kevin, a young thru-hiker. “Fire!”, I said, seeing the wind ripping smoke out of the fire pit. “How’d you pull that off?” Kevin was knelt by the fire. He grinned like it was no big deal. “Sticks and fire”. Then he laughed. “Respect”, I said, I asked for more details. The old-timer had a long beard and a weathered face. He was smoking a Backwoods cigar. As it were, the two were holed up in the shelter because the next peak on the trail, Tray Mountain, was demolished by a terrible ice storm. The trail was impassable, said the old-timer; he had tried. The company was nice, especially by two with more knowledge of mountain survival than I. “So where’d you learn to make a fire in the snow?”, I asked. Kevin had been a hunting guide in British Columbia for half of the year, for the past six years, and had “pulled out bodies” from the snow many times. I told him of the previous night’s problems and asked for advice, “The learning curve in the cold is steep, bro” he said grinning. He was really impressed by my light pack. “Hats off to you, mate. Especially in cold weather.”
+
+I gave Kevin some cheese, warmed my hands up by the fire, and marched on down to Unicoi Gap to hitch into town. Dry gear and a warm motel were in high demand. After a minute of thumbing a black car pulled over. Alex, a gay artist on his way to see his boyfriend, was glad to drive me around town to check various motel prices. He was “paying back a favor, or paying it forward, whichever one” He said in his hometown, Hayesville, NC, alcohol had just become legal last month. He had been a vocal advocate. His father, a Baptist minister, had led the opposition. I laughed. Alex said goodbye at the EconoLodge, and I fell asleep on my $30/night bed. I woke up, took a shower, called home, and ate some shrimp ramen with tuna and olive oil. Everyone seemed fine at home, like they’d moved on without me as I’m accustomed to them doing. When you’re away, all you can really say is “I love you” or “I miss you” but those words don’t mean much. It still kinda sucks. I thought about that while I ate my ramen. That night I watched a cheesy movie about aliens. I just didn’t feel like writing.
+---
+
+# Friday, February 12, 2010 — Mull's Motel (Hiawasee, GA)
+**Start Location:** EconoLodge Motel (Helen, GA)
+**Miles Today:** 15
+**Trip Miles:** 78
+
+At 6:15 the next morning, I was packing my gear up. It was all so warm and dry. I wrote until 7 o’clock then went to breakfast. Ron, the on-duty manager, was fiddling around with setting up breakfast. He rambled on about how dismal Richmond was for various reasons, including one story about two hookers begging him for crack money. Another story involved drug-running and leaving town after a 6’5” friend fooled around with some other guy’s girlfriend. “I gotta ask you something”, he said. “Are you carrying a gun?”
+
+After breakfast, I dressed my blisters. I bought moleskin at Randy’s pharmacy and the lady let me sit inside to apply it. Randy gave me free blister tape: Trail Magic! “Stay as long as you want, I’d let you lay out and take a nap if we still had those mattresses!”
+
+I walked out to the road and stuck out my thumb. Believe it or not, Ron pulled over. He rambled about me burning ukp all his gas money, running a homeless shelter, how “he don’t pay me shit” at his job and the yars he spent with black ops in Vietnam. “I help people like you out because of what I done to all them”, he said looking skyward. “You wouldn’t believe the sniper rifles they got these days,” he said next. Ron was a good man, a wreck but worth every penny. I’m glad I met him. “I can’t afford to burn all this gas,” he said. “But I need to get up into these mountains. It’s beautiful”. I got out and slammed the door at the trailhead. He rolled down his window and yelled for me. “Hey, hey…I’ve gotta ask you a question.” “Do you ever see things up there that you’d never see down here?” I said “Yes, you do.”
+
+That day on the trail was great. I passed one hiker after another, meeting and greeting and exchanging trail info. I first passed Ryan, another thru-hiker. He’d been laid off, but luckily gotten into law school, and, with his wife’s permission, took off on the A.T. during the layover. He had a nice North Carolina draw. “I’m one of those slow, deliberate people”, he said as I passed. “Yeah,” I laughed. “You’ll probably pass me napping in the next shelter”. Next, I passed three sturdy men moving in the opposite direction. They were older, yet were “tougher than your average weekenders” as they assured, and seemed it. They were impressed by my ultralight pack. On my way up Tray Mountain, I passed an older fellow coming down. Dave Herring was in his 60’s and still climbing Georgia’s mountains, meeting up with thru-hikers and helping them along the way. A full-time Trail Angel, you might say. Today, he escorted two thru-hikers up and over Tray Mountain (remember, the trail was all but wiped out by the storm). For two separate nights, Dave had brought the hikers homecooked dinner, a warm bed, and a place to watch the Super Bowl. For three days, he had brought in two thru-hikers for hot meals, beds, and a Super Bowl party while icy conditions on Tray Mountain improved. Today, he escorted them up and over the mountain. He used to be a big runner, he said, but had lost cartilage in his knee. Now, he was down to just day-hiking for he and his wife. I was overwhelmed with gratitude for this man and his wife, for people who give themselves so fully to the strangers passing through. I’m talking about the A.T.’s host of Angels, and they’re watching over our road north.
+
+After a long nap at the top of Tray, I passed two thru-hikers, Fauma and Second Stage, on the way down the mountain (when I say “down the mountain”, I’m referring t the many ups and downs between a summit and a gap. Rarely is there black-and-white ascent and descent on the AT). All day, I’d been tracking their prints through the snow and around the debris. Catching up to them was the climax of the day. “You hear about these hikers ahead of you and you read all their entries in the shelter journals. You start to paint a mental picture of them,” I told Fauma when I caught him. “It’s kinda like online dating.” He laughed, “Wow, guy”.
+
+My eyes were set on Dicks Creek Gap, still 5.5 miles away by dusk. I flicked on my headlamp, chugged some orange juice and kept trucking. My legs were tired and my feet sore from walking in my booties for 8 miles already. I made it by 7:30 and hitched a ride into Hiawasee by 8pm. I got a motel room for $50 despite efforts at bargaining. I walked across the street to Hardee’s for dinner. I wrote, took a hot shower, and fell asleep by 11:00 with the lights on.
+---
+
+# Saturday, February 13, 2010 — Mull's Motel (Hiawasee, GA)
+**Start Location:** Mull's Motel (Hiawasee, GA)
+**Miles Today:** 0
+**Trip Miles:** 78
+
+I woke up and caught the motel on fire. My alcohol stove liaks, you see, so when I placed it right outside the door of my second-story room it soaked the green carpet with alcohol. When I lit it, it exploded in a flame. I tried to blow it out to no avail. I knocked it over and flaming alcohol spilled out over more carpet. Flames were at least a foot high. I beat at it and finally got it under control, but the damage was done. The carpet was black and smoking. “Shit.” I said calmly. I quickly packed up my gear and got the hell out of there ASAP, tip-toeing over the office, down the steps, and one building down to a café.
+
+As I sipped my coffee and wrote, I kept waiting for the motel owner to come looking for me. Afterall, in a small town one can’t run far. The café door would squeak open and I’d brace for confrontation, over and over again. “The cops are here for you”, I suddenly heard the barista tell a regular. I tensed. Maybe cops were turning into the motel parking lot, which the café shared, to hunt the fleeing vandal. And sure enough, three cops entered and stood by the door looking at me. “Can I help you officers?”, said the barista, and the officers sat down for a doughnut. I breathed out.
+
+Looking over my shoulder, I crossed the street to the grocery store. I spent $33 for almost a week’s worth of food. Then I got a ride to the Blueberry Patch Hostel where the owner, Gary Potteat, turned me down at the driveway. “We’re just not finished yet. Maybe tomorrow.” He said kinda sorely. He’s a good Christian man who’s taken in thousands of hikers for no gain but ministry, so if he was sore I think it was because he had to turn down a hiker in need.
+
+I had only 60 some dollars left, so another night at the motel was out of the question, even if I hadn’t fled the burned carpet that morning. I had no where to go.
+
+The kind folks who gave me a ride (out of their way) to Blueberry Patch Hostel dropped me off at a church at the junction where they returned to their route to Atlanta to see their sick mother. I’ve always wanted to test out the church as a place of unconditional refuge, so I walked up to the office and knocked on the door. No answer. Just before walking back out to the road to thumb to another church, I noticed a small house on the corner of the church property. A pick-up was out front. I walked up and knocked, and to my surprise a younger man opened the door. He was hip-looking, sharp, kinda like a Young Life leader. “Let me see what I can do. Come on in.” I knelt down to pet the lab. “You know, I’m a thru-hiker back in 1996”. I couldn’t believe it. But the magic didn’t stop there. He said, “Follow me” and we walked over to the church. He flicked on the light in a room, “Wait in there and I’m gonna try to pull some strings,” he said, then disappeared. I read a bible for about five minutes, when a gleaming middle-aged woman walked in. “I’m Lynn”, she said. “I’m Gary’s wife, at the Blueberry Patch. We’re gonna get you a room in town.” I couldn’t believe it. Lynn, the gleaming secretary at the church, at which I fortuitously knocked, was the wife of the woner of the hostel where I’d just stopped, wife of a man who’s Christian kindness spread his name all the way to Richmond. And this connection was dropped in my lap by a sympathetic thru-hiking pastor. “We’re going to get you a room at Mull’s Motel”, she said. My stomach dropped. The burned carpet. That’s where I left the burned carpet. “Let me drive you to Mull’s” said the young pastor. We pulled in and I prepared for impact upon entering the cramped motel office. Fortunately, the 86 year old lady was still there in her nightgown, just like I’d seen her the evening before. And, (thanks to her age, perhaps) she didn’t remember me. I couldn’t believe it. I was redeemed. “I really don’t know how to thank you, man,” I said. “It just works out, doesn’t it”, he said. I think from time to time God has fun and wires things. Redemption of unbelievable cause-and-effect complexity. Even miracles. No, it’s not in his nature. It’s not all like that. Jesus spent but a sliver of his hours dropping jaws with these unbelievable occurances. Most of his days were spent walking around in the dust, telling people that, yeah..reality can be really boring but it’s okay. The miracles almost never happen around town but it doesn’t matter because the real miracle is deep within. The real wonder is the heart and soul of man. So, I won’t walk to Maine looking for him to wink at me again. I’ll keep looking within.
+
+Snow fell that night in Hiawasee, about 2 inches. I ate my trail mix and wrote oa letter to the Potteats from the warmth of my motel room. After two nights of comfort, I was ready to hit the trail again.
+---
+
+# Sunday, February 14, 2010 — Blueberry Patch Hostel
+**Start Location:** Mull's Motel (Hiawasee, GA)
+**Miles Today:** 0
+**Trip Miles:** 78
+
+After a "zero day" off the trail, I awoke again in Mull's Motel and gathered my things. A lady saw me and asked if I needed any fuel of supplies. Yes, I said. I needed denatured alcohol for my stove. She pointed towards an outfitter down the street and told me to meet her there. "We got some for ya." She drove her truck around the corner, parked out front and opened the door and led me in. "It's free," she said, pointed towards some steel cans of alcohol. "Just leave a little something in the Kitty." I dropped a couple quarters in a cat-shaped container, thanked her, and hitched to the Blueberry Patch Hostel. The owner Gary Poteat still hadn't opened for the season, but I needed to pick up a package my parents had shipped there. Gary's house is off a 45 mph highway, miles from the city. It's easy to get a ride there from the city, but hitching away is difficult. A nice guy in a pick-up dropped me off there and drove away. Nobody was home so I waited, but I quickly realized it was too cold to hang around. Back to the trail was my only option. I left a note and walked out to the road. I stuck out my thumb and tried to look cold and miserable.The more cold and miserable you look, the more likely a car is to stop. I think.
+
+After almost 30 minutes, around the bend came a pickup. It was slowing and it's turn signal was on. It was Gary and his wife, Lynna, returning from town. They pulled in. "I know yall aren't open yet. I just need a package before I go," I quickly said as they got out. I wanted to make it clear that I just needed a package, not more charity. He said he had it and added, "You're welcome to stay the night." I pretended not to hear. If he really meant it, he'd repeat the offer. Sure enough, he did. "Yeah, I'd love to." This meant another day's delay, a second "zero", but I didn't care. This was an experience I wanted to have. Back in Richmond, I'd heard of Gary, his hostel, and even his hiker-famous blueberry pancakes. It was worth a day lost.
+
+We chatted as he lit the wood stove in the bunkhouse. Gary was a talker, and told me some of his story in his cool, Georgia-accented voice. He thru-hiked in the 90's and felt the Lord's voice. "Open a hostel of your own," he heard. "Minister to hikers." He married, moved back to Georgia and bought a parcel off the AT. Ever since, he's taken in ragamuffin hikers like myself. I was the first of his 18th year.
+
+The telephone rang and he walked over an answered it. Another hiker was on his way. Soon, a familiar face appeared at the door. Keven, the Canadian I'd met on Blue Mountain, walked in the door. He was thrilled to see me. I was glad to see him.
+
+That night we went into Hiawasee. We bought food for the next stretch to Fontana Dam, a tedious process of diving out calories on price. Keven convinced me to share food together over the next two weeks--breakfast, lunch, and dinner. Sounded like a good idea. I mean, why not? We also got some steaks and asparagus to take back to cook. I bought a crispy Fuji apple. Back at the hostel, we ate heartily and stayed up until 1:00 dividing ten days of food weight.
+---
+
+# Monday, February 15, 2010 — Muskrat Creek Shelter
+**Start Location:** Blueberry Patch Hostel
+**Miles Today:** 15
+**Trip Miles:** 93
+
+We skipped church the next morning. The pastor of the Poteat's church, the Macedonian Baptist, had given me a ride into town and paid for a $50 motel room, and Gary Poteat had broken tradition and opened the hostel a day early just for me. I owed it to them to go to church and I knew it. But to make it 11 miles to the Muskrat Shelter by Sunday night, we needed to leave early. Kevin agreed. I still feel like I missed something by skipping church. I think He was waiting for me there, but I was too hasty to stop. We broke the news to Gary that night.
+
+At 7:30 Sunday morning, I packed my pack and prepared to leave. Gary called us inside for a stellar breakfast of sausage, biscuts, eggs and pancakes with home-picked & home-made blueberry syrup. We held hands and prayed over the food, just like home. Gary prayed for us and I knew he (and Lynna) meant every word. It all warmed me up. Lynna gave us a hug before leaving, told us he'd be watching out. I've never meant a person that glowed so genuinely for Christ. You can't glow for God, I thought to myself, cus he's kinda mean. He's like the snow and ice. But you can glow for Christ. He's like the sunshine.
+
+By 10:15 we were on the Trail, marching towards Maine. Just before the Muskrat Creek Shelter we crossed the North Carolina border. We celebrated and cursed Georgia. "Screw Georgia! We're in North Carolina!". Remember, all was buried in 1.5 feet of snow. Some drifts were even up to our thighs. After passing the gnarled oak in the clearing at Bly Gap, North Carolina greeted us with a grueling climb in 2-foot snow drifts. Very difficult. At Muskrat Creek, we found some food left by the previous night's campers. We played cards while we ate it for dinner. That night 4 inches of snow fell. Snowflakes drifted in and soaked into our down sleeping bags. I slept well.
+---
+
+# Tuesday, February 16, 2010 — Standing Indian Shelter
+**Start Location:** Muskrat Creek Shelter
+**Miles Today:** 5.30
+**Trip Miles:** 98.30
+
+The snowfall paralyzed the next day's movement. We packed up and ran down to Raven Rock, a side trail to a rocky outcropping over miles of open ridge & valley. The view was spectacular. Kevin pointed out a bear. I wasn't convinced.
+
+A word on Kevin. He's good kid, 22 years-old and mild-mannered like myself. And like myself, his giggles and lightheartedness are clear stamps of loving parents and a comfortable, financially-stable home. Still, being with him is a challenge. It's Kevin in the morning and Kevin in the evening. We share shelter, food and water. We share the gratification of a long day's hike. We even share the silence of nightfall, which he prefers filling with dialogue. In a word, I'm sharing my great spiritual journey and it's irritating. I didn't hit the trail for company, to substitute "I" for "us" in my journaling. But the Spirit put him in here for a reason. To show me something or another.
+
+The short 5.3-mile hike taxed our mind and body. We crawled along at about 1mph through the snow, inspiring each other with singing and joking. For hours we carried on, and arrived at the Standing Indian Shelter by dusk. We threw down our packs and searched for firewood. In 20 minutes a fire was blazing. It's amazing what a fire can do for spirits! "I'm not afraid of the night anymore," I said. "I'm not afraid of the cold." The fire smoked-out the shelter, sending us coughing out into the snow. It died down as we cooked tortillas with cheese over the flames. Beef stew for dinner. For some reason, Kevin got sick and I kinda had to take care of him in the cold. Up to that point, I'd kind of honored him as a senior, like a guide. But I realized then that I was better off alone. I was strong and independent.
+---
+
+# Wednesday, February 17, 2010 — Carter Gap Shelter
+**Start Location:** Standing Indian Shelter
+**Miles Today:** 7.60
+**Trip Miles:** 105.90
+
+The next morning was 10 F in the shadow of Standing Indian Mountain. According to Cherokee legend, "a great winged monster once inhabited the mountain, and, during the monster's reign, warriors were posted on the mountain as lookouts." One day, a huge bold of lightening exploded on the mountain, killing the monster and striking the unfortunate warrior on-duty at the time. He was a lousy look-out, apparently. That's why he was struck and turned to stone. He's still there, a "Standing Indian" stone, but I didn't see it.
+
+The sun was out and it was freezing. It had snowed another inch. Again, I had to wait for Kevin and ended up just leaving. We were both miserably cold. My feet were numb and patience low, but I brightened up the moment I started walking. That day flew by. We rolled into the shelter by 3:30 after nearly 8 miles of snow trudging. Fahma from Massachusetts was there. He'd taken the day off "I've been eatin' and drinkin' all day," he said. Running into Fahma was the highlight of the day. The night fell easier with him there to break the monotony of Kevin's voice. No offense to Kevin's voice. I'm just tired of it.
+
+I asked Fahma about his family. He said he once had a son who thru-hike with him two years ago. "He had so much energy," he said. "He really got me through it". His son died last April of a brain tumor, and this hike was for him. According to Kevin, he paid for the Gooch Mountain Shelter I'd stayed in several nights before, in honor of his son. I recalled seeing a memorial photo on the wall. "This is for you, Tim", Fahma writes on every shelter journal. Lord, the baggage we carry so silently.
+---
+
+# Thursday, February 18, 2010 — Sapphire Inn (Franklin, NC)
+**Start Location:** Carter Gap Shelter
+**Miles Today:** 15.90
+**Trip Miles:** 121.80
+
+I left Kevin again that morning. That's how it'll probably always be: me leaving early and him catching up at the shelter at the end of the day. Because I'm with him morning and night, I cherish the days where it's just me and the trail. It's funny I use the words "me and the trail" when I sort of mean "me and God". Because that's kinda what he's like. Like a trail.
+
+The first several hours were painful. My feet burned and ached from numbness, and I groaned aloud. "My toes," I kept saying. "My toes hurt." Frostbite was a possibility, I thought, but I felt no tingling. Just numbness. I debated stopping and firing up my stove to thaw them out, but it was just too cold to stop. "And if I do get frostbite," I thought, "it's okay because I'm young." Still I was worried. I kept walking.
+
+I took a side trail around Mount Albert, the official "emergency weather route". The moment I spotted an observation tower on it's summit I veered back onto the trail. An observation tower would be worth the difficulty. As expected, the rocky ascent was extremely precarious in the 2-foot snow drifts (I quickly learned that they offer "emergency weather" routes for a good reason). The tower was old and tired-looking and surrounded by dense rhododendron thicket. The wind blew. I climbed up to look out over the valley, spreading out for perhaps 50 miles. On the horizon hunched the Smokies, blue and ominous. A snowstorm obscured its peaks. I felt like Frodo, staring out to the black peaks of Mordor where my road would inevitably lead. Except this Mordor was blue and icy.
+
+At about 2:00 I felt my toes for the first time that day, thanks to a gradual downhill that allowed me to pick up speed and get blood down to my feet. I gulped from a stream. I walked on. Time blurred and suddenly it was 4:00. I waited at the shelter for Kevin.
+
+Soon Kevin arrived, and we decided to move on to Franklin, 3.7 miles down the trail. After 5 days and 4 nights in the cold, we needed a night off. My feet were sore and stressed and I suspected some hairline fractures, but I kept on 'til we reached the highway. After 20 minutes of thumbing, a white pick-up pulled over. He was a skinny, tatooed young guy with a NC accent and Marlboro Red in his mouth.
+
+He, his brother, his father, and even his grandfather--yeah, his grandfather!--all enlisted in the Marines within the last decade. He's been shot twice and blasted by an IED. The IED was a ticket home, where he got a job managing three Hardee's in the area. The "interview" for the job was a West Virginia football game, where he got hammered and had flashbacks from the fireworks. "I freaked out," he said. After a pause, "And I got the job the next day." For a while, he took post-tramautic stress disorder ("PSTD", he called it), but it killed his personality. "I'll take the flashbacks," he said. He also said he'd die before his son grew up as poor as he did, eating PB&J for dinner. That made me happy to hear.
+
+He dropped us at the Sapphire Inn where we got a 10% discount for being A.T. thru-hikers. We had fajitas at a Mexican place across the street and lounged in the room until around midnight. I took off my boots for a shower before dinner and found a browned and swelled pinky toe. It burned under water. Frostbite! I laughed and decided not to tell my parents when I called. I journaled later that night. Kevin watched TV. I wished I had the room to myself.
+---
+
+# Friday, February 19, 2010 — Siler Bald Shelter
+**Start Location:** Sapphire Inn (Franklin, NC)
+**Miles Today:** 6
+**Trip Miles:** 127.80
+
+We left late the next morning. I drank 4-5 cups of coffee and updated my blog on the hotel’s computer. Kevin packed up and watched TV in the room. At 11:00 we walked over to Hardee’s. Kevin ordered 4 burgers and I brought in some tortillas, PB and honey. We got a hitch to the tail from another young local. “S\*\*\*, man. Just came from a funeral. I had to get the F\*\*\* outa there.” A buddy of 21 years had gotten drunk and dropped a cigarette in the couch. The house caught fire and “they found him right next to the F\*\*\* door”, he said. “I guess the smoke just got to him”. He got quiet. “We all knew him pretty well.” He pulled over and ran into a convenience store. He came out with a brown bag and drove off. He steered with his knees and rolled a cigarette. “I’d offer you some weed but my girlfriend has it all.” He complained about unemployment and not being able to provide for his kids. He seemed so worn out by it all. He dropped us at the trailhead and drove off.
+
+The hike in was only 6 miles, a steady climb on a good trail. At the shelter we ate two burgers that Kevin had mistakenly received at the Hardee's, and we went to bed early after a game of cards. Playing cards in the cold takes a lot of effort.
+---
+
+# Saturday, February 20, 2010 — Cold Spring Shelter
+**Start Location:** Siler Bald Shelter
+**Miles Today:** 12.60
+**Trip Miles:** 140.40
+
+We started late the next day, the day that would be the physically hardest yet of my journey. After a morning of lounging in the sun and eating, I was on the trail at noon. My destination: Cold Spring shelter, 12 miles away. The snow was deep over Siler’s Bald, where the imaginary Joseph Siler grazed stock nearly 200 years ago, and I followed Kevin’s prints. I caught up with him at Wayah Gap after 2 miles of trudging. I was enjoying myself, yelling “Wayah” over and over again in a high pitched voice.
+
+The ascent after Wayah was difficult. I blazed through knee-deep snow for nearly 2 miles, stopping every 20 steps to catch my breath. That wore me out. The trail wound around the mountain and up to an old stone observation tower built by the CCC in 1933. We stopped to take photos and eat dinner (it was 5:00). We hit the trail again in an hour under a setting sun.. The snow looked orange. We didn’t want to go but knew we had to in order to make it to NOC in time to meet Kevin’s friend, so that night we hiked until 10:00 pm to Cold Spring Shelter, totaling 12 miles that day.
+---
+
+# Sunday, February 21, 2010 — A cabin (NOC)
+**Start Location:** Cold Spring Shelter
+**Miles Today:** 12
+**Trip Miles:** 152.40
+
+There were 12 miles to go before the NOC, so we got up early (7:45) and hit the trail. The conditions on the hike were good – better than the day before – and we made excellent time. 12 miles in 5 hours, thanks in part to a 6 mile downhill. The last bit of the trail was paradise. The sun hit down in to the pines and to the understory, and the world was green and brown. I savored the smell of the pines. “This is how the South should smell,” I thought. That snowless section, though short, redeemed all days before it. Or at least gave them a happy ending.
+
+Kevin’s friend treated us well that night, feeding us homebaked cookies, cheetos, and whiskey and then taking us out for $15 steaks. The house was warm and, honestly, that was the biggest treat of all. They’re good friends and got drunk. I sat inside and wrote. It felt like a perfect day off, as do any long days with a warm-bed ending.
+
+At this point on the trail, I don’t know how I feel. Since joining up with Kevin, I feel like the emotional growth has stopped. It’s just been a social experience since and doesn’t excite me like the first leg of the journey did. I’m kind of bored with it, in fact, because it’s no longer mine. It’s shared with Kevin. My happy memories all lie in the first week, before Kevin. Since, it’s been dull and lifeless. God hasn’t been there. He hasn’t said a thing. It makes me hate Kevin for robbing it all from me, this once-in-a-lifetime season with God. I need to get away. I’ve decided that. I don’t know how. Will god put an opportunity in my lap to sneak away? Or should I just break away. For now, everyday is a lost one with Kevin. Every day is just like the rest.
+
+I wrote all that just several hours before, as a timely answer to my prayers, Kevin decided to take a “zero day” and let me hike on. We’d catch up in Fontana, three days away. It was just so perfect the way it worked out, you know? Maybe a wink from Him, saying “don’t you worry. Just seek me and you’ll find me.”
+---
+
+# Monday, February 22, 2010 — Sassafras Gap Shelter
+**Start Location:** A cabin (NOC)
+**Miles Today:** 7.50
+**Trip Miles:** 159.90
+
+So we ate a huge brunch and at 12:30 Kevin and his friend drove me to the trailhead. I was so happy to be off again, alone on my quest. The sun was out, snow melted and there was smell of pine everywhere. Just like summer! I took my shirt off and yipped aloud.
+
+I thought about my family and how much I miss them. They’ve done so much for me already, loved me so fully that I teared-up thinking about it. I saw god in all the beauty there. Our family is such a sold rock.
+
+By and by the trial became snowy and deep, and splintered rhododendron thickets, limbs and full trees blocked the trail every 50-some feet. Anger came at all the slipping and sliding. My frostbite blisters ached. So did my heel blisters. The deep snow and debris persisted. My anger grew. By the time I reached the shelter, that anger had burned me out. I didn’t really feel anything, and so the day ended on kind of a sour note. That night the wind made strange noises that kept me on edge. The drips of the shelter sounded just like feet crunching through show, and several times I got out of my sleeping bag and sent out to see nothing.
+---
+
+# Tuesday, February 23, 2010 — Brown Fork Gap Shelter
+**Start Location:** Sassafras Gap Shelter
+**Miles Today:** 9.10
+**Trip Miles:** 169
+
+I awoke late that morning. Being alone is good, but it’s just so lonely. Kevin is irritating me but I think it all may be more pleasant with him around. Not better for me, just more pleasant.
+
+At noon I left. A very late start to my destination 10 miles away. I’d eaten all of my cliff bars, smoked pipe, and played my harmonica. All was well. I was cursing again up the mountain to Cheoah Bald, furious at the debris blocking the trail and snow slipping under my feet. I hated everything around me, I hated god, and I hated myself. Fog was everywhere.
+
+The trail disappeared at Cheoah and it took a while to find. My anger was still around just quieted down. Another hour passed and the fog lifted. Suddenly, the sun broke through and illuminated the trail.. Bugs began to fly. Birds called. My heart was lifted and cleared out, and I laughed outloud. I thought about my family and how much love is there and started to cry in joy. I’m so emotionally unstable. Maybe I’m just mimicking a trail that itself is so irregular. Then I thought deeply about anger. Because I felt like people walking in the woods should think deeply about things. Anger comes up from below, I figured, only when a happy ending is no where in sight. It’s when you feel like your stranded in a bad situation with no ladder around to climb out. When I know the shelter is right around the corner, I don’t care how many limbs are on the trail. The end is near. But for some reason it angers me when I don’t know how long the struggle will ensue. Trudging through snow is okay if I know the shelter is near, but I go to rage when the end is nowhere in sight.
+
+In the sunshine I thought also about my friends at JMU. Leaving them behind and hiking with a stranger, I realize how deep and true they all are. I’m not talking about my dear old friends, Sean and Wesley, whose role in my life day to day is marginal nowadays. I’m talking about the Treehouse boys (my roommates), who I see now are so much more than I realized. Something about them – maybe their humor, maybe their devotion to each other, maybe the way they gave themselves so truly to me – strikes a chord deep in my heart. I didn’t see it before, but looking back alone in the woods I see it now: Rawlz, Chocolate, Seth, Barefoot, Cameron, Will and Fedesh were a gift. They were God showing me how it should be. I almost cried thinking about the gift.
+
+As you can see, reader, I’m entirely emotionally unstable as I hike towards Maine. I fly high in the morning, curse God at noon, whimper in the evening, and quietly surrender myself to His will before I go to bed. It’s an incredible high relief experience, now that I think about it, that few are fortunate enough to have. The portrait of god out here, captured through the lens of my twisted hart, is so shocking. So outrageous. So explosive. I’m seeing colors flashing and booming in my heart that I never knew existed.
+
+That night I slept at the Brown fork Shelter with Bill, a skinny old guy with a beard. He was good company. He liked to talk wild about anything that was worth talking about with a loud and enthusiastic voice. Trail conditions, hiking at night, his dog, good gear, philosophical matters. Like I said, he’s good energy generating company.
+---
+
+# Wednesday, February 24, 2010 — Fontana Lodge (Fontana Village)
+**Start Location:** Brown Fork Gap Shelter
+**Miles Today:** 12
+**Trip Miles:** 181
+
+We all got up in the morning to make it 12 miles to Fontana Dam. I really didn’t feel like hiking and I cursed on the way out. My mom says I’m angry and need to deal with it. She says that maybe I have anger buried deep and that this walk will help release it. All I know is that I have a lot of anger and it boils out on the trail. The demons spill out, yeah, but I still don’t know how to extinguish them before they manifest in all my rage. I haven’t accomplished anything until I’ve accomplished that.
+
+By 2:00 I was thumbing for a ride into Fontana Village – a older guy in a pick-up stopped. He was on his way to work on some village lodges and said in a North Carolina accent that he’d love to say “F\* society” and go into the woods. I think every man has it somewhere in him, that drive away from the world and into the woods.
+
+At the post office I picked up my new showshoes and strapped them to my back. The other package –my food maildrop- hadn’t yet arrived so I walked over to the lodge to call home. On the way, I stopped by the convenience store and the clerk gave me a free sausage dog. I loaded it up with relish, cheese, and chili and bought a chocolate milk and candy bar to wash it down. At the lodge I dialed home and , as it turned out, they had my package right behind the counter. “You’re Ford?”, she said. “Ford Prior?” I was warm and cozy in the lobby and so got a room for $60 – I’d get $30 off for a broken heater. I washed up back at the room. I read the letters in the care package and thought about home before falling sleep. The chef called to invite me to dinner and I feel asleep again.
+---
+
+# Thursday, February 25, 2010 — Fontana Dam Shelter
+**Start Location:** Fontana Lodge (Fontana Village)
+**Miles Today:** 1
+**Trip Miles:** 182
+
+In the morning I went to the front desk at 6:45 and asked for some money back. The heater had kept me awake and restless during my one night of what should have been sweet dreams. I got half of my money back and typed on the guest computer for an hour or two. I went back to sleep, got up and returned to the lobby. Kevin and Bill soon showed up. We lounged there for several hours then hitched to the Fontana Dam Shelter just up the road. Bill, Kevin and I went into town to resupply. At the shelter we ate almost uncontrollably into our food stash and had to force ourselves to stop.
+---
+
+# Friday, February 26, 2010 — Mollie's Ridge Shelter
+**Start Location:** Fontana Dam Shelter
+**Miles Today:** 11.30
+**Trip Miles:** 193.30
+
+Since before leaving home, I’d gloomily anticipated entering the Great Smoky Mountains. It lay like a snowy wall before us, visible now and again from on ly the highest peaks but always on the back of our minds. Today we entered it, crossing over Fontana Dam and into the woods. Huge snowflakes fell. The grade was steep, as we recovered elevation, and with higher altitudes came old snow. That day 12 miles weren’t difficult, well, they were like any miles, reader; they had their curses and laughs and felt linger than they actually were. Mollies Ridge shelter was nice, and we built a fire that wouldn’t stay lit. It snowed all night.
+---
+
+# Saturday, February 27, 2010 — Derrick Knob Shelter
+**Start Location:** Mollie's Ridge Shelter
+**Miles Today:** 12
+**Trip Miles:** 205.30
+
+That night was very cold. Bill, the 51 year old 4-time Ironman athlete, said “back home, nobody is ever going to understand. They’ll ask, “was it cold?” All you’ll be able to say is “yes, it was cold.” He also spoke of toughness. “You’re going to forget a lot of this, like how tough you had to be. You’re going to have to remind yourself, time and again for the rest of your life, how tough you really are.” I thought about that.
+
+The previous morning we woke and set off to Derrick Knob , another 12 miles up and over Thunderhead Mountain. I blazed and it broke me, and that day I cried like a baby. I screamed, too. And cursed. It was just so hard I didn’t know what to do. If there had of been someone with me, I would’ve tempered myself. But there were no pressures to keep my cool and I exploded. Friends and family may wonder, “happy ole Ford has anger problems?” I say not really, but you’d be a different man or woman, too, if you were in my position. You’d lose yourself like you never thought you would.
+---
+
+# Sunday, February 28, 2010 — On the side of the road (U.S. 442)
+**Start Location:** Derrick Knob Shelter
+**Miles Today:** 15
+**Trip Miles:** 220.30
+
+What a day! It’s funny how you can wake up in the morning and all sorts of things happen and that night you wind up falling asleep in some bizarre place you’d never of guessed. It’s wild. That night I fell asleep spooning with Kevin and cramped up against two large propane tanks. Tight around us was a high wall fence for the tanks, which plugged into the back of a locked weather building next to Route 441 at Newfound Gap. We had hiked 18 miles in the worst of conditions. We hoped to hitch into town at Route 441, but it was desolate, closed, we guessed. The march from Derrick Knob took us to the top of Clingman’s Dome, the AT’s highest point, and down to the gap in 15 hours. Hiking for 15 hours (that includes your four 15 minute breaks) in 2 feet of snow (sometimes 3 foot drifts) will take the fight out of you, until 1:00am we walked, slowly aching and soring all in places we never thought we’d ache and sore. Like my collarbone, which I broke in 9th grade. It was hard, and I pushed my mind and body just a little farther towards wherever we should be pushing our mind and body.
+
+\*Looking back, I realize how intense that night was.
+---
+
+# Monday, March 01, 2010 — A cabin (Gatlinburg, TN)
+**Start Location:** On the side of the road (U.S. 442)
+**Miles Today:** 0
+**Trip Miles:** 220.30
+
+Redemption Days, I call them, are when you go into town, you take a hot shower like you’ve never had one before. You eat a meal and close your eyes and wish it would never end. And you sleep in a warm bed in dry clothes and you feel just like a little kid again.
+
+Today, we awoke to the sound of snowplow trucks in reverse. I climbed out of the propane area and ran out to the road in my long underwear. I flagged down the truck. The driver looked at me funny. I didn’t know what to say. “Can you help us out?” He said he couldn’t give us a ride to town but a park ranger would be up in about an hour. He showed up in an hour in his big white suburban and was glad to give us a lift. He talked in the car about how very few thru-hikers are dope-smoking hippies like he once believed. They’re a strong, healthy bunch, he said.
+
+He dropped us at the Visitors Center and I flipped through some summer photography books from the Smokies. The warm, colorful photos made me laugh and tear up. The coming of Spring and Summer arouses such strong emotions for a nomad in the cold.
+
+Kevin’s friend, a grad student working on his thesis, picked us up and took us back to his uncle’s mountain house. We got pizza and beer and lounged by the television. I took a nap and a hot shower and then another nap. Sleep came early that night on a full belly and central heat.
+---
+
+# Tuesday, March 02, 2010 — Icewater Spring Shelter
+**Start Location:** A cabin (Gatlinburg, TN)
+**Miles Today:** 3
+**Trip Miles:** 223.30
+
+Some say getting back on the trail after a day off is difficult, but hitting the trail after our day off at Gatlinburg wasn’t too bad. Our pockets were stuffed with fruit and sausage biscuits as we walked three miles to Icewater Shelter The view was great over Cherokee and the sun was strong, so we stopped, gathered firewood, and relaxed for the afternoon. We slept sweet that night.
+---
+
+# Wednesday, March 03, 2010 — Pecks Corner Shelter
+**Start Location:** Icewater Spring Shelter
+**Miles Today:** 8
+**Trip Miles:** 231.30
+
+The next day was an 8 mile hump to Deck shelter in terrible conditions. It snowed all day and the sun buried in gray clouds. The trail disappeared and we had to blaze through 2 and 3 foot drifts that were often sloped so steeply as to collapse into mini-avalanches that would overcome a mouse. Kevin slid down the mountain some 30 feet, and I had to throw him a linie to drag his pck out. It was 45 minute ordeal. That night we arrived at almost 10pm. It was another long day in the Smokies. That night I punctured my blow-up thermarest, spilled my dinner all over the ground and broke Kevin’s spoon. I was angry.
+---
+
+# Thursday, March 04, 2010 — Cosby Knob Shelter
+**Start Location:** Pecks Corner Shelter
+**Miles Today:** 14
+**Trip Miles:** 245.30
+
+The next day we covered 14 miles to the Crosby Knob shelter, a 10 hour hike. Another difficult day. I could get used to this cold, wet snow hiking, but it would be a miserable existence. Like a caveman. Today we blazed trail again, showshoeing through virgin drifts. At Crosby Knob, I found a cigar and smoked it after dinner and drank hot chocolate. Not a bad night. Actually, quite a pleasant one. I’ll never forget the simple pleasure of hot chocolate on a cold night and the glow of the cigar in the pitch black.
+---
+
+# Friday, March 05, 2010 — Standing Bear Farm Hostel
+**Start Location:** Cosby Knob Shelter
+**Miles Today:** 10
+**Trip Miles:** 255.30
+
+|     |
+| --- |
+| [![](https://www.trailjournals.com/images/photos/journals/10467/tj10467_032710_190106_517655.jpg)](https://www.trailjournals.com/journal/photos/10467/517655/301896) |
+
+Getting out of that sleeping bag in the cold is the hardest part of the day. Every morning I lie in my “womb” for as long as I can, trying to convince myself that I’ll make it to my next destination on time, even if I lie just a little longer. That morning was one of those mornings. The sun was high and schedule tight by the time I was out of the bag and on my feet.
+
+The day’s destination was the Standing Bear Farm Hostel, several miles out of the Smokies. The last push wasn’t bad, moving slowly but with momentum, up and over the last mountain. I blazed with snowshoes and Kevin followed. We ran into four Spring Break hikers from Roanoke College – Casey-Lynn, Erin, Cary and Alex Ali (from Godwin!) – coming in the opposite direction. I burst out in excitement, “Oye!” and asiled them with questions and marvels of the trail. A friendly bunch they were, and matched my enthusiasm. They were astounded to run into a veritable thru-hiker, as I’ve been so many times before, and I felt for a moment that my undertaking was indeed greater than myself, that in the eyes of the world, this was a real-life epic, and it was all steered by little ol’ me. And I won’t feign humility here; it sure does feel like it sometimes. They gave us carrots, Kashi bars, and one delicious apple (thanks guys! You’re Angels!) to quiet our grumbling stomachs and hugs to sate a month dry of human contact.
+
+The snow cleared up and we stripped off our snowshoes. Down the hill we ran, yipping and hollering. At last, our feet were free from snow and shoe for the first time in three burdened days-and the liberty was exhilarating. The sun broke through the clouds and illuminated the snow. The sky was blue. I laughed to myself and almost cried: How can it be that the sky opens so easily? How can things be okay again so quickly? One thing I’ve learned in the past month is to expect that of life. When it goes way down it’s okay because it’ll surface again. It gets so bad out here-the snow, the ice, wind, the debris- but I’ve slowly come to know that it’s okay. “Just hang on,” I tell myself. “It’ll be better soon.” When I get home I’ll remember that, because some years ago my mother looked at me hard and said “things are great now, but they won’t be forever”. So when things do go bad I’ll remember the Smokies and all that snow. It’s gets better at the bottom of the hill.
+
+I lay in the sun and took a nap. Lou, from Kentucky, woke me up. He was passing on to the next shelter to “get away and read a little bit.” He had turned back from the trailhead near Gatlinburg, through which I was proud to say we’d fought, successfully. We shook hands and moved on. I arrived at Standing Bear in the afternoon and met Curtis, the owner. Curtis is rough-looking hippie with tough hands and a ponytail. “F\* off, we’re full!” he said with a cigarette in his mouth when I rounded the corner. I laughed and sat on the porch. That night we sat by the wood stove, ate Mom’s banana bread and drank a 24 oz. Heiniken. No hot showers. Oh well.
+---
+
+# Saturday, March 06, 2010 — Groundhog Creek Shelter
+**Start Location:** Standing Bear Farm Hostel
+**Miles Today:** 8
+**Trip Miles:** 263.30
+
+|     |
+| --- |
+| [![](https://www.trailjournals.com/images/photos/journals/10467/tj10467_032710_190106_517656.jpg)](https://www.trailjournals.com/journal/photos/10467/517656/301897) |
+
+When you really don't want to hit the trail, it seems time slips by quicker. This morning we woke late (at least for us) and lay silent in our sleeping bags until nearly 9:30. It had been a late night in the hostel bunkhouse as Kevin, myself, and Hawk the caretaker built homemade alcohol stoves until past 1am to the sound of hard rock radio and in the heat of the bunkhouse's wood stove. With Hawk's recycled metal, I built two new experimental stoves. In case you didn't know, reader, alcohol stoves are made with beer cans and cheap scrap metals. Using the alcohol in your medicine cabinet as fuel, you can boil a pot of water in five minutes. A cool, lightweight and easy-to-make outdoor gear. I bought a 24 oz. Heineken can, drank the contents and built a replacement piece for my old stove. By the time I hit the sack, I was exhausted.
+
+I ate like a lion today, almost uncontrollably. The trail mix, granola, and whole grain couscous was all so good. I was just so hungry. It made me feel full, sleepy and comfortable like I hadn't felt since relaxing at home a month ago.
+
+Curtis, the owner, gave us a tour of the old tobacco farm. I saw a foot-thick American Chestnut tree, which excited me. Curtis was a nice guy, a burned-out yet shrewd hippie with a ponytail and more than an ounce of simmering ambition. He ranted about his farm's potential in a niche organic tobacco market; "Right now, all I farm is hikers. And rocks. That's a figue speech, you know." Whenever he made a joke he paused to clarify with that same phrase: "It's a figure of speech," even when it wasn't a figure of speech. He showed me a sheet of fresna lense, which, used like a magnifying glass on ants, could "melt a penny in a minute". Indeed, in a couple seconds it burned my hand. Curtis laughed.
+
+I sent off some journal entries and at 3:45 we were on the road again towards Maine. The hike wore me out. I was blazing again. We caught a magnificent sunset ontop of the Snowbird Mountain bald. Layered in red and velvet, the Smokies stood solemnly like a blue and white fortress wall. It was the most beautiful I've ever seen. I was pissed about the tough climb. Had Kevin not been there to hold me up and remind me of the beauty, I'd of moped right on down the mountain, counting my curses. I didn't really think about God then, as some of you readers would have hoped. I just thought about how everything fits nicely in the end, and how this sunset was some kind of redemption from the painful two weeks in the Smokies we'd just left behind.
+
+The last stretch of the hike was mild. Kevin led with his headlamp, which I call the "Eye of God" for its brightness. We chatted to pass the time. That night Kevin extinguished an all-too-audacious mouse with the sharp end of his trekking pole and we ate chocolate bars.
+---
+
+# Sunday, March 07, 2010 — Roaring Fork Shelter
+**Start Location:** Groundhog Creek Shelter
+**Miles Today:** 11.50
+**Trip Miles:** 274.80
+
+"Dude, I just don't care anymore," I told Kevin several hours into the next day. He sort of laughed. "Neither do I, man. I've thought more about quitting today than I ever did in the Smokies." It was true. We'd covered over 250 miles and broke past our most formidable challenge, the Great Smoky Mountains, a climax in itself. But the trail felt empty post-climactic void. There was nothing really to look forward to now. No dramatic punctuations. Just dull and difficult miles, and 2,000 miles of them.
+
+That morning had been another late start. We just couldn't move on with any intention or speed. I was angry at Kevin for something stupid and left before him. On the mountain my toes went numb and dangerously close to frostbite. I groaned and groaned at the pain. I finally pulled over, took off my shoes and socks, and heated up my feet over the stove until my feet stopped hurting. The feeling was vaguely there, but the frostbite pain (which is like someone bending your toes backwards) was gone. Kevin walked up and sat down. We cooked a hot meal in the middle of the trail and moved along. (I learned later that I'd sustained more frostbite on my big toe, but the skin was protected by thick toe-pad callus. Writing 2 days later, it's still totally numb on both toes).
+
+At Max Patch, an amazing bald so large that airplanes used to land on it, we found some dayhikers and talked to them as the sun set. Then it was on to Roaring Fork Shelter, where we found two more overnighters to share the lean-to. “People! Kevin, people! Are you excited? I’m excited.” He was. This was the first night with company. After almost a month of occupying shelters with just Kevin, seeing a light through the woods beyond the “SHELTER” sign brought me to a yip and a yell. In fact, all the human contact that day filled me up; the shelter company was just icing on the cake.
+
+Yeah, we were weary coming out of the Smokies, but we’d moved on that day hoping for a little inspiration. Mr. Boyer said I’d empty out for a long time before the Lord would fill me back up. So maybe that’s what’s happening now. I do not fear it. It’s no fun, but I do not fear it.
+---
+
+# Monday, March 08, 2010 — Deer Park Shelter
+**Start Location:** Roaring Fork Shelter
+**Miles Today:** 15
+**Trip Miles:** 289.80
+
+A great day.
+---
+
+# Tuesday, March 09, 2010 — A cabin (Hot Springs, NC)
+**Start Location:** Deer Park Shelter
+**Miles Today:** 3.20
+**Trip Miles:** 293
+
+Many nights, I open my eyes in confusion. I awake from deep dreams of home, so it sickens the stomach when one realizes he's far from it. Sadly, that hard floor below and black shelter ceiling above mean one thing: I'm on the A.T. The disappoinment is alawys deep. Early this morning I awoke in Hot Springs, lying under soft bed covers in a heated cabin, and it hit me. Opening my eyes was deeply disappointing. The dream wasn't of home (actually, it was of NASCAR races in the Outer Banks, NC), but it was so warm and fuzzy. It wasn't along the A.T. where, deep down, I don't want to be. That's right: I don't want to be here
+
+That "Live in the present" B.S. only works for 10-second bursts available 3 to 5 times a day. The rest of the day sucks, and one can either spend time not thinking (i.e. approaching mental fluidity and Zen) or thinking (i.e. consciously cursing each bump on the trail). I move back and forth between both.
+
+So even though I was riding the gravy train in Hot Springs, I still didn't want to be there. I wanted to be home. As for the day's schedule, there's not much to say. Eating heartily between each event, we relaxed, showered, hot tubbed, and slept. The best part of the day? Plunging into the icy Frech Broad River from the cozy hot springs.
+
+So to all you faithful readers who say to yourselves, "DOESN'T WANT TO BE THERE?! IS HE CRAZY? HE'S LIVING THE DREAM!", remember that, no matter how uncomfortable I am, I'm following Truth and that's all I need. "Following truth" sounds cheesy and over-inflated, but honestly that's the only reason I'm here. That is what's binding me to The Trail.
+
+P.S. Sorry about the sporadic entries. My faithful mother is serving as secretary and transcribing the journal pages I'm mailing from trail towns. Using a computer like I am now is an exception.
+---
+
+# Thursday, March 11, 2010 — Spring Mountain Shelter
+**Start Location:** A cabin (Hot Springs, NC)
+**Miles Today:** 11
+**Trip Miles:** 304
+
+March 11
+
+The vortex. That’s what the lady at the outfitter called it. I’m not familiar with the vortex but I’ve felt its presence especially as Kevin and I debated on whether or not to move on today. When your feet stop moving the pull of the vortex begins, they say. First it’s an extra day of rest, then it’s a week, then you’ve given up. But it wasn’t like that for us. We just needed another day of rest, and, writing a day later, I’m glad we kicked up our feet another day. No regrets. I’m all alone now, sitting in a diner at 6:45am. It’s warm outside and rain is coming. I’m as happy as I could be to be one country breakfast away from hitting the trail again.
+
+A man behind with suspenders and a white beard rambled on to every local who comes in the door. “Johnny, d’you remember when the bank got robbed?” he says to Johnny, who pays for a to-go cup of coffee. The old bearded man tells the story just as he did to the last passerby. Johnny tries to go. “Darn it, Johnny, sit down here and let’s talk,” gripes the old man. After 20-some minutes the conversation goes to corporal punishment, “You know that’s what’s a matter with kids these days. Hell, I’ll come over there and whip ‘em myself!” Then stories are exchanged.
+
+The day's hike was not a bad one, but climbing back into the mountains from Hot Springs made me question why I was moving on in the first place. The old-timer's rambling 9-5 routine was so appealing. Rain broke, and I reached the shelter feeling miserable and cursing under my breath. But, as always, I got in my sleeping bag and everything was alright.
+---
+
+# Friday, March 12, 2010 — Jerry Cabin Shelter
+**Start Location:** Spring Mountain Shelter
+**Miles Today:** 15.40
+**Trip Miles:** 319.40
+
+Today ended with seven hikers, lined like sardines in a shelter with the rain pattering on the roof. I wished I was alone, but oh well. The day had been a good one – almost 16 miles – and clear enough to keep me in bright spirits. It rained on and off and I was always wet, but the air was balmy and wind low and I stayed lkay the whole day. I won’t go into the boring details because to everyone except me they’re just that: boring.
+
+So at the shelter we met some kids from Appalachian State, including two pretty girls. It was nice being around some pretty girls. They gave us a full loaf of home-risen bread. In the morning, I hiked alone in the sunshine and had a revelation about the “remember how tough you are” bit of advice. Nobody’s ever a coward or a wimp, they just don’t remember how tough they are. And when you’re a Christian, it’s not remembering how tough He is.
+
+I got up in the dark of the night. The rain was really coming down in heaves and everyone was asleep. Someone snored nightly. I looked out in the gloomy woods, just a mess of dark gray and black. It was all so beautiful, and I wondered if this was God romancing me, you know? I lit a pipe and watched the embers glow and die and glow and die, not knowing what the silence of the night meant, but knowing it meant something.
+---
+
+# Saturday, March 13, 2010 — Hogback Ridge Shelter
+**Start Location:** Jerry Cabin Shelter
+**Miles Today:** 14.70
+**Trip Miles:** 334.10
+
+Another beautiful day, and hopes were high as I crossed mile 300. I was leading the pack, the second northbound thru-hiker of the worse-weathered season in recent memory, and I felt strong and confident. Three hundred miles of ups and downs and here I am: on the bright side. We made it to our shelter before nightfall, and found 2 beers, 7 sodas floating in the icy cold pool by the spring. Our first encounter with premeditated trail magic! I used ear plugs that night for Rooster’s snoring. I’m starting to write strange things in the trail registers. Yesterday, I wrote that monkeys stole all our food. Tonight I wrote that watch-selling gypsies showed up at 3am.
+---
+
+# Sunday, March 14, 2010 — No Business Knob Shelter
+**Start Location:** Hogback Ridge Shelter
+**Miles Today:** 20.70
+**Trip Miles:** 354.80
+
+And I thought we were in the clear. The morning opened with an inch of still-falling snow on the ground, and we were off with moderate spirits, and I was feeling alright, in the zone. But approaching the top of Big Bald, the trail simply disappeared. The snow was knee-deep by now. Two experienced college kids had given up searching the day before and set up an emergency shelter. A 20-something couple had done the same. Both groups headed back down the mountain, but we didn't have the luxury of turning back. We took a photo of a contour map and kept trudging on. The trail – or lack there of – was hell, and we wandered the woods, completely lost. Finally, we found some cross country ski tracks and followed them to the shelter. I don’t feel like recounting those last 10 miles, but I got lost a couple more times for 30 minutes, broke my trekking pole against a tree in anger, and arrived to camp in the pitch black of night. Deep snow, bad downfalls, a numb-toed nap in a hollowed-out tree. Twenty-one miles and a long, long day. But we made it, and all’s well that ends well.
+---
+
+# Monday, March 15, 2010 — Curley Maple Gap Shelter
+**Start Location:** No Business Knob Shelter
+**Miles Today:** 10.50
+**Trip Miles:** 365.30
+
+All-You-Can-Eat pizza took the place of breakfast, lunch, and dinner today. We sat in Erwin’s Pizza Plus for several hours, eating pizza after pizza and drinking Mountain Dew. It was incredible. It made my day. We’d trotted 6 miles into town that morning to resupply and left to the next shelter late that afternoon. I bought fuel, 7 snickers bars, 7 oatmenal packets, lemondade mix, 2 ramens, and mixed two varieties of trail mix – nuts, raisins and baking chocolates & pinapple, mangoes, cranberries and nuts. Enough for 3 days of strenuous hiking. We also did a load of detergentless laundry at the coin laundry. Rooster, the kindhearted Arizonan we’d picked up in the Springs, decided to quit. “It wasn’t what I thought it’d be, man. Not like last year.” I’ll miss him and the way he calmed the room. Oh well. We got to the shelter that night in the dark. I smoked my pipe, drank hot tea, and whished I was alone. The other guys just wouldn’t stop talking loudly. An interesting thought: Toe Man said that when he’s hiking alone he knows exactly where he is , but when he’s with company he doesn’t really know what’s going on. He relies on others to lead him. Life is like that , he said. I agree. Things are so clear alone.
+---
+
+# Tuesday, March 16, 2010 — Clyde Smith Shelter
+**Start Location:** Curley Maple Gap Shelter
+**Miles Today:** 22
+**Trip Miles:** 387.30
+
+Robin said that (even though we are out of the Smokies) challenges lay ahead. Yesterday I army-crawled over Unaka Mountain, and I realized how right she was. Unaka was buried with 3 feet of snow, and on the way up we ran into a Citadel grad, 3 months shy of deployment to Iraq. He said he’d been on the mountain for three days, trying unsuccessfully to push through the snow and downfall with his GPS. He’d lost the trail. "Want us to lead you over?," Toe Man asked. "We're not turning back." In a couple hours, we broke through the mess. “What does that say about the U.S. Military?” Toe Man joked.   Every soul we’ve encountered has been in escape of the mountain, retreating with head hung low. That days hike carried over into night. Even with my headlamp, all was murky as thick fog rolled in. I was ahead, and when I got to the shelter I sat out in the dark to smoke my pipe. No headlamp; just my pipe, the dark and I.
+---
+
+# Wednesday, March 17, 2010 — A cabin (near Overmountain Shelter?)
+**Start Location:** Clyde Smith Shelter
+**Miles Today:** 13.10
+**Trip Miles:** 400.40
+
+|     |
+| --- |
+| [![](https://www.trailjournals.com/images/photos/journals/10467/tj10467_032710_190106_517666.jpg)](https://www.trailjournals.com/journal/photos/10467/517666/302273) |
+
+You never really know who to trust when asking about the trail ahead. Everyone has his or her standards of assessment, so when Joe at the trailhead looks wearily at me and says, “Turn back man. It’s impossible.” The trail may in fact be quite the opposite. It may be an easy day. So whenever someone tells me it’s impossible, I size ‘em up. What are they wearing? Do they sound frantic? How long were they at it? And did they use the work “impossible”? Because if they did, they are not to be trusted. Down in Erwin, the outfitter told us (in crude language) that Roan Mountain would be extremely difficult, that we should wait for better weather. Well, we made it over Roan today defying the outfitter’s forecast of failure and surprising the critics once again. It was hard, but not as hard as he said. Off the mountain I was soaked with snow, sweat, and ice-melt. I met aaron, a warmhearted man on his way down from a day-hike. He was full of love. Or maybe it was joy. Aaron: if you read this, thanks for brightening my life. You radiate, man. I caught a “God Bless” when we parted ways and I think it may have something to do with it.
+
+Next we climbed several balds, open grassy expanses that took me back to scenes from Braveheart. Lone Scots running along highland ridges with bagpipes in the background. The bagpipes played on as we walked with 360 degree panoramic views.
+
+Off the balds we lost the trail. We ended up following a old logging road to the bottom of the vally. In the dark, we spotted a dimly lit mansion and approached. Upon knocking we met Jim Morton, who gave us directions back to the trail but offered us a night in one of his five cabins on the property. We couldn’t believe our good fortune, and I fell asleep that night on a soft bed. Trail magic, once again.
+---
+
+# Thursday, March 18, 2010 — Mountain Harbour Hostel (Elk Park, TN)
+**Start Location:** A cabin (near Overmountain Shelter?)
+**Miles Today:** 9
+**Trip Miles:** 409.40
+
+I was all out of food, so the next day’s journey was a hungry one. We crossed two 5,500 foot balks and descended down to Elk Park, TN over the course of 9 miles. I got ahead of Toe Man and Kevin and, at the road, hitchhiked in to town to pick up my maildrop. I was ecstatic to be away from the fellas. They were really starting to get on my nerves, and I felt the rush of freedom as I sat at the hostel and slit open the maildrop box with my knife. Or maybe that was just the rush of seeing a zip-lock bag of homemade cookies! I took a shower, stoked the wood stove, ate cookies, and walked around the living room if the hostel, not really sure what to do with myself. Free time? For all the vagrant conceptions of thru-hikers, we’re actually a busy bunch. Free time is a treat.
+---
+
+# Friday, March 19, 2010 — Moreland Gap Shelter
+**Start Location:** Mountain Harbour Hostel (Elk Park, TN)
+**Miles Today:** 16.70
+**Trip Miles:** 426.10
+
+I passed a “mile 400” sign today in a ravine, and I kept on walking, wondering how I made it this far. I thought back to the second day, when I felt like things couldn’t get any worse, and I wonder what bizarre force pushed me on. Was it will? Stubborness? Faith? Or something other than that?
+
+Tonight is the most quiet night of the walk so far. It’s like a glassy lake fogged with darkness. I’m alone tonight again and glad for it. “Make it stop”. I kept saying aloud on the way here. It wad dark and my feet were at their limit, pounding with a pain I just couldn’t numb my mind to. My feet were not happy, and every step was a reminder of 400 miles of walking, these were the most painful of all. I did something I’ve never done before, right then: I asked God for strength. I didn’t really know what else to do. I wasn’t angry or emotional like before – I shed neither rage nor tears – but just tired of my feet hurting. And my prayer worked like a good medicine. In a couple of minutes, a second wind picked me up and carried me to the shelter.
+
+Like I said, that night was quiet like a cathedral. You could feel it all around you, that still and open space that afforded the lonely hiker with a sense of safety in the night.
+---
+
+# Saturday, March 20, 2010 — Kincora (Dennis Cove, TN)
+**Start Location:** Holiday Inn Express (Abingdon, VA)
+**Miles Today:** 6
+**Trip Miles:** 432.10
+
+I think if Jesus was around, he’d sit down and talk wit you about your favorite thing, no matter how boring it was. He’d pretend to be interested while the NASCAR fan talked his ear off about why Dale Jarret should be in the Hall of Fame. He’d ask questions, too, and pretend to be excited with you. “Wait, he won the Daytona how many times?!?!” There aren’t enough people like Jesus around to encourage us to spout off our passions, so we begin to believe that those passions aren’t worth being passionate about. I try to jump in like Jesus would, but I forget most days. I mean, it’s exhausting.
+
+Today I went to church with Bob Peoples, owner of the Kincora Hostel, and after the service he invited me to a dinner. It was all old folks, but I sat with a girl my age who wants to open a quilt shop. She was a really nice girl. After the dinner, I sat around and chatted while Bob helped clean up with the other men. “They wanna do their part so I understand,” said the woman who prepared the dinner, “but it’d be quicker if they just let me do it. They don’t know where anything goes.” Her husband came out to catch his breath ,and started talking to me about his German Shepard. Nobody was really listening to him as he went on, so I stepped up and played Jesus. “It’s only two years and weighs 105 lbs.!?!? Does she eat a lot?” And doing that for him, really validating his passion, filled me up.
+
+The woman was overweight and had short-hair and was the kind I would have passed on the street with a judgemental eye. But she sprang to life as I talked to her about her work with the church and state as a counselor psychologist. She was full of love, like we all should be. She mentioned her five kids. “It sounds like you’re a mother to more than five,” I said.
+
+Back at the hostel I talked with five students from Grinnell College, and it hit me how sociable JMU kids are by comparison. JMU kids know the art of communication and pride themselves in being exceptionally agreeable citizens. Kids from smaller, private liberal arts schools tend to communicate awkwardly and choose not to shake hands and smile. So it seems, at least.
+---
+
+# Sunday, March 21, 2010 — Kincora (Dennis Cove, TN)
+**Start Location:** Kincora (Dennis Cove, TN)
+**Miles Today:** 0
+**Trip Miles:** 432.10
+
+I took a “zero” day today to rest my feet. I don’t really have blister problems; it’s my bone structure and foot pads that hurt so badly. In a word, my feet just feel bruised. The whole situation doesn’t irritate me too much, but I am disappointed to be wasting away this beautiful weather. I wish I just felt good. I could really start complaining here but I’ll save my time. Can’t wait to be back on the trail tomorrow but fearing my feet.
+---
+
+# Wednesday, March 24, 2010 — The Place (Damascus, VA)
+**Start Location:** Double Spring Shelter
+**Miles Today:** 18
+**Trip Miles:** 450.10
+
+|     |
+| --- |
+| [![](https://www.trailjournals.com/images/photos/journals/10467/tj10467_032710_190106_517674.jpg)](https://www.trailjournals.com/journal/photos/10467/517674/301902) |
+
+Yesterday was another day split by dull pain and bright moments of joy. I ate some cold oatmeal (it's better cold, I beleive) and left Double Spring Shelter at 9:36. According to Tony, it was "surely" no more than 8 miles to Damascus, a section he claimed was "the easiest section on the Trail." Not true. I cursed him under my breath the whole way for being so sure about something he obviously knew nothing about. Before long I was at the gap and soon after that Abingdon Shelter. There, I cooked (and ate) too much couscous and fell asleep with my feet propped up to reduce swelling. I woke nearly an hour later from deep sleep. My head felt fresh but my feet hurt badly. The march down to Damascus was a difficult one, but I was there by 5:00. At The Place, an unattended $5-donation hostel run by the Methodist Church, I ate too many candy bars (a bag of them, left as Trail Magic in the hostel). I left to grab a bacon cheesburger, Mountain Dew, and an ice cream bar. Then, an old-timer invited me back to his house for teriyaki chicken. I obliged. His name was Larry, and he's got a wild story. He escaped the law and hid in the woods for 3 years, until he had a spiritual revelation and turned himself in. He did time and came out somewhat reformed. Since, Damascus has taken him in and he's taken to helping hikers. Now, Larry lives with his dog and cat. He stands in front of a warehouse and sells yard-sale things. That night, I ate more candy bars and fell asleep.
+---
+
+# Thursday, March 25, 2010 — The Place (Damascus, VA)
+**Start Location:** The Place (Damascus, VA)
+**Miles Today:** 0
+**Trip Miles:** 450.10
+
+My zero day in Damascus has little to say. I was supposed to walk over to Larry's to buy some eggs and turn his garden, but instead I ate dougnuts and walked over to Mount Rogers Outfitters to try on some insoles. My feet were killing me. Jeff, the large, kindhearted foot expert there, fitted me for some Superfeet insoles and said it would solve my problems. It took him a half hour to explain the foot-mechanics behind my pain, and I appreciated every minute of it. It's not often you run across someone who really knows what they're talking about. I met up with Lucky, a SOBO, and another section hiker. We power-walked a mile or so to a Pizza Plus (all-you-can-eat pizza), then waddled like penquins back to the hostel. I took a nap then walked over to Joe's Gym, and I paid him $5 for a MMA lesson. We practiced kickboxing kicks, boxing drills, ju-jitsu holds, and muy thai clinches. Afterwards I lifted weights. Shaking up the routine like that it sometimes all a hiker needs. Hanging out with Joe freshened my spirits. That night we went to Quincy's Bar & Grill and I had a Star Hill IPA and a grilled cheese. It was live music night, and we listened to some suprisingly-talented locals sing, strum the guitar, and play the harmonica. "In Color" was my favorite cover they performed. Everyone at the bar was singing along. The other hikers watched the March Madness game and I watched the locals interact. The Place was cold and had only dirty towels (yea, I may have used one or two) and hardwood beds, so it was just a step up from the shelter. Still, I slept alright.
+---
+
+# Friday, March 26, 2010 — Augusta's Appalachian Inn (Damascus, VA)
+**Start Location:** The Place (Damascus, VA)
+**Miles Today:** 18
+**Trip Miles:** 468.10
+
+|     |
+| --- |
+| [![](https://www.trailjournals.com/images/photos/journals/10467/tj10467_032710_190106_517675.jpg)](https://www.trailjournals.com/journal/photos/10467/517675/302260) |
+
+Today my dad came! I woke up early and walked across the street to Augusta's Appalachian Inn. I'd met Terry and Sissy on their front porch of their B&B the day I entered town, so I recommended the place to my dad. down the street/AT for a diner for a breakfast of pancakes, bacon and egg. From there I hit the trail for an 18-mile day hike (I'd hitch back to Damascus that afternoon to meet my dad). I was anxious to get some more miles under my belt.
+
+A mile down the trail, I realized that I forgot the pay for my breakfast. But I disappeared into the woods and told myself I'd pay when I got back to town. It was raining and I was soaked shortly, which was uncomfortable. I wore only Terry's daypack, so I was able to trail run off and on. My feet hurt.
+
+For you history buffs, the trail was a cool one. It ran along the Virginia Creeper Trail, an old railroad used to export valuable timber from the region. Thanks to the Creeper, named for the "creeping" slow speeds of the trains, acres of old-growth poplar and hemlock forests were leveled and Damascus experienced a economic boom. The lumber boom died, the rail went to public transportation, and by the 1980's the state stripped the ties and closed the line. In it's place, they layed out the Virginia Creeper Scenic Trail. It is open for pedestrian, equestrian, and bicycle traffic. Between the trail and the rail flowed the Laurel River, a fairly-wide river popular for trout angling. The whole day, I could hear the dull roar of the river rapids.
+
+By 2:30 I was at U.S. Highway 58 (1.5 mi N of Lost Mountain Shelter), where I was to meet my Dad in the parking lot at 5:00 PM. Too cold to wait, I thumbed a ride. The pick-up took my several miles down the road, but I found myself again on the side of the road, sticking out my thumb in the rain-turned-snow. It was cold.
+
+After over 2 hours of thumbing unsuccessfully (I hated Mankind at this point), I saw Terry coming down the road in his new 4-door pick-up. It had been a cold and shivering wait, and I was too exhausted to be excited about this stroke up good fortune (\*you see, my Dad had called in bad traffic and asked for Terry to come pick me up). I got back to the B&B, drank hot coffee, and took a shower before my Dad arrived. I got out of the showever and stopped: was that my Dad's voice downstairs? It was, and something ticked and I suddenly felt so safe. Yea, Pops was downstairs, and it was good.
+
+That night we went out for burgers at Quincy's and met "Full Moon," our waiter and three-time 1,000-miler that worked also at the bike shop next store. We asked about biking the Virginia Creeper Trail tomorrow, and he gave us the low-down. We asked about the Tavern, a fancy restaurant in Abingdon, and he gave us the low-down. The chef came out and talked to us about the menu; the the scznitzel, he said, the scznitzel.
+We drank some beers and walked back to Augusta's and sorted out my food. All I can say is that reunited with my Dad was one of the most amazing things I've yet experienced on the Trail. We went to bed around midnight.
+---
+
+# Saturday, March 27, 2010 — Holiday Inn Express (Abingdon, VA)
+**Start Location:** Augusta's Appalachian Inn (Damascus, VA)
+**Miles Today:** 0
+**Trip Miles:** 468.10
+
+What a weekend with Ford. I guess you can call me a "Guest" writer for Ford (Uncle Frank). After a great day in Damascus conquering the grueling downhill Creeper trail on bikes, we headed over to Abingdon to see the town and get a steak dinner before Ford hits the trail again. Abingdon is a very cool town that is home to The Tavern where Ford and I got the VERY best steak that I have had in memory. I don’t know if it was the self imposed fast that Ford and I were on in preparation for our dinner or the company but we both agreed that steak dinners like that don’t come frequently enough. After we gorged ourselves we lay back in our chairs, starred at each other and reminisced of great steak dinners of our time. We agreed that we must do better about keep track of great steak dinners and that more were surly to come. I also reminded Ford that a great lobster, not yet in the boat awaited him in Maine. Ford is a big topic with Ford nowadays and I don’t mind doing my part to make sure he gets his share of gastronomical events while in Virginia.
+I put him back on the trail today. Rested I hope. The rain began to fall as Ford got his gear together put it on his back and slipped into his poncho. I was amazed at how fast he got his gear together and reminisced at the time when he was a scout when it took hours to leave the car for an overnight and he was ready and on the trail in 5 minutes for a week. After a hug and some encouraging words before he disappeared into the wet leaves of the Rhododendrons of the Appalachian Trail.
+As I made my way back to Richmond, I thought about how much I wished I could be on the trail with Ford and what an amazing journey he is on. To be with him this weekend gave me some insight into his journey. It’s complicated but very simple. It seems like by being on the trail alone most of time, when you get to a small town like Damascus or Abingdon, connecting with people becomes a big part of the experience. No one does this with more enthusiasm than Ford. I am so proud to say I am Ford’s Dad.
+---
+
+# Sunday, March 28, 2010 — Wise Shelter
+**Start Location:** U.S. 58
+**Miles Today:** 20
+**Trip Miles:** 488.10
+
+Hey Everybodies! I'm losing steam documenting every detail of every day, so I'm just going to do a High-and-Low format to cut down on the tedium and simplify things a bit. Here it goes...
+
+Highs: My first high was meeting up and picking the brain of Eric, a 7-time PCT (and 2-time AT) ultra-light thru-hiker with a 6 lbs. pack. Eric is 39 and works at a brewery out West to save money for his next thru-hike, and I asked him question after question about how he accomplishes a thru-hike. What do you eat? How often do you drink? Do you take ibuprofen? Why the umbrella?
+
+My second high was hiking on Whitetop Mountain in 100 mph winds (100 according to Eric). Crossing the bald, that mighty wind blew OFF his poncho and knocked me down twice. I just screamed with excitement, "Wooooooooo-hoo-hoo-hoo!". It was a blast. Eric said he'd never seen winds that high. "And it cost zero dollars and zero cents!", I said. Eric liked to trail run and I struggled to keep up.
+
+Lows: Saying "Bye Dad" sucked. He dropped me at the trailhead and we both went our separate ways and I told myself, "Just keep walking. It'll all be fine. Just keep walking." I tried to be jolly but I felt so alone.
+---
+
+# Monday, March 29, 2010 — Trimpi Shelter
+**Start Location:** Wise Shelter
+**Miles Today:** 20
+**Trip Miles:** 508.10
+
+Highs: Seeing a young owl flap curiously around me. His flap was loud and awkward, and needed practice. That was at dusk, after I'd spent almost an hour trail running down to Trimpi Shelter. When I got to the shelter, two old fellas awaited me with a hot fire, and I dried my socks and boots.
+
+Lows: It rained alot that morning/afternoon, and for a couple hours I sat in the shelter not wanting to move on into the rain. Getting started sucked. Another low was wandering with numb barefeet around Trimpi Shelter looking for firewood.
+---
+
+# Tuesday, March 30, 2010 — north of Atkins
+**Start Location:** Trimpi Shelter
+**Miles Today:** 27
+**Trip Miles:** 535.10
+
+Highs: Eating at a shelter after a morning of hunger, napping in the sun, smelling the pines. Also, I met Joe, a 2-time record-breaker for speed-hiking the PCT. He was also ultra-light. Joe was stocky with tattooed arms (not your typical long-distance hiker build). I hiked with him until near Atkins and picked his brain. "You'll be a different person when you get back," he promised me. "Something will change." At such a young age, he said I'd probably end up hiking the PCT next year. "Twenty-one? It's good you're getting into this stuff \[long-distance hiking\] so early," he said. He was in his 40's.
+
+Another high was leaving Joe to trail-run to Atkins, down the mountains and into the pastureland. At the bog, the grass was lush and green, and I saw purplish-green jar plants. At Atkins, I ate veggies and picked up a maildrop at the Barnyard Restaurant and set off at sunset for some night hiking. I hiked until nearly 10:30 under a full moon. At the top of the mountain, I pulled off and layed out my sleeping bag under the moon. I toothed open a bottle of Dead Guy Ale and drank it, staring dazed at the moon. Everything was gray silver or hidden in moon-shadow. A full moon is an amazing thing.
+
+Lows: None! Maybe a little foot pain in the beginning, but nothing qualifying as a low.
+---
+
+# Wednesday, March 31, 2010 — Jenkins Shelter
+**Start Location:** north of Atkins
+**Miles Today:** 30
+**Trip Miles:** 565.10
+
+Highs: Joe caught up with me mid-day, and covering ground with him was probably my high of the day. I asked him questions and let him talk. Also, getting up at sunrise on the mountaintop was a gratifying experience. Lastly, a tough 4-mile climb with Joe culminated at Chestnut Nob, a beautiful 270-degree view of the surrounding mountains. You could really see the hand of geology from the ridge, the pushed the mountains together into wrinkles and smoothed them over.
+
+Lows: Eating too much cous-cous at lunch always sucks. I was burping it up all the way up Chestnut Nob. Good energy, I guess. The last bit of night-hiking sucked. I was just impatient and ready to call it a day, but I pushed on.
+---
+
+# Thursday, April 01, 2010 — Jenny's Knob Shelter
+**Start Location:** Jenkins Shelter
+**Miles Today:** 23.80
+**Trip Miles:** 588.90
+
+Highs: My highest point of the day, I think, was deciding to make 9 miles in 3 hours and DOING IT, despite uphill terrain and sore feet. I just pushed and pushed, invigorated by cool night air and a big bag of walnuts, almonds, and cranberries (my power food, I think). I also enjoyed lounging by the river for what seemed like all afternoon. Lastly, finding Storm Crow in the shelter that night was a pleasant surprise. He gave me some trail mix because I was hungry from hiking and all out of food. I got to hear Storm Crow talk about his hobby: medieval battle. Since his 20's he's been dressing as a "3rd to 4th Century Germanic warrior" and battling against other characters with dull weapons. It's called Live Action Warfare (LAW) or something like that, and well-dressed Americans trade their collared shirts and slacks for a full medieval suit of armor and a weapon to match. All fighting styles gather in field and forest for an eclectic battle of epic proportions, and afterwards they brew up a massive pot of stew and drink punch. Storm Crow was knocked unconscious once, he said, by a blow dealt by the catan of a Japanese Samurai, and brought him into his tent afterwards for a drink \[That's right, he owns a authentic medievel tent\]. In the heat of battle, if you're hit in the arm you can't use it anymore. Hit in the leg? You've got to hop. The chest or neck? You're dead. It all sounded pretty awesome. Wesley, Sean and I have dealt full blows before with wooden shafts in our lacrosse pads, but doing it with practice and precision sounds awesome. Not to mention charging into enemy lines with 500 fellow warriors.
+
+Lows: Eating all my food, though relaxing, makes me feel like crap. I do it anyway out of an incontrollable hunger instinct, and it does give me fuel for afternoon hiking. But that was my low of the day. Also, the first 5 miles was painful on my feet.
+---
+
+# Friday, April 02, 2010 — Woods Hole Hostel
+**Start Location:** Jenny's Knob Shelter
+**Miles Today:** 21
+**Trip Miles:** 609.90
+
+The highs included eating and lounging outside a convenience store after a morning of aching hunger. I had 2 slices of pizza, 2 gatorades, a candybar, and a bag of nuts. A stray puppy kept wandering out of an old barn and barking at me. I'd ignore him and he'd tip-toe back into the barn. Local lumbermill workers on lunch-break sat quietly at a picnic table nearby. I layed over and fell asleep. Storm Crow walked up shortly after with a 6-pack of Yuengling. He called for a shuttle to the Woods Hole Hostel, and he drank and talked about 4 "pretty recent" hiker murders in the area.
+I set off from there into the Dismal Creek lowlands, a labrytnh of creeks and rhododenron where the murders took place. The murderer had known the area well, and had taken back passages to sneak around the hikers and ambush them and escape afterwards. I was paranoid, and kept hearing sounds of ATVs or pickups through the woods. Or maybe it was just the creek. I was sweating heavily and took a bath in the stream, feeling like someone was watching me.
+Several miles later, I realized I'd left my map at the creek where I bathed. The map had all my scheduled stops starred, so I imagined the killer following my tracks and pciking up the map with a sick grin. Up the trail I stopped at Watipi Shelter, where some guy shot cans with a pellet gun and showed off his knife and machete. The other fellow there was named "Know-Nothing", because he didn't want to know anything new on the trail. I ate and moved on to Woods Hole Shelter.
+The sun set and my headlight flicked on. I was paranoid still as I approached Sugar Run Road, where the killer had crashed his car in escape. My light was dim and rocks difficult to hike on. I extinguished my light near the road and approached under the cover of darkness. Keep in mind, this road was a totally isolated forest road. At the clearing, my map lay on the ground. That's right: my lost map 10 miles ahead, right on the trail. The killer! He'd found my map, and taken a back road ahead of me! My heart stopped. he must be watching me. It was a half-mile down the road to Woods Hole Hostel, so I snatched the map and took of running. Immediatly, I saw a car parked facing towards me, lights off. This was it. He was waiting in the car for me. Instinctually, I darted to the left and charged the car with my hiking poles out to stab. But the car was empty. Still on edge, I took off running again down the road. Headlights beamed around the bend, so flicked off my light and crashed down into a ravine. The car drove by. I remounted the road and took off running again. Soon I saw lights and ran up to the hostel. A bonfire was burning and hikers gathered around it. I was sweating and out of breath. My feet pounded. Someone brought me a beer and sat down. In a minute, the car came back down and pulled into the driveway. The owner got out. She'd come up to fetch me from the trailhead, and I apologized. "I'd of dived off the road too!," he said. BY the way, that beer was a high of the day.
+---
+
+# Saturday, April 03, 2010 — A cabin (Pearisburg, VA)
+**Start Location:** Woods Hole Hostel
+**Miles Today:** 10
+**Trip Miles:** 619.90
+
+Highs: Seeing my FAMILY! They met me on the trail down from Angel's Rest, the lookout above Pearisburg. From up the trail, I heard their voices down below. That was the high of my day. I ran down full tilt, crashing with a sweaty hug into my little sister. We laughed and yipped. Then I ran down to my mother and tried not to cry with joy. I didn't understand why I wanted to cry, but then again I don't really understand alot about myself. I hugged my Dad, and we all sat down for lunch on the trail. I was ontop of the world.
+
+Later that night we played memory with Dawson, Corey and Morgan, had an awesome conversation about grandparents over my Mom's spaghetti dinner, and watched everyone go to bed. I stayed up to sort out food and pack. The soft bed that night was awesome.
+
+Lows: Everything up to meeting my family on the trail sucked. My feet pounded with pain and I groaned aloud. I tried to be happy becuase my family was waiting ahead, but I just couldn't muster up a smile. I imagined seeing them and saying, "Hold on guys, I just need to keep hiking and get this over with," then hiking on to the bottom. It was very painful. Also, having to divy up my next week's provisions that night sucked, because it was a stressful task that ate of precious time with my family.
+---
+
+# Sunday, April 04, 2010 — Rendezevous Motel (Pearisburg, VA)
+**Start Location:** A cabin (Pearisburg, VA)
+**Miles Today:** 0
+**Trip Miles:** 619.90
+
+Highs: My mother and I woke up early and we hung out together in the cabin kitchen. I love that time with my Mom. She made a huge breakfast of pancakes, eggs and bacon. We packed up and left the cabin and drove into Pearisburg to do some shopping. My Dad and I did a small section of hiking and my Mom and sister staked out a cool spot for lunch. We all went to the New River boat landing and lunched by the river under the bridge. It was cool there in the shade with a light breeze. It was like heaven. Everything I wanted in life was there, it seemed, sitting by the river. We threw skipped rocks and talked about nothing at all. I wish I was back there right now.
+
+Lows: Saying goodbye at the motel sucked. It ached my heart like leaving Springer all over again, and there was nothing I could do about it. That's a funny feeling, waving off the car and closing the motel door on something you desire with all your heart. It ached like love lost. I turned on the TV to take my mind off it all, and flicked to a murder scene in a horror flick. That unsettled me even more. That night sucked.
+---
+
+# Monday, April 05, 2010 — Bailey Gap Shelter
+**Start Location:** Rendezevous Motel (Pearisburg, VA)
+**Miles Today:** 23.20
+**Trip Miles:** 643.10
+
+Highs: My high was hiking in a crazy thunderstorm that night. The lightening exploded over my head in the darkness, thunder matching flash. The air smelled rich and metallic, which exhilerated me. After coving 20-some miles, it was a invigorating ending to a painful day. I got lost and heard voices as the storm cleared, so I called out, "HELLO!". I saw flashlights ahead. The shelter! "Is that Uncle Frank?," said a voice. It was TwoCan, the guy who had given me the beer at Woods Hole. Another high was sleeping at the shelter on the sunny bald and dreaming of home.
+
+Lows: I left the motel and called my Mother, which made me feel like crap. I missed home so much and didn't know what to do. The first half of the day was painful inside and out.
+---
+
+# Tuesday, April 06, 2010 — Niday Shelter
+**Start Location:** Bailey Gap Shelter
+**Miles Today:** 26.20
+**Trip Miles:** 669.30
+
+Toggle navigation[Trail Journals](https://www.trailjournals.com/)
+
+- [Journals](https://www.trailjournals.com/journal/entry/304005#)  - [Journals](https://www.trailjournals.com/journals)
+  - [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail/2026)
+  - [Pacific Crest Trail](https://www.trailjournals.com/journals/pacific_crest_trail/2026)
+  - [Colorado Trail](https://www.trailjournals.com/journals/colorado_trail/2026)
+  - [Continental Divide Trail](https://www.trailjournals.com/journals/continental_divide_trail/2026)
+  - [Long Trail - Vermont](https://www.trailjournals.com/journals/the_long_trail_-_vermont/2026)
+  - [Florida Trail](https://www.trailjournals.com/journals/the_florida_trail/2026)
+  - [Arizona Trail](https://www.trailjournals.com/journals/arizona_trail/2026)
+  - [John Muir Trail](https://www.trailjournals.com/journals/john_muir_trail/2026)
+  - [Camino de Santiago](https://www.trailjournals.com/journals/camino_de_santiago/2026)
+  - [American Discovery Trail](https://www.trailjournals.com/journals/american_discovery_trail/2026)
+  - [Coast to Coast Walk](https://www.trailjournals.com/journals/coast_to_coast_walk/2026)
+  - [More...](https://www.trailjournals.com/journals/)
+- [Trails](https://www.trailjournals.com/trails/)
+- [Photos](https://www.trailjournals.com/photos/2026)
+- [Gear](https://www.trailjournals.com/journal/entry/304005#)  - [Current Sales](https://www.trailjournals.com/gear/deals/onsale)
+  - [REI](https://www.trailjournals.com/gear/rei)
+  - [ULA](https://www.trailjournals.com/gear/ula)
+  - [Patagonia](https://www.trailjournals.com/gear/patagonia)
+  - [Cabela's](https://www.trailjournals.com/gear/cabela)
+- [Planning](https://www.trailjournals.com/journal/entry/304005#)  - [Plan Your Hike](https://www.trailjournals.com/planning/)
+  - [Gear](https://www.trailjournals.com/gear/)
+  - [Books](https://www.trailjournals.com/books/)
+  - [Links](https://www.trailjournals.com/links/)
+- [Search](https://www.trailjournals.com/search/)
+- [About](https://www.trailjournals.com/journal/entry/304005#)  - [About Trailjournals](https://www.trailjournals.com/about/)
+  - [Login](https://www.trailjournals.com/user/login)
+  - [Join](https://www.trailjournals.com/join)
+  - [Support Trailjournals](https://www.trailjournals.com/about/donate/)
+  - [Contact](https://www.trailjournals.com/about/contact)
+  - [Store](https://www.trailjournals.com/store/)
+
+Backpacking Journals and Photos from Long Distance Hikers
+
+1. [Home](https://www.trailjournals.com/)
+2. [Journals](https://www.trailjournals.com/journals)
+3. [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail)
+4. [2010](https://www.trailjournals.com/journals/appalachian_trail/2010)
+5. [Uncle Frank](https://www.trailjournals.com/journal/10467)
+6. [Entries](https://www.trailjournals.com/journal/entries/10467/uncle%20-frank)
+7. April 06, 2010
+
+Toggle navigation
+
+- [Journal](https://www.trailjournals.com/journal/10467)
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+- [My Journals](https://www.trailjournals.com/myjournals/10467)
+- [View Guest Book](https://www.trailjournals.com/journal/guestbook/10467)
+- [Sign Guest Book](https://www.trailjournals.com/journal/guestbook/sign/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/5a.gif)![](https://www.trailjournals.com/images/9a.gif)
+
+[Journal](https://www.trailjournals.com/journal/10467)
+
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+
+--Choose--01/21/1002/06/1002/07/1002/08/1002/09/1002/10/1002/11/1002/12/1002/13/1002/14/1002/15/1002/16/1002/17/1002/18/1002/19/1002/20/1002/21/1002/22/1002/23/1002/24/1002/25/1002/26/1002/27/1002/28/1003/01/1003/02/1003/03/1003/04/1003/05/1003/06/1003/07/1003/08/1003/09/1003/11/1003/12/1003/13/1003/14/1003/15/1003/16/1003/17/1003/18/1003/19/1003/20/1003/21/1003/24/1003/25/1003/26/1003/27/1003/28/1003/29/1003/30/1003/31/1004/01/1004/02/1004/03/1004/04/1004/05/1004/06/1004/07/1004/08/1004/09/1004/10/1004/11/1004/12/1004/13/1004/14/1004/15/1004/16/1004/17/1004/18/1004/19/1004/20/1004/21/1004/23/1004/24/1004/25/1004/26/1004/27/1004/28/1004/29/1004/30/1005/01/1005/02/1005/03/1005/04/1005/05/1005/06/1005/07/1005/08/1005/09/1005/10/1005/11/1005/12/1005/13/1005/14/1005/15/1005/16/1005/17/1005/18/1005/19/1005/20/1005/21/1005/22/1005/23/1005/24/1005/25/1005/26/1005/27/1005/28/1005/29/1005/30/1005/31/1006/01/1006/02/1006/03/1006/04/1006/05/1006/06/1006/07/1006/08/1006/09/1006/10/1006/11/1006/12/1006/13/1006/14/1006/15/1006/16/1006/17/1006/18/1006/19/1006/20/1006/21/10
+
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+
+Guest Book
+
+- [Sign](https://www.trailjournals.com/journal/guestbook/sign/10467)
+- [View](https://www.trailjournals.com/journal/guestbook/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/5a.gif)![](https://www.trailjournals.com/images/9a.gif)
+
+- [AT Journals](https://www.trailjournals.com/journals/appalachian_trail)
+- [AT Photos](https://www.trailjournals.com/photos/appalachian_trail)
+- [AT Books](https://www.trailjournals.com/books/appalachian_trail)
+- [Appalachian Trail](http://www.appalachiantrail.org/)
+
+[Join](https://www.trailjournals.com/join) [Login](https://www.trailjournals.com/user/login)
+
+[RSS](https://www.trailjournals.com/journal/rss/10467/xml)
+
+# Uncle Frank's 2010  Appalachian Trail Journal
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/304004) [Next](https://www.trailjournals.com/journal/entry/304006) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+Tuesday, April 06, 2010
+
+Destination:Niday Shelter
+
+Today's Miles:26.20
+
+Start Location:Bailey Gap Shelter
+
+Trip Miles:669.30
+
+Destination:Niday Shelter
+
+Start Location:Bailey Gap Shelter
+
+Today's Miles:26.20
+
+Trip Miles:669.30
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/304004) [Next](https://www.trailjournals.com/journal/entry/304006) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+### Hiker Entries April 06, 2010
+
+|  | Journalist | Destination | Trail |
+| --- | --- | --- | --- |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Roche_13900TN.jpg) | [Roche](https://www.trailjournals.com/journal/about/13900) | [Beard Cane Campsite (#11)](https://www.trailjournals.com/journal/entry/385929) | [Other Trails](https://www.trailjournals.com/journals/Other%20_Trails) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2005Blucher_8775TN.jpg) | [Bob](https://www.trailjournals.com/journal/about/8775) | [Jenkins Shelter](https://www.trailjournals.com/journal/entry/367417) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [magic man](https://www.trailjournals.com/journal/about/12513) | [hawk mountain shelter](https://www.trailjournals.com/journal/entry/355996) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DidgeridudeandDoodlebug_9852TN.jpg) | [Didgeridude and Doodlebug](https://www.trailjournals.com/journal/about/9852) | [TriCorner Knob](https://www.trailjournals.com/journal/entry/334619) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2014Sundance_6768TN.jpg) | [Sundance](https://www.trailjournals.com/journal/about/6768) | [NOC](https://www.trailjournals.com/journal/entry/333397) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Dilly Dally & Cubbie](https://www.trailjournals.com/journal/about/10450) | [Tray Mtn. Shelter](https://www.trailjournals.com/journal/entry/324819) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Peru_10969TN.jpg) | [Peru](https://www.trailjournals.com/journal/about/10969) | [Hawk Mountain Shelter](https://www.trailjournals.com/journal/entry/317974) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Opus](https://www.trailjournals.com/journal/about/10015) | [Deep Gap shelter](https://www.trailjournals.com/journal/entry/314912) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Wilderness Bob](https://www.trailjournals.com/journal/about/10881) | [\-\- View Entry --](https://www.trailjournals.com/journal/entry/314749) | [Tahoe Rim Trail](https://www.trailjournals.com/journals/Tahoe%20_Rim%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2008Stickbuilt_7055TN.jpg) | [Stickbuilt](https://www.trailjournals.com/journal/about/7055) | [Maine](https://www.trailjournals.com/journal/entry/314276) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| [More...](https://www.trailjournals.com/entries/2010/04/06) [Grouped By Trail...](https://www.trailjournals.com/entries/2010/04/06/trail) |
+
+|     |
+| --- |
+| The last mile proved particularly arduous. The steepness of the descent was ridiculous. Picture one of those Hobbit movies with stairs at an angle that makes you wince just to look at them. Well, the director of those movies got his inspiration from this section of the AT.... <br>[Blazer](https://www.trailjournals.com/journal/entry/543948) —<br>[Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail) [2016](https://www.trailjournals.com/journals/appalachian_trail/2016) |
+
+[![Trailjournals](https://www.trailjournals.com/images/logo.png)](https://www.trailjournals.com/)
+
+#### Hiking
+
+- [Trails](https://www.trailjournals.com/trails/list)
+- [Journals](https://www.trailjournals.com/journals)
+- [Photos](https://www.trailjournals.com/photos)
+- [Calendar](https://www.trailjournals.com/calendar)
+- Gear
+- [Links](https://www.trailjournals.com/links)
+
+#### Partners
+
+- [ULA Equipment](https://ula-equipment.sjv.io/drN9K)
+- [REI](http://www.avantlink.com/click.php?tt=ml&ti=45265&pw=68025)
+- [Patagonia](http://www.avantlink.com/click.php?tt=ml&ti=45781&pw=68025)
+
+#### Network
+
+- [Trail Forums](http://www.trailforums.com/)
+- Trail News
+
+#### About Us
+
+- [Contact](https://www.trailjournals.com/about/contact)
+- [Donate](https://www.trailjournals.com/about/donate)
+- [Join](https://www.trailjournals.com/join)
+- [Login](https://www.trailjournals.com/user/login)
+- [Help](https://www.trailjournals.com/help)
+
+#### Follow Us
+
+- [Facebook](https://www.facebook.com/trailjournals)
+- [Instagram](https://instagram.com/trailjournals/)
+- [Twitter](https://twitter.com/trailjournals)
+- [Pinterest](https://www.pinterest.com/trailjournals/)
+- [Linkedin](https://www.linkedin.com/company/trailjournals-llc)
+
+Top Photo © Renee Patrick - Pacific Crest Trail,
+05/21/2006 by
+[She-ra](https://www.trailjournals.com/journal/2942)
+
+Trailjournals LLC © 2026
+All Rights Reserved. [privacy policy](https://www.trailjournals.com/about/privacy)
+
+Newburyport, MA 01950
+
+[Terms under which this service is provided to you.](https://www.trailjournals.com/about/privacy)
+
+Build: 20210226:165913 [Manage Settings](https://www.trailjournals.com/about/settings)
+---
+
+# Wednesday, April 07, 2010 — Campbell Shelter
+**Start Location:** Niday Shelter
+**Miles Today:** 27.10
+**Trip Miles:** 696.40
+
+High: Today's high was probably seeing a pretty girl on her way up to Dragon's Tooth, south of Catawba. She was with another VT student, a lean guy who would probably be good at ultimate frisbee. She, herself, was fit and strong, also probably good at frisbee. Both were really nice and kind of glowed, balanced in that they didn't give off any more light than they were willing to take in. I chatted with them for 5 maybe 10 minutes then moved on, but their fresh spirit stayed wit me. I had been feeling pretty low. As I descended I could see them on top of the Tooth. "Thank You." I wanted to yell. I moved along quietly. At the gap I walked down to the store to buy a can of Mountain Dew and a 25 cent pack of gum. Near dusk I moved on. I passed a girl in her late twenties by the creek. She'd stopped for the last night of her first camping trip ever, a five day trek. I admired her courage. Being out in the woods in scary, even for a seasoned hiker like myself. She said she wanted to hike the AT one day. I told her firmly that she could.
+Darkness wore on from there, by the creek, across the pasture and into the woods. I felt alright, alright enough to keep up a steady 3 mph pace. The next shelter was 8 miles away. I got to the road at 9:30. It was a usy road, loud and mean in the night. This area was a popular local hang-out, so already I was on edge. the random shootings along the Blue Ridge Parkway - I'd seen on the newspaper at the store - were fresh on my mind, adding to the tension. Just before crossing, I heard a sound in the woods by the road. It was louder than a deer and quicker than a bear, and immediately I decided it was a human. And not just a human: a crazed killer waited to murder night-hikers. I flicked off my flashlight and waited. The sound stopped. I took off running, across the road and back in to the woods. He's following me, I said to myself. He's gonna follow me to the next shelter. I hoofed quickly to the shelter a mile in , hoping to find it packed with hikers. It was empty. Dead quiet. I quickly moved on the next shelter, another mile in. I heard a single gunshot on the way: the killer had arrived at the first shelter to murder me and shot the wall in frustration when he found it empty. The next shelter was empty, too. On to the next shelter, 2.5 miles away. On the way, I heard another gunshot meaning the killer had arrived at the second shelter.
+At McAfee Knob, just before the third shelter, I could see Roanoke glowing, the valley like gold glittering on the ocean floor. An incredible view. I awaited an ambush from the killer, who'd taken the fire road and beat me to the top. At the third shelter, I found two kids sleeping in a tent and felt like I'd beat the killer. I was out of range. I ate some cold oatmeal and went to sleep. It was 12:15am.
+---
+
+# Thursday, April 08, 2010 — Travelodge Motel (Daleville, VA)
+**Start Location:** Campbell Shelter
+**Miles Today:** 17
+**Trip Miles:** 713.40
+
+Gnats buzzed in my hair when I awoke. It was only 6:45am, but with the sunrise came heat and bugs so I couldn't sleep. I talked with the kids in the tent as I packed up, and I was on the trail by 7:30. It was a hot, hot day, and my feet were in alot of pain. By the time I got to Lambert's Meadow Shelter, I was ready for a long break. I drank from the stream and washed my body, then took a long nap in the shelter shade. I soaked my shirt and bandana and drapped them over my chest and head, put on my long pants, and went to sleep bug-proofed. I woke up to a dad and his kids arriving from the north. They were two smart kids with a good strong dad who was trying to make them as strong as he. And he was doing a fine job. I told them I was out of food and he accused me of yogi-ing. I retorted, "If I was yogi-ing, I'd be alot smoother than that." What I meant to say was that if I'm yogi-ing I'd ask you straight up for food.
+Clouds covered the sun and I moved on at noon for Daleville, 9 miles away. the hike flew by and the hunger wasn't as bad as the foot pain. By the last mile, I was in so much pain. My four blisters were on fire and my foot pads bruised. I hobbled off the trail to a convenience store to buy a gatorade, then hobbled to the Outfitter to use the computer, then hobbled to the the Three Little Pigs BBQ for dinner. The meal was amazing - fried onion strips and buffalo chips with a big mound of both the tomato and vinegar BBQ and a 1/2 pint of Magic Hat Lager. The BEST meal since the steak with Dad, and the best BBQ ever. I hung at the Outfitter for almost four hours after, reading and writing and chatting with the manager, while rain pounded outside. My mom called their phone and we coordinated Dawson, Caleb and Michael's visit. It was still pouring rain at closing time, so I bribed a ride to the motel from the employee wit ha 6-pack of Miller Lite.
+That night I wrote and showered and ate three apples.
+---
+
+# Friday, April 09, 2010 — Fullhardt Knob Shelter
+**Start Location:** Travelodge Motel (Daleville, VA)
+**Miles Today:** 4.90
+**Trip Miles:** 718.30
+
+High: An all-you-can-eat breakfast at Shoney's was up on the list, but I must say the high was seeing Caleb, Dawson, and Michael pull to a stop in front of the outfitter after waiting for them all day in Troutville. We all hugged and walked over for an expensive (yet totally worth-it) BBQ dinner at Three Little Pigs. We joked with the waitress and laughed at nothing in particular. It was a grand ol' time, and the adventure hadn't even really begun. It was 9:15 PM when we walked back out to the car and sorted out the gear for the hike under the lamplight. By 10:00 PM we were on the trail, a line of dim headlamps inching towards Fullhardt Knob Shelter.
+Caleb, Dawson and Michael were all sturdy hikers--sturdier than I expected, in fact--and we arrived in good time that night (by "good time" I mean 12:15 am). I bore Caleb's backpack, my rusty old Kelty external-frame from my Boy Scout days. It was loaded with 50+ lbs. of stuff, an entirely foreign level of stress to my feet. Bone structure clearly disturbed, I could feel them groaning in my tennis-shoes like an old ship in a storm. Just outside of Troutville, we cut off the headlamps and crossed a hilly pasture, big and black under a dim blue spread of starlit sky above.
+That night was Caleb and Dawson's first night in an A.T. shelter, which really excited me. It was late and I was tired. I was the first asleep.
+---
+
+# Saturday, April 10, 2010 — Cove Mountain Shelter
+**Start Location:** Fullhardt Knob Shelter
+**Miles Today:** 20
+**Trip Miles:** 738.30
+
+We rose late the next morning, I repeating my eat-and-return-to-sleep cycle several times before actually rising. The others had no real schedule or "hiking routine", so we all just kind of took our time. We left the shelter by 11:15, passing Drip-Dry and Reveille who had hiked the 5 miles from town early that morning. We stopped at a waterfall and stream several miles down the trail. There, we all layed down for a long and sleepy break in the sun. I ate, Caleb and Dawson smoked a cigar, and Michael puffed on his pipe; we all slept. I was in bliss. I will never forget that long, warm hour by the stream.
+
+On we hiked, passing the Blue Ridge Parkway for the first time. Again, we stopped to eat and sleep in the sun. It was heaven. I was drifting off when I heard a voice: "Are yall thru-hikers?." I opened my eyes and looked back. A car was pulled up and a thin, scruffy kid hung out the passenger window. "I am," I said, "I'm Uncle Frank." As it turns out, it was Knee-Deep, another thru-hiker I'd heard a great deal about on the trail. He'd been a day or so behind me for months, he said, and was about to catch up. Today, however, he was spending on the parkway with his girlfriend. He said he'd plan to catch me in a couple of days, and I said I'd be looking forward to it. Off he drove. Off I went back to sleep.
+
+Near dusk we pulled off at a shelter for dinner, SWEET POTATOES! We made a roaring kindling fire and dumped the foil-wrapped 'taters in the coals. Fifty minutes later, we each had a piping hot meal in our hands. We ate and night grew. By 8:00, we were on the trail again. The climb was grueling, but by 10:30 we were at the next shelter. Again, I fell asleep quickly. Later that night, I awoke to the sound of Caleb throwing up. I got out of my bag, grabbed some trail mix, ate it, then went back to sleep. Caleb was still vomiting, yet I was surprisingly indifferent. To me, upchucking is a good thing.
+---
+
+# Sunday, April 11, 2010 — Thunder Hill Shelter
+**Start Location:** Cove Mountain Shelter
+**Miles Today:** 17.20
+**Trip Miles:** 755.50
+
+I'll just do highs and lows today. The high was hiking with the boys down to the river. I really did love the company and I dreaded losing it, but there was nothing I could do as Caleb, Dawson and Michael drove off. That was the low. In fact, the rest of the day was low. I hiked slowly and indifferently, covering only 17-some miles and intermittently napping because it took my mind off my depression. It was just a hard day. Several highs, however: I saw a pretty wildflower bed along the trail, and I arrived at the shelter before dark. I thought about calling Haywood and telling him, "I know what you mean: M.A.I.D."
+---
+
+# Monday, April 12, 2010 — Punchbowl Shelter
+**Start Location:** Thunder Hill Shelter
+**Miles Today:** 25.10
+**Trip Miles:** 780.60
+
+I'd run out of food the day before and had 15 miles to cover to access my mail-drop in Glasgow, VA. My hunger wasn't too bad, neither hurting nor slowing me down noticeably. The trail was smooth and hot, and it reminded me of the trails out in New Mexico. I felt good. High up on the ridge, I spotted the James River, flowing mightily in the valley. I hollered in joy. Not only was it a symbol of home, it was the location of the road to Glasgow and thus a symbol of food. I called my Dad and we set up a mail-drop and talked about meeting up in Harper's Ferry. I missed him. Down into the valley the trees bloomed and leafed, making a tunnel of neon-green light. It was magnificent. The red-buds were blooming in their explosive purples and the maple leaves were glowing verdantly. I took photos of wildflowers and cool leaves. At the river, I was bubbly. I ran across the footbridge just as a freight train ran across on a nearby trestle. The sun poured down on the river. It was all so glorious. I yipped and hollered uncontrollably like a little kid.
+
+At the road I stuck out my thumb and an under-cover cop pulled over. "Hitchhiking is illegal anywhere in Virginia," he said. He background checked by ID and gave me a ride into town in the back of his souped-up Dodge Charger. I sat in the back where they put the criminals, fidgeting on hard plastic seats meant to tell them: You're screwed, and these seats are just the beginning. The cop was nice, and asked me question after question. At the store, I bought some chocolate milk and picked up my mail-drop, and the cop gave me a ride back to the trailhead.
+
+I hauled up the food 1.7 miles to a shelter, where I sat down for a gorge to remember. I chugged chocolate milk and consumed an entire loaf of homemade banana bread, then passed out for an hour. I awoke feeling great.
+
+I lounged at the shelter for at least an hour, until Knee-Deep came strolling down the trail. "Theerrreee he is," he said. "Now I can finally stop." He'd been hiking for 28 miles already that day in order to catch me, and after exchanging trail news and whatnot we both moved on 7 miles to the next shelter. The shelter is located near the site of an unexplained murder of 4 year-old Ottie Bundren in the 1890's, and it's apprently haunted. We left some chocolate by the gravestone where they found her body to pacify the ghost. I slept well that night.
+---
+
+# Tuesday, April 13, 2010 — Seely-Woodworth Shelter
+**Start Location:** Punchbowl Shelter
+**Miles Today:** 25.30
+**Trip Miles:** 805.90
+
+We left camp at sunrise, before 6:45 am. The first several hours of hiking were difficult. My feet hurt and morale was low, but being with Knee-Deep helped a lot. We talked most of the time, exchanging stories and sharing experiences. Then we'd go silent before resuming talk. Trail talk is a funny mode of communication. It's entirely aimless and self-centered, bouncing mindlessly from one subject to the next. For example:
+
+Knee-Deep: "I love dogs."
+
+Me: "Yea, I want to get a pit bull one day."
+
+Knee-Deep: "My Uncle has a pit bull. He has like ten Siamese cats, too"
+
+Me: "Oooo, my neighbors had some Siamese cats. They were awesome."
+
+And so on...
+
+Knee-Deep needed to resupply, so I waited on a picnic table in the sun while he hitched into town. I gave him $10 and asked him to get me "something meaty" at the Subway. He came back in 2 hours, I ate my sub, and we marched on. We passed Cold Mountain, my old stomping ground, and took in some awesome views. The views in Virginia have been like no other: I'm proud to call this state "home."
+At the shelter (it was dark by then), we found an older fellow sleeping with his two wily pit bulls. They growled at us but were a cute, innocent pair of pups. Someone had left a bag of food, so I ate three bags of oatmeal before falling asleep.
+---
+
+# Wednesday, April 14, 2010 — Reed's Gap
+**Start Location:** Seely-Woodworth Shelter
+**Miles Today:** 22.30
+**Trip Miles:** 828.20
+
+The next morning I was dragging painfully once again. We stopped in the fog for a climb to a view less Spy Rock, then made our way to The Priest Shelter. After the climb up Spy Rock I was feeling brighter. The fog was thick and soaked everything. At the shelter, we laughed at the trail register, where, going with the "Priest" theme, people had left all sorts of confessions (mostly about skipping miles and not paying at hostels). They were hilarious. From there, we dropped off the edge of The Priest into the valley below. There, the Tye River paralleled a highway, and we walked down the road to get chocolate and soda and hitched back. The climb up from the valley to Three Ridges wasn't as bad as we expected (we'd been dreading it all day). The views were spectacular on top. I took some amazing photos and was in high spirits.
+
+A side note: when I say "high spirits", I mean a sort of bursting joy that I scarcely find in civilization. It's a strange mix of physical exhaustion, emotional exhilaration, and mental consolidation. I'll miss that when this is all through.
+
+Knee-Deep and I had planned to stay at Rusty's Hard-Time Hollow, but we decided to move on to cowboy camp. There were plenty of awesome overlooks, and we hiked into the night for an hour before finding a great spot at Reed's Gap. It was a 360-degree view of the mountains and stars. We bedded down on the grass and fell asleep.
+P.S. Where's God been the last several weeks? I don't know...surely not loud like before.
+---
+
+# Thursday, April 15, 2010 — Wesley's frat house (Charlottesville, VA)
+**Start Location:** Reed's Gap
+**Miles Today:** 28
+**Trip Miles:** 856.20
+
+As usual, getting started that day was hard. I always drag in the mornings. My right foot was killing me. Knee-Deep's snoring that night had kept my awake, so I was doubly tired as well. Also, I was hungry and out of food. Knee-Deep gave some to me, but my stomach was still grumbling. Those were all the lows.
+
+The highs were plenty, as I ended the day in C'ville. But first, running 8 miles before 4:45 was a rewarding yet painful event. That made my day. Wesley picked me up from there and took us (Knee-Deep hung back and we picked him up at I-64) out to dinner at the A.Y.C.E. dining hall, and I drank Legends Brown Ale and listened to the Avett Brothers that evening. There was a frat party, but I didn't feel like going. It was an awesome night.
+---
+
+# Friday, April 16, 2010 — Pinefield Hut
+**Start Location:** Wesley's frat house (Charlottesville, VA)
+**Miles Today:** 26.20
+**Trip Miles:** 882.40
+
+Toggle navigation[Trail Journals](https://www.trailjournals.com/)
+
+- [Journals](https://www.trailjournals.com/journal/entry/306438#)  - [Journals](https://www.trailjournals.com/journals)
+  - [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail/2026)
+  - [Pacific Crest Trail](https://www.trailjournals.com/journals/pacific_crest_trail/2026)
+  - [Colorado Trail](https://www.trailjournals.com/journals/colorado_trail/2026)
+  - [Continental Divide Trail](https://www.trailjournals.com/journals/continental_divide_trail/2026)
+  - [Long Trail - Vermont](https://www.trailjournals.com/journals/the_long_trail_-_vermont/2026)
+  - [Florida Trail](https://www.trailjournals.com/journals/the_florida_trail/2026)
+  - [Arizona Trail](https://www.trailjournals.com/journals/arizona_trail/2026)
+  - [John Muir Trail](https://www.trailjournals.com/journals/john_muir_trail/2026)
+  - [Camino de Santiago](https://www.trailjournals.com/journals/camino_de_santiago/2026)
+  - [American Discovery Trail](https://www.trailjournals.com/journals/american_discovery_trail/2026)
+  - [Coast to Coast Walk](https://www.trailjournals.com/journals/coast_to_coast_walk/2026)
+  - [More...](https://www.trailjournals.com/journals/)
+- [Trails](https://www.trailjournals.com/trails/)
+- [Photos](https://www.trailjournals.com/photos/2026)
+- [Gear](https://www.trailjournals.com/journal/entry/306438#)  - [Current Sales](https://www.trailjournals.com/gear/deals/onsale)
+  - [REI](https://www.trailjournals.com/gear/rei)
+  - [ULA](https://www.trailjournals.com/gear/ula)
+  - [Patagonia](https://www.trailjournals.com/gear/patagonia)
+  - [Cabela's](https://www.trailjournals.com/gear/cabela)
+- [Planning](https://www.trailjournals.com/journal/entry/306438#)  - [Plan Your Hike](https://www.trailjournals.com/planning/)
+  - [Gear](https://www.trailjournals.com/gear/)
+  - [Books](https://www.trailjournals.com/books/)
+  - [Links](https://www.trailjournals.com/links/)
+- [Search](https://www.trailjournals.com/search/)
+- [About](https://www.trailjournals.com/journal/entry/306438#)  - [About Trailjournals](https://www.trailjournals.com/about/)
+  - [Login](https://www.trailjournals.com/user/login)
+  - [Join](https://www.trailjournals.com/join)
+  - [Support Trailjournals](https://www.trailjournals.com/about/donate/)
+  - [Contact](https://www.trailjournals.com/about/contact)
+  - [Store](https://www.trailjournals.com/store/)
+
+Backpacking Journals and Photos from Long Distance Hikers
+
+1. [Home](https://www.trailjournals.com/)
+2. [Journals](https://www.trailjournals.com/journals)
+3. [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail)
+4. [2010](https://www.trailjournals.com/journals/appalachian_trail/2010)
+5. [Uncle Frank](https://www.trailjournals.com/journal/10467)
+6. [Entries](https://www.trailjournals.com/journal/entries/10467/uncle%20-frank)
+7. April 16, 2010
+
+Toggle navigation
+
+- [Journal](https://www.trailjournals.com/journal/10467)
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+- [My Journals](https://www.trailjournals.com/myjournals/10467)
+- [View Guest Book](https://www.trailjournals.com/journal/guestbook/10467)
+- [Sign Guest Book](https://www.trailjournals.com/journal/guestbook/sign/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/2a.gif)
+
+[Journal](https://www.trailjournals.com/journal/10467)
+
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+
+--Choose--01/21/1002/06/1002/07/1002/08/1002/09/1002/10/1002/11/1002/12/1002/13/1002/14/1002/15/1002/16/1002/17/1002/18/1002/19/1002/20/1002/21/1002/22/1002/23/1002/24/1002/25/1002/26/1002/27/1002/28/1003/01/1003/02/1003/03/1003/04/1003/05/1003/06/1003/07/1003/08/1003/09/1003/11/1003/12/1003/13/1003/14/1003/15/1003/16/1003/17/1003/18/1003/19/1003/20/1003/21/1003/24/1003/25/1003/26/1003/27/1003/28/1003/29/1003/30/1003/31/1004/01/1004/02/1004/03/1004/04/1004/05/1004/06/1004/07/1004/08/1004/09/1004/10/1004/11/1004/12/1004/13/1004/14/1004/15/1004/16/1004/17/1004/18/1004/19/1004/20/1004/21/1004/23/1004/24/1004/25/1004/26/1004/27/1004/28/1004/29/1004/30/1005/01/1005/02/1005/03/1005/04/1005/05/1005/06/1005/07/1005/08/1005/09/1005/10/1005/11/1005/12/1005/13/1005/14/1005/15/1005/16/1005/17/1005/18/1005/19/1005/20/1005/21/1005/22/1005/23/1005/24/1005/25/1005/26/1005/27/1005/28/1005/29/1005/30/1005/31/1006/01/1006/02/1006/03/1006/04/1006/05/1006/06/1006/07/1006/08/1006/09/1006/10/1006/11/1006/12/1006/13/1006/14/1006/15/1006/16/1006/17/1006/18/1006/19/1006/20/1006/21/10
+
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+
+Guest Book
+
+- [Sign](https://www.trailjournals.com/journal/guestbook/sign/10467)
+- [View](https://www.trailjournals.com/journal/guestbook/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/2a.gif)
+
+- [AT Journals](https://www.trailjournals.com/journals/appalachian_trail)
+- [AT Photos](https://www.trailjournals.com/photos/appalachian_trail)
+- [AT Books](https://www.trailjournals.com/books/appalachian_trail)
+- [Appalachian Trail](http://www.appalachiantrail.org/)
+
+[Join](https://www.trailjournals.com/join) [Login](https://www.trailjournals.com/user/login)
+
+[RSS](https://www.trailjournals.com/journal/rss/10467/xml)
+
+# Uncle Frank's 2010  Appalachian Trail Journal
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/305233) [Next](https://www.trailjournals.com/journal/entry/306439) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+Friday, April 16, 2010
+
+Destination:Pinefield Hut
+
+Today's Miles:26.20
+
+Start Location:Wesley's frat house (Charlottesville, VA)
+
+Trip Miles:882.40
+
+Destination:Pinefield Hut
+
+Start Location:Wesley's frat house (Charlottesville, VA)
+
+Today's Miles:26.20
+
+Trip Miles:882.40
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/305233) [Next](https://www.trailjournals.com/journal/entry/306439) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+### Hiker Entries April 16, 2010
+
+|  | Journalist | Destination | Trail |
+| --- | --- | --- | --- |
+|  | [magic man](https://www.trailjournals.com/journal/about/12513) | [nantahala outdoor center](https://www.trailjournals.com/journal/entry/361075) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DidgeridudeandDoodlebug_9852TN.jpg) | [Didgeridude and Doodlebug](https://www.trailjournals.com/journal/about/9852) | [Devil Fork Gap- Asheville](https://www.trailjournals.com/journal/entry/334629) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2014Sundance_6768TN.jpg) | [Sundance](https://www.trailjournals.com/journal/about/6768) | [Roaring Forks Shelter](https://www.trailjournals.com/journal/entry/333693) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Superman_10150TN.jpg) | [Superman](https://www.trailjournals.com/journal/about/10150) | [Tellico River Road](https://www.trailjournals.com/journal/entry/330110) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Peru_10969TN.jpg) | [Peru](https://www.trailjournals.com/journal/about/10969) | [Hiawassee](https://www.trailjournals.com/journal/entry/325327) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Dilly Dally & Cubbie](https://www.trailjournals.com/journal/about/10450) | [Spence Field Shelter](https://www.trailjournals.com/journal/entry/324872) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Opus](https://www.trailjournals.com/journal/about/10015) | [Russel Field shelter](https://www.trailjournals.com/journal/entry/314949) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010BruceCook_9777TN.jpg) | [HooYaa!](https://www.trailjournals.com/journal/about/9777) | [Dick's Creek Gap](https://www.trailjournals.com/journal/entry/314470) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2011ErictheRed_9407TN.jpg) | [Eric the Red](https://www.trailjournals.com/journal/about/9407) | [Grassy Gap (138.1)](https://www.trailjournals.com/journal/entry/313497) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Tintin_9861TN.jpg) | [Tintin](https://www.trailjournals.com/journal/about/9861) | [Overmountain Shelter](https://www.trailjournals.com/journal/entry/311126) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| [More...](https://www.trailjournals.com/entries/2010/04/16) [Grouped By Trail...](https://www.trailjournals.com/entries/2010/04/16/trail) |
+
+|     |
+| --- |
+| The woods here are alive with vibrant color, the temps are right on, and the falling dark reminded me of all those days when I was hiking out West and making miles before the headlight needed to be switched on. ... <br>[Uncle Tom](https://www.trailjournals.com/journal/entry/437077) —<br>[Continental Divide Trail](https://www.trailjournals.com/journals/continental_divide_trail) [2013](https://www.trailjournals.com/journals/continental_divide_trail/2013) |
+
+[![Trailjournals](https://www.trailjournals.com/images/logo.png)](https://www.trailjournals.com/)
+
+#### Hiking
+
+- [Trails](https://www.trailjournals.com/trails/list)
+- [Journals](https://www.trailjournals.com/journals)
+- [Photos](https://www.trailjournals.com/photos)
+- [Calendar](https://www.trailjournals.com/calendar)
+- Gear
+- [Links](https://www.trailjournals.com/links)
+
+#### Partners
+
+- [ULA Equipment](https://ula-equipment.sjv.io/drN9K)
+- [REI](http://www.avantlink.com/click.php?tt=ml&ti=45265&pw=68025)
+- [Patagonia](http://www.avantlink.com/click.php?tt=ml&ti=45781&pw=68025)
+
+#### Network
+
+- [Trail Forums](http://www.trailforums.com/)
+- Trail News
+
+#### About Us
+
+- [Contact](https://www.trailjournals.com/about/contact)
+- [Donate](https://www.trailjournals.com/about/donate)
+- [Join](https://www.trailjournals.com/join)
+- [Login](https://www.trailjournals.com/user/login)
+- [Help](https://www.trailjournals.com/help)
+
+#### Follow Us
+
+- [Facebook](https://www.facebook.com/trailjournals)
+- [Instagram](https://instagram.com/trailjournals/)
+- [Twitter](https://twitter.com/trailjournals)
+- [Pinterest](https://www.pinterest.com/trailjournals/)
+- [Linkedin](https://www.linkedin.com/company/trailjournals-llc)
+
+Top Photo © Renee Patrick - Pacific Crest Trail,
+05/21/2006 by
+[She-ra](https://www.trailjournals.com/journal/2942)
+
+Trailjournals LLC © 2026
+All Rights Reserved. [privacy policy](https://www.trailjournals.com/about/privacy)
+
+Newburyport, MA 01950
+
+[Terms under which this service is provided to you.](https://www.trailjournals.com/about/privacy)
+
+Build: 20210226:165913 [Manage Settings](https://www.trailjournals.com/about/settings)
+---
+
+# Saturday, April 17, 2010 — Bearfence Mountain Hut
+**Start Location:** Pinefield Hut
+**Miles Today:** 20.60
+**Trip Miles:** 903
+
+Toggle navigation[Trail Journals](https://www.trailjournals.com/)
+
+- [Journals](https://www.trailjournals.com/journal/entry/306439#)  - [Journals](https://www.trailjournals.com/journals)
+  - [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail/2026)
+  - [Pacific Crest Trail](https://www.trailjournals.com/journals/pacific_crest_trail/2026)
+  - [Colorado Trail](https://www.trailjournals.com/journals/colorado_trail/2026)
+  - [Continental Divide Trail](https://www.trailjournals.com/journals/continental_divide_trail/2026)
+  - [Long Trail - Vermont](https://www.trailjournals.com/journals/the_long_trail_-_vermont/2026)
+  - [Florida Trail](https://www.trailjournals.com/journals/the_florida_trail/2026)
+  - [Arizona Trail](https://www.trailjournals.com/journals/arizona_trail/2026)
+  - [John Muir Trail](https://www.trailjournals.com/journals/john_muir_trail/2026)
+  - [Camino de Santiago](https://www.trailjournals.com/journals/camino_de_santiago/2026)
+  - [American Discovery Trail](https://www.trailjournals.com/journals/american_discovery_trail/2026)
+  - [Coast to Coast Walk](https://www.trailjournals.com/journals/coast_to_coast_walk/2026)
+  - [More...](https://www.trailjournals.com/journals/)
+- [Trails](https://www.trailjournals.com/trails/)
+- [Photos](https://www.trailjournals.com/photos/2026)
+- [Gear](https://www.trailjournals.com/journal/entry/306439#)  - [Current Sales](https://www.trailjournals.com/gear/deals/onsale)
+  - [REI](https://www.trailjournals.com/gear/rei)
+  - [ULA](https://www.trailjournals.com/gear/ula)
+  - [Patagonia](https://www.trailjournals.com/gear/patagonia)
+  - [Cabela's](https://www.trailjournals.com/gear/cabela)
+- [Planning](https://www.trailjournals.com/journal/entry/306439#)  - [Plan Your Hike](https://www.trailjournals.com/planning/)
+  - [Gear](https://www.trailjournals.com/gear/)
+  - [Books](https://www.trailjournals.com/books/)
+  - [Links](https://www.trailjournals.com/links/)
+- [Search](https://www.trailjournals.com/search/)
+- [About](https://www.trailjournals.com/journal/entry/306439#)  - [About Trailjournals](https://www.trailjournals.com/about/)
+  - [Login](https://www.trailjournals.com/user/login)
+  - [Join](https://www.trailjournals.com/join)
+  - [Support Trailjournals](https://www.trailjournals.com/about/donate/)
+  - [Contact](https://www.trailjournals.com/about/contact)
+  - [Store](https://www.trailjournals.com/store/)
+
+Backpacking Journals and Photos from Long Distance Hikers
+
+1. [Home](https://www.trailjournals.com/)
+2. [Journals](https://www.trailjournals.com/journals)
+3. [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail)
+4. [2010](https://www.trailjournals.com/journals/appalachian_trail/2010)
+5. [Uncle Frank](https://www.trailjournals.com/journal/10467)
+6. [Entries](https://www.trailjournals.com/journal/entries/10467/uncle%20-frank)
+7. April 17, 2010
+
+Toggle navigation
+
+- [Journal](https://www.trailjournals.com/journal/10467)
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+- [My Journals](https://www.trailjournals.com/myjournals/10467)
+- [View Guest Book](https://www.trailjournals.com/journal/guestbook/10467)
+- [Sign Guest Book](https://www.trailjournals.com/journal/guestbook/sign/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/2a.gif)
+
+[Journal](https://www.trailjournals.com/journal/10467)
+
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+
+--Choose--01/21/1002/06/1002/07/1002/08/1002/09/1002/10/1002/11/1002/12/1002/13/1002/14/1002/15/1002/16/1002/17/1002/18/1002/19/1002/20/1002/21/1002/22/1002/23/1002/24/1002/25/1002/26/1002/27/1002/28/1003/01/1003/02/1003/03/1003/04/1003/05/1003/06/1003/07/1003/08/1003/09/1003/11/1003/12/1003/13/1003/14/1003/15/1003/16/1003/17/1003/18/1003/19/1003/20/1003/21/1003/24/1003/25/1003/26/1003/27/1003/28/1003/29/1003/30/1003/31/1004/01/1004/02/1004/03/1004/04/1004/05/1004/06/1004/07/1004/08/1004/09/1004/10/1004/11/1004/12/1004/13/1004/14/1004/15/1004/16/1004/17/1004/18/1004/19/1004/20/1004/21/1004/23/1004/24/1004/25/1004/26/1004/27/1004/28/1004/29/1004/30/1005/01/1005/02/1005/03/1005/04/1005/05/1005/06/1005/07/1005/08/1005/09/1005/10/1005/11/1005/12/1005/13/1005/14/1005/15/1005/16/1005/17/1005/18/1005/19/1005/20/1005/21/1005/22/1005/23/1005/24/1005/25/1005/26/1005/27/1005/28/1005/29/1005/30/1005/31/1006/01/1006/02/1006/03/1006/04/1006/05/1006/06/1006/07/1006/08/1006/09/1006/10/1006/11/1006/12/1006/13/1006/14/1006/15/1006/16/1006/17/1006/18/1006/19/1006/20/1006/21/10
+
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+
+Guest Book
+
+- [Sign](https://www.trailjournals.com/journal/guestbook/sign/10467)
+- [View](https://www.trailjournals.com/journal/guestbook/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/2a.gif)
+
+- [AT Journals](https://www.trailjournals.com/journals/appalachian_trail)
+- [AT Photos](https://www.trailjournals.com/photos/appalachian_trail)
+- [AT Books](https://www.trailjournals.com/books/appalachian_trail)
+- [Appalachian Trail](http://www.appalachiantrail.org/)
+
+[Join](https://www.trailjournals.com/join) [Login](https://www.trailjournals.com/user/login)
+
+[RSS](https://www.trailjournals.com/journal/rss/10467/xml)
+
+# Uncle Frank's 2010  Appalachian Trail Journal
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/306438) [Next](https://www.trailjournals.com/journal/entry/306440) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+Saturday, April 17, 2010
+
+Destination:Bearfence Mountain Hut
+
+Today's Miles:20.60
+
+Start Location:Pinefield Hut
+
+Trip Miles:903
+
+Destination:Bearfence Mountain Hut
+
+Start Location:Pinefield Hut
+
+Today's Miles:20.60
+
+Trip Miles:903
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/306438) [Next](https://www.trailjournals.com/journal/entry/306440) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+### Hiker Entries April 17, 2010
+
+|  | Journalist | Destination | Trail |
+| --- | --- | --- | --- |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DidgeridudeandDoodlebug_9852TN.jpg) | [Didgeridude and Doodlebug](https://www.trailjournals.com/journal/about/9852) | [Asheville](https://www.trailjournals.com/journal/entry/334631) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2014Sundance_6768TN.jpg) | [Sundance](https://www.trailjournals.com/journal/about/6768) | [Hot Springs NC](https://www.trailjournals.com/journal/entry/333694) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010EUREKA!_10324TN.jpg) | [Jerry from Kentucky](https://www.trailjournals.com/journal/about/10324) | [Spring Mountain Shelter](https://www.trailjournals.com/journal/entry/333253) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Peru_10969TN.jpg) | [Peru](https://www.trailjournals.com/journal/about/10969) | [Hiawassee](https://www.trailjournals.com/journal/entry/325329) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Dilly Dally & Cubbie](https://www.trailjournals.com/journal/about/10450) | [Double Spring Shelter](https://www.trailjournals.com/journal/entry/324873) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [oakleaf](https://www.trailjournals.com/journal/about/10570) | [maine](https://www.trailjournals.com/journal/entry/322412) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Obi-Wan](https://www.trailjournals.com/journal/about/11050) | [\-\- View Entry --](https://www.trailjournals.com/journal/entry/321931) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Obi-Wan](https://www.trailjournals.com/journal/about/11050) | [Springer Mountain](https://www.trailjournals.com/journal/entry/321928) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Opus](https://www.trailjournals.com/journal/about/10015) | [Double-Spring Gap shelter](https://www.trailjournals.com/journal/entry/314950) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010BruceCook_9777TN.jpg) | [HooYaa!](https://www.trailjournals.com/journal/about/9777) | [Muskcrat Creek Shelter](https://www.trailjournals.com/journal/entry/314596) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| [More...](https://www.trailjournals.com/entries/2010/04/17) [Grouped By Trail...](https://www.trailjournals.com/entries/2010/04/17/trail) |
+
+|     |
+| --- |
+| The White Mountains are the hardest part of the trail and the most majestic. I feel lucky having hiked my whole life in this range, perhaps it’ll make other parts of the trail less daunting. ... <br>[Connor Litchman](https://www.trailjournals.com/journal/entry/441689) —<br>[Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail) [2014](https://www.trailjournals.com/journals/appalachian_trail/2014) |
+
+[![Trailjournals](https://www.trailjournals.com/images/logo.png)](https://www.trailjournals.com/)
+
+#### Hiking
+
+- [Trails](https://www.trailjournals.com/trails/list)
+- [Journals](https://www.trailjournals.com/journals)
+- [Photos](https://www.trailjournals.com/photos)
+- [Calendar](https://www.trailjournals.com/calendar)
+- Gear
+- [Links](https://www.trailjournals.com/links)
+
+#### Partners
+
+- [ULA Equipment](https://ula-equipment.sjv.io/drN9K)
+- [REI](http://www.avantlink.com/click.php?tt=ml&ti=45265&pw=68025)
+- [Patagonia](http://www.avantlink.com/click.php?tt=ml&ti=45781&pw=68025)
+
+#### Network
+
+- [Trail Forums](http://www.trailforums.com/)
+- Trail News
+
+#### About Us
+
+- [Contact](https://www.trailjournals.com/about/contact)
+- [Donate](https://www.trailjournals.com/about/donate)
+- [Join](https://www.trailjournals.com/join)
+- [Login](https://www.trailjournals.com/user/login)
+- [Help](https://www.trailjournals.com/help)
+
+#### Follow Us
+
+- [Facebook](https://www.facebook.com/trailjournals)
+- [Instagram](https://instagram.com/trailjournals/)
+- [Twitter](https://twitter.com/trailjournals)
+- [Pinterest](https://www.pinterest.com/trailjournals/)
+- [Linkedin](https://www.linkedin.com/company/trailjournals-llc)
+
+Top Photo © Renee Patrick - Pacific Crest Trail,
+05/21/2006 by
+[She-ra](https://www.trailjournals.com/journal/2942)
+
+Trailjournals LLC © 2026
+All Rights Reserved. [privacy policy](https://www.trailjournals.com/about/privacy)
+
+Newburyport, MA 01950
+
+[Terms under which this service is provided to you.](https://www.trailjournals.com/about/privacy)
+
+Build: 20210226:165913 [Manage Settings](https://www.trailjournals.com/about/settings)
+---
+
+# Sunday, April 18, 2010 — Treehaus
+**Start Location:** Bearfence Mountain Hut
+**Miles Today:** 0
+**Trip Miles:** 903
+
+Toggle navigation[Trail Journals](https://www.trailjournals.com/)
+
+- [Journals](https://www.trailjournals.com/journal/entry/306440#)  - [Journals](https://www.trailjournals.com/journals)
+  - [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail/2026)
+  - [Pacific Crest Trail](https://www.trailjournals.com/journals/pacific_crest_trail/2026)
+  - [Colorado Trail](https://www.trailjournals.com/journals/colorado_trail/2026)
+  - [Continental Divide Trail](https://www.trailjournals.com/journals/continental_divide_trail/2026)
+  - [Long Trail - Vermont](https://www.trailjournals.com/journals/the_long_trail_-_vermont/2026)
+  - [Florida Trail](https://www.trailjournals.com/journals/the_florida_trail/2026)
+  - [Arizona Trail](https://www.trailjournals.com/journals/arizona_trail/2026)
+  - [John Muir Trail](https://www.trailjournals.com/journals/john_muir_trail/2026)
+  - [Camino de Santiago](https://www.trailjournals.com/journals/camino_de_santiago/2026)
+  - [American Discovery Trail](https://www.trailjournals.com/journals/american_discovery_trail/2026)
+  - [Coast to Coast Walk](https://www.trailjournals.com/journals/coast_to_coast_walk/2026)
+  - [More...](https://www.trailjournals.com/journals/)
+- [Trails](https://www.trailjournals.com/trails/)
+- [Photos](https://www.trailjournals.com/photos/2026)
+- [Gear](https://www.trailjournals.com/journal/entry/306440#)  - [Current Sales](https://www.trailjournals.com/gear/deals/onsale)
+  - [REI](https://www.trailjournals.com/gear/rei)
+  - [ULA](https://www.trailjournals.com/gear/ula)
+  - [Patagonia](https://www.trailjournals.com/gear/patagonia)
+  - [Cabela's](https://www.trailjournals.com/gear/cabela)
+- [Planning](https://www.trailjournals.com/journal/entry/306440#)  - [Plan Your Hike](https://www.trailjournals.com/planning/)
+  - [Gear](https://www.trailjournals.com/gear/)
+  - [Books](https://www.trailjournals.com/books/)
+  - [Links](https://www.trailjournals.com/links/)
+- [Search](https://www.trailjournals.com/search/)
+- [About](https://www.trailjournals.com/journal/entry/306440#)  - [About Trailjournals](https://www.trailjournals.com/about/)
+  - [Login](https://www.trailjournals.com/user/login)
+  - [Join](https://www.trailjournals.com/join)
+  - [Support Trailjournals](https://www.trailjournals.com/about/donate/)
+  - [Contact](https://www.trailjournals.com/about/contact)
+  - [Store](https://www.trailjournals.com/store/)
+
+Backpacking Journals and Photos from Long Distance Hikers
+
+1. [Home](https://www.trailjournals.com/)
+2. [Journals](https://www.trailjournals.com/journals)
+3. [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail)
+4. [2010](https://www.trailjournals.com/journals/appalachian_trail/2010)
+5. [Uncle Frank](https://www.trailjournals.com/journal/10467)
+6. [Entries](https://www.trailjournals.com/journal/entries/10467/uncle%20-frank)
+7. April 18, 2010
+
+Toggle navigation
+
+- [Journal](https://www.trailjournals.com/journal/10467)
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+- [My Journals](https://www.trailjournals.com/myjournals/10467)
+- [View Guest Book](https://www.trailjournals.com/journal/guestbook/10467)
+- [Sign Guest Book](https://www.trailjournals.com/journal/guestbook/sign/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/4a.gif)
+
+[Journal](https://www.trailjournals.com/journal/10467)
+
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+
+--Choose--01/21/1002/06/1002/07/1002/08/1002/09/1002/10/1002/11/1002/12/1002/13/1002/14/1002/15/1002/16/1002/17/1002/18/1002/19/1002/20/1002/21/1002/22/1002/23/1002/24/1002/25/1002/26/1002/27/1002/28/1003/01/1003/02/1003/03/1003/04/1003/05/1003/06/1003/07/1003/08/1003/09/1003/11/1003/12/1003/13/1003/14/1003/15/1003/16/1003/17/1003/18/1003/19/1003/20/1003/21/1003/24/1003/25/1003/26/1003/27/1003/28/1003/29/1003/30/1003/31/1004/01/1004/02/1004/03/1004/04/1004/05/1004/06/1004/07/1004/08/1004/09/1004/10/1004/11/1004/12/1004/13/1004/14/1004/15/1004/16/1004/17/1004/18/1004/19/1004/20/1004/21/1004/23/1004/24/1004/25/1004/26/1004/27/1004/28/1004/29/1004/30/1005/01/1005/02/1005/03/1005/04/1005/05/1005/06/1005/07/1005/08/1005/09/1005/10/1005/11/1005/12/1005/13/1005/14/1005/15/1005/16/1005/17/1005/18/1005/19/1005/20/1005/21/1005/22/1005/23/1005/24/1005/25/1005/26/1005/27/1005/28/1005/29/1005/30/1005/31/1006/01/1006/02/1006/03/1006/04/1006/05/1006/06/1006/07/1006/08/1006/09/1006/10/1006/11/1006/12/1006/13/1006/14/1006/15/1006/16/1006/17/1006/18/1006/19/1006/20/1006/21/10
+
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+
+Guest Book
+
+- [Sign](https://www.trailjournals.com/journal/guestbook/sign/10467)
+- [View](https://www.trailjournals.com/journal/guestbook/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/4a.gif)
+
+- [AT Journals](https://www.trailjournals.com/journals/appalachian_trail)
+- [AT Photos](https://www.trailjournals.com/photos/appalachian_trail)
+- [AT Books](https://www.trailjournals.com/books/appalachian_trail)
+- [Appalachian Trail](http://www.appalachiantrail.org/)
+
+[Join](https://www.trailjournals.com/join) [Login](https://www.trailjournals.com/user/login)
+
+[RSS](https://www.trailjournals.com/journal/rss/10467/xml)
+
+# Uncle Frank's 2010  Appalachian Trail Journal
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/306439) [Next](https://www.trailjournals.com/journal/entry/306441) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+Sunday, April 18, 2010
+
+Destination:Treehaus
+
+Today's Miles:0
+
+Start Location:Bearfence Mountain Hut
+
+Trip Miles:903
+
+Destination:Treehaus
+
+Start Location:Bearfence Mountain Hut
+
+Today's Miles:0
+
+Trip Miles:903
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/306439) [Next](https://www.trailjournals.com/journal/entry/306441) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+### Hiker Entries April 18, 2010
+
+|  | Journalist | Destination | Trail |
+| --- | --- | --- | --- |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2007IPOD_5637TN.jpg) | [IPOD](https://www.trailjournals.com/journal/about/5637) | [Harper's Creek Shelter](https://www.trailjournals.com/journal/entry/350402) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2014Sundance_6768TN.jpg) | [Sundance](https://www.trailjournals.com/journal/about/6768) | [Hot Springs NC](https://www.trailjournals.com/journal/entry/333758) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Superman_10150TN.jpg) | [Superman](https://www.trailjournals.com/journal/about/10150) | [Cold Spring Gap](https://www.trailjournals.com/journal/entry/330111) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Peru_10969TN.jpg) | [Peru](https://www.trailjournals.com/journal/about/10969) | [Siler Bald Shelter](https://www.trailjournals.com/journal/entry/325328) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Dilly Dally & Cubbie](https://www.trailjournals.com/journal/about/10450) | [Pecks Corner Shelter](https://www.trailjournals.com/journal/entry/324874) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DannyGrady_10127TN.jpg) | [Teen Wolf](https://www.trailjournals.com/journal/about/10127) | [Campsite One Mile Past Neels Gap](https://www.trailjournals.com/journal/entry/319044) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Opus](https://www.trailjournals.com/journal/about/10015) | [Icewater Spring shelter](https://www.trailjournals.com/journal/entry/314952) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010BruceCook_9777TN.jpg) | [HooYaa!](https://www.trailjournals.com/journal/about/9777) | [Carter Gap Shelter](https://www.trailjournals.com/journal/entry/314784) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2011ErictheRed_9407TN.jpg) | [Eric the Red](https://www.trailjournals.com/journal/about/9407) | [Fontana Dam Shelter (163.7)](https://www.trailjournals.com/journal/entry/313499) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Tintin_9861TN.jpg) | [Tintin](https://www.trailjournals.com/journal/about/9861) | [Zero Day in Roan Mountain](https://www.trailjournals.com/journal/entry/311770) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| [More...](https://www.trailjournals.com/entries/2010/04/18) [Grouped By Trail...](https://www.trailjournals.com/entries/2010/04/18/trail) |
+
+|     |
+| --- |
+| As I embark on this journey, this fulfillment of a dream, this undertaking that will require all the physical, mental, and emotional strength that God grants me, I will travel toward my destination, proudly, as Don’s Brother. ... <br>[Don's Brother](https://www.trailjournals.com/journal/entry/400624) —<br>[Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail) [2013](https://www.trailjournals.com/journals/appalachian_trail/2013) |
+
+[![Trailjournals](https://www.trailjournals.com/images/logo.png)](https://www.trailjournals.com/)
+
+#### Hiking
+
+- [Trails](https://www.trailjournals.com/trails/list)
+- [Journals](https://www.trailjournals.com/journals)
+- [Photos](https://www.trailjournals.com/photos)
+- [Calendar](https://www.trailjournals.com/calendar)
+- Gear
+- [Links](https://www.trailjournals.com/links)
+
+#### Partners
+
+- [ULA Equipment](https://ula-equipment.sjv.io/drN9K)
+- [REI](http://www.avantlink.com/click.php?tt=ml&ti=45265&pw=68025)
+- [Patagonia](http://www.avantlink.com/click.php?tt=ml&ti=45781&pw=68025)
+
+#### Network
+
+- [Trail Forums](http://www.trailforums.com/)
+- Trail News
+
+#### About Us
+
+- [Contact](https://www.trailjournals.com/about/contact)
+- [Donate](https://www.trailjournals.com/about/donate)
+- [Join](https://www.trailjournals.com/join)
+- [Login](https://www.trailjournals.com/user/login)
+- [Help](https://www.trailjournals.com/help)
+
+#### Follow Us
+
+- [Facebook](https://www.facebook.com/trailjournals)
+- [Instagram](https://instagram.com/trailjournals/)
+- [Twitter](https://twitter.com/trailjournals)
+- [Pinterest](https://www.pinterest.com/trailjournals/)
+- [Linkedin](https://www.linkedin.com/company/trailjournals-llc)
+
+Top Photo © Renee Patrick - Pacific Crest Trail,
+05/21/2006 by
+[She-ra](https://www.trailjournals.com/journal/2942)
+
+Trailjournals LLC © 2026
+All Rights Reserved. [privacy policy](https://www.trailjournals.com/about/privacy)
+
+Newburyport, MA 01950
+
+[Terms under which this service is provided to you.](https://www.trailjournals.com/about/privacy)
+
+Build: 20210226:165913 [Manage Settings](https://www.trailjournals.com/about/settings)
+---
+
+# Monday, April 19, 2010 — Byrd's Nest #3
+**Start Location:** Treehaus
+**Miles Today:** 22.40
+**Trip Miles:** 925.40
+
+Toggle navigation[Trail Journals](https://www.trailjournals.com/)
+
+- [Journals](https://www.trailjournals.com/journal/entry/306441#)  - [Journals](https://www.trailjournals.com/journals)
+  - [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail/2026)
+  - [Pacific Crest Trail](https://www.trailjournals.com/journals/pacific_crest_trail/2026)
+  - [Colorado Trail](https://www.trailjournals.com/journals/colorado_trail/2026)
+  - [Continental Divide Trail](https://www.trailjournals.com/journals/continental_divide_trail/2026)
+  - [Long Trail - Vermont](https://www.trailjournals.com/journals/the_long_trail_-_vermont/2026)
+  - [Florida Trail](https://www.trailjournals.com/journals/the_florida_trail/2026)
+  - [Arizona Trail](https://www.trailjournals.com/journals/arizona_trail/2026)
+  - [John Muir Trail](https://www.trailjournals.com/journals/john_muir_trail/2026)
+  - [Camino de Santiago](https://www.trailjournals.com/journals/camino_de_santiago/2026)
+  - [American Discovery Trail](https://www.trailjournals.com/journals/american_discovery_trail/2026)
+  - [Coast to Coast Walk](https://www.trailjournals.com/journals/coast_to_coast_walk/2026)
+  - [More...](https://www.trailjournals.com/journals/)
+- [Trails](https://www.trailjournals.com/trails/)
+- [Photos](https://www.trailjournals.com/photos/2026)
+- [Gear](https://www.trailjournals.com/journal/entry/306441#)  - [Current Sales](https://www.trailjournals.com/gear/deals/onsale)
+  - [REI](https://www.trailjournals.com/gear/rei)
+  - [ULA](https://www.trailjournals.com/gear/ula)
+  - [Patagonia](https://www.trailjournals.com/gear/patagonia)
+  - [Cabela's](https://www.trailjournals.com/gear/cabela)
+- [Planning](https://www.trailjournals.com/journal/entry/306441#)  - [Plan Your Hike](https://www.trailjournals.com/planning/)
+  - [Gear](https://www.trailjournals.com/gear/)
+  - [Books](https://www.trailjournals.com/books/)
+  - [Links](https://www.trailjournals.com/links/)
+- [Search](https://www.trailjournals.com/search/)
+- [About](https://www.trailjournals.com/journal/entry/306441#)  - [About Trailjournals](https://www.trailjournals.com/about/)
+  - [Login](https://www.trailjournals.com/user/login)
+  - [Join](https://www.trailjournals.com/join)
+  - [Support Trailjournals](https://www.trailjournals.com/about/donate/)
+  - [Contact](https://www.trailjournals.com/about/contact)
+  - [Store](https://www.trailjournals.com/store/)
+
+Backpacking Journals and Photos from Long Distance Hikers
+
+1. [Home](https://www.trailjournals.com/)
+2. [Journals](https://www.trailjournals.com/journals)
+3. [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail)
+4. [2010](https://www.trailjournals.com/journals/appalachian_trail/2010)
+5. [Uncle Frank](https://www.trailjournals.com/journal/10467)
+6. [Entries](https://www.trailjournals.com/journal/entries/10467/uncle%20-frank)
+7. April 19, 2010
+
+Toggle navigation
+
+- [Journal](https://www.trailjournals.com/journal/10467)
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+- [My Journals](https://www.trailjournals.com/myjournals/10467)
+- [View Guest Book](https://www.trailjournals.com/journal/guestbook/10467)
+- [Sign Guest Book](https://www.trailjournals.com/journal/guestbook/sign/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/8a.gif)![](https://www.trailjournals.com/images/2a.gif)
+
+[Journal](https://www.trailjournals.com/journal/10467)
+
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+
+--Choose--01/21/1002/06/1002/07/1002/08/1002/09/1002/10/1002/11/1002/12/1002/13/1002/14/1002/15/1002/16/1002/17/1002/18/1002/19/1002/20/1002/21/1002/22/1002/23/1002/24/1002/25/1002/26/1002/27/1002/28/1003/01/1003/02/1003/03/1003/04/1003/05/1003/06/1003/07/1003/08/1003/09/1003/11/1003/12/1003/13/1003/14/1003/15/1003/16/1003/17/1003/18/1003/19/1003/20/1003/21/1003/24/1003/25/1003/26/1003/27/1003/28/1003/29/1003/30/1003/31/1004/01/1004/02/1004/03/1004/04/1004/05/1004/06/1004/07/1004/08/1004/09/1004/10/1004/11/1004/12/1004/13/1004/14/1004/15/1004/16/1004/17/1004/18/1004/19/1004/20/1004/21/1004/23/1004/24/1004/25/1004/26/1004/27/1004/28/1004/29/1004/30/1005/01/1005/02/1005/03/1005/04/1005/05/1005/06/1005/07/1005/08/1005/09/1005/10/1005/11/1005/12/1005/13/1005/14/1005/15/1005/16/1005/17/1005/18/1005/19/1005/20/1005/21/1005/22/1005/23/1005/24/1005/25/1005/26/1005/27/1005/28/1005/29/1005/30/1005/31/1006/01/1006/02/1006/03/1006/04/1006/05/1006/06/1006/07/1006/08/1006/09/1006/10/1006/11/1006/12/1006/13/1006/14/1006/15/1006/16/1006/17/1006/18/1006/19/1006/20/1006/21/10
+
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+
+Guest Book
+
+- [Sign](https://www.trailjournals.com/journal/guestbook/sign/10467)
+- [View](https://www.trailjournals.com/journal/guestbook/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/8a.gif)![](https://www.trailjournals.com/images/2a.gif)
+
+- [AT Journals](https://www.trailjournals.com/journals/appalachian_trail)
+- [AT Photos](https://www.trailjournals.com/photos/appalachian_trail)
+- [AT Books](https://www.trailjournals.com/books/appalachian_trail)
+- [Appalachian Trail](http://www.appalachiantrail.org/)
+
+[Join](https://www.trailjournals.com/join) [Login](https://www.trailjournals.com/user/login)
+
+[RSS](https://www.trailjournals.com/journal/rss/10467/xml)
+
+# Uncle Frank's 2010  Appalachian Trail Journal
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/306440) [Next](https://www.trailjournals.com/journal/entry/306442) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+Monday, April 19, 2010
+
+Destination:Byrd's Nest #3
+
+Today's Miles:22.40
+
+Start Location:Treehaus
+
+Trip Miles:925.40
+
+Destination:Byrd's Nest #3
+
+Start Location:Treehaus
+
+Today's Miles:22.40
+
+Trip Miles:925.40
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/306440) [Next](https://www.trailjournals.com/journal/entry/306442) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+### Hiker Entries April 19, 2010
+
+|  | Journalist | Destination | Trail |
+| --- | --- | --- | --- |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2007IPOD_5637TN.jpg) | [IPOD](https://www.trailjournals.com/journal/about/5637) | [dripping rock parking](https://www.trailjournals.com/journal/entry/350403) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DidgeridudeandDoodlebug_9852TN.jpg) | [Didgeridude and Doodlebug](https://www.trailjournals.com/journal/about/9852) | [campsite past Sam's gap](https://www.trailjournals.com/journal/entry/334632) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2014Sundance_6768TN.jpg) | [Sundance](https://www.trailjournals.com/journal/about/6768) | [Spring Mtn. Shelter](https://www.trailjournals.com/journal/entry/333759) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010BruceCook_9777TN.jpg) | [HooYaa!](https://www.trailjournals.com/journal/about/9777) | [Rock Gap Shelter](https://www.trailjournals.com/journal/entry/331901) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Superman_10150TN.jpg) | [Superman](https://www.trailjournals.com/journal/about/10150) | [Mile 177](https://www.trailjournals.com/journal/entry/330112) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Peru_10969TN.jpg) | [Peru](https://www.trailjournals.com/journal/about/10969) | [Cold Spring Shelter](https://www.trailjournals.com/journal/entry/325330) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Dilly Dally & Cubbie](https://www.trailjournals.com/journal/about/10450) | [Davenport Gap Shelter](https://www.trailjournals.com/journal/entry/324875) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010UnbreakableandNoTrace_9709TN.jpg) | [Unbreakable & No Trace](https://www.trailjournals.com/journal/about/9709) | [Mount Laguna](https://www.trailjournals.com/journal/entry/320920) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DannyGrady_10127TN.jpg) | [Teen Wolf](https://www.trailjournals.com/journal/about/10127) | [Blue Mountain Shelter](https://www.trailjournals.com/journal/entry/319046) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Opus](https://www.trailjournals.com/journal/about/10015) | [Cosby Knob shelter](https://www.trailjournals.com/journal/entry/314953) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| [More...](https://www.trailjournals.com/entries/2010/04/19) [Grouped By Trail...](https://www.trailjournals.com/entries/2010/04/19/trail) |
+
+|     |
+| --- |
+| "...had to chuckle at myself walking along at a blazing 3MPH! I would take about seven hours to hike seventeen miles today and those cars and trucks were doing the same mileage in about twenty minutes. It is so awesome to be out of "Life in the fast lane."... <br>[Soul Asylum](https://www.trailjournals.com/journal/entry/477737) —<br>[Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail) [2017](https://www.trailjournals.com/journals/appalachian_trail/2017) |
+
+[![Trailjournals](https://www.trailjournals.com/images/logo.png)](https://www.trailjournals.com/)
+
+#### Hiking
+
+- [Trails](https://www.trailjournals.com/trails/list)
+- [Journals](https://www.trailjournals.com/journals)
+- [Photos](https://www.trailjournals.com/photos)
+- [Calendar](https://www.trailjournals.com/calendar)
+- Gear
+- [Links](https://www.trailjournals.com/links)
+
+#### Partners
+
+- [ULA Equipment](https://ula-equipment.sjv.io/drN9K)
+- [REI](http://www.avantlink.com/click.php?tt=ml&ti=45265&pw=68025)
+- [Patagonia](http://www.avantlink.com/click.php?tt=ml&ti=45781&pw=68025)
+
+#### Network
+
+- [Trail Forums](http://www.trailforums.com/)
+- Trail News
+
+#### About Us
+
+- [Contact](https://www.trailjournals.com/about/contact)
+- [Donate](https://www.trailjournals.com/about/donate)
+- [Join](https://www.trailjournals.com/join)
+- [Login](https://www.trailjournals.com/user/login)
+- [Help](https://www.trailjournals.com/help)
+
+#### Follow Us
+
+- [Facebook](https://www.facebook.com/trailjournals)
+- [Instagram](https://instagram.com/trailjournals/)
+- [Twitter](https://twitter.com/trailjournals)
+- [Pinterest](https://www.pinterest.com/trailjournals/)
+- [Linkedin](https://www.linkedin.com/company/trailjournals-llc)
+
+Top Photo © Cindy - The Appalachian Trail,
+04/01/2002 by
+[MrsGorp](https://www.trailjournals.com/journal/569)
+
+Trailjournals LLC © 2026
+All Rights Reserved. [privacy policy](https://www.trailjournals.com/about/privacy)
+
+Newburyport, MA 01950
+
+[Terms under which this service is provided to you.](https://www.trailjournals.com/about/privacy)
+
+Build: 20210226:165913 [Manage Settings](https://www.trailjournals.com/about/settings)
+---
+
+# Tuesday, April 20, 2010 — Gravel Springs Hut
+**Start Location:** Byrd's Nest #3
+**Miles Today:** 17.50
+**Trip Miles:** 942.90
+
+Toggle navigation[Trail Journals](https://www.trailjournals.com/)
+
+- [Journals](https://www.trailjournals.com/journal/entry/306442#)  - [Journals](https://www.trailjournals.com/journals)
+  - [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail/2026)
+  - [Pacific Crest Trail](https://www.trailjournals.com/journals/pacific_crest_trail/2026)
+  - [Colorado Trail](https://www.trailjournals.com/journals/colorado_trail/2026)
+  - [Continental Divide Trail](https://www.trailjournals.com/journals/continental_divide_trail/2026)
+  - [Long Trail - Vermont](https://www.trailjournals.com/journals/the_long_trail_-_vermont/2026)
+  - [Florida Trail](https://www.trailjournals.com/journals/the_florida_trail/2026)
+  - [Arizona Trail](https://www.trailjournals.com/journals/arizona_trail/2026)
+  - [John Muir Trail](https://www.trailjournals.com/journals/john_muir_trail/2026)
+  - [Camino de Santiago](https://www.trailjournals.com/journals/camino_de_santiago/2026)
+  - [American Discovery Trail](https://www.trailjournals.com/journals/american_discovery_trail/2026)
+  - [Coast to Coast Walk](https://www.trailjournals.com/journals/coast_to_coast_walk/2026)
+  - [More...](https://www.trailjournals.com/journals/)
+- [Trails](https://www.trailjournals.com/trails/)
+- [Photos](https://www.trailjournals.com/photos/2026)
+- [Gear](https://www.trailjournals.com/journal/entry/306442#)  - [Current Sales](https://www.trailjournals.com/gear/deals/onsale)
+  - [REI](https://www.trailjournals.com/gear/rei)
+  - [ULA](https://www.trailjournals.com/gear/ula)
+  - [Patagonia](https://www.trailjournals.com/gear/patagonia)
+  - [Cabela's](https://www.trailjournals.com/gear/cabela)
+- [Planning](https://www.trailjournals.com/journal/entry/306442#)  - [Plan Your Hike](https://www.trailjournals.com/planning/)
+  - [Gear](https://www.trailjournals.com/gear/)
+  - [Books](https://www.trailjournals.com/books/)
+  - [Links](https://www.trailjournals.com/links/)
+- [Search](https://www.trailjournals.com/search/)
+- [About](https://www.trailjournals.com/journal/entry/306442#)  - [About Trailjournals](https://www.trailjournals.com/about/)
+  - [Login](https://www.trailjournals.com/user/login)
+  - [Join](https://www.trailjournals.com/join)
+  - [Support Trailjournals](https://www.trailjournals.com/about/donate/)
+  - [Contact](https://www.trailjournals.com/about/contact)
+  - [Store](https://www.trailjournals.com/store/)
+
+Backpacking Journals and Photos from Long Distance Hikers
+
+1. [Home](https://www.trailjournals.com/)
+2. [Journals](https://www.trailjournals.com/journals)
+3. [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail)
+4. [2010](https://www.trailjournals.com/journals/appalachian_trail/2010)
+5. [Uncle Frank](https://www.trailjournals.com/journal/10467)
+6. [Entries](https://www.trailjournals.com/journal/entries/10467/uncle%20-frank)
+7. April 20, 2010
+
+Toggle navigation
+
+- [Journal](https://www.trailjournals.com/journal/10467)
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+- [My Journals](https://www.trailjournals.com/myjournals/10467)
+- [View Guest Book](https://www.trailjournals.com/journal/guestbook/10467)
+- [Sign Guest Book](https://www.trailjournals.com/journal/guestbook/sign/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/5a.gif)
+
+[Journal](https://www.trailjournals.com/journal/10467)
+
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+
+--Choose--01/21/1002/06/1002/07/1002/08/1002/09/1002/10/1002/11/1002/12/1002/13/1002/14/1002/15/1002/16/1002/17/1002/18/1002/19/1002/20/1002/21/1002/22/1002/23/1002/24/1002/25/1002/26/1002/27/1002/28/1003/01/1003/02/1003/03/1003/04/1003/05/1003/06/1003/07/1003/08/1003/09/1003/11/1003/12/1003/13/1003/14/1003/15/1003/16/1003/17/1003/18/1003/19/1003/20/1003/21/1003/24/1003/25/1003/26/1003/27/1003/28/1003/29/1003/30/1003/31/1004/01/1004/02/1004/03/1004/04/1004/05/1004/06/1004/07/1004/08/1004/09/1004/10/1004/11/1004/12/1004/13/1004/14/1004/15/1004/16/1004/17/1004/18/1004/19/1004/20/1004/21/1004/23/1004/24/1004/25/1004/26/1004/27/1004/28/1004/29/1004/30/1005/01/1005/02/1005/03/1005/04/1005/05/1005/06/1005/07/1005/08/1005/09/1005/10/1005/11/1005/12/1005/13/1005/14/1005/15/1005/16/1005/17/1005/18/1005/19/1005/20/1005/21/1005/22/1005/23/1005/24/1005/25/1005/26/1005/27/1005/28/1005/29/1005/30/1005/31/1006/01/1006/02/1006/03/1006/04/1006/05/1006/06/1006/07/1006/08/1006/09/1006/10/1006/11/1006/12/1006/13/1006/14/1006/15/1006/16/1006/17/1006/18/1006/19/1006/20/1006/21/10
+
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+
+Guest Book
+
+- [Sign](https://www.trailjournals.com/journal/guestbook/sign/10467)
+- [View](https://www.trailjournals.com/journal/guestbook/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/5a.gif)
+
+- [AT Journals](https://www.trailjournals.com/journals/appalachian_trail)
+- [AT Photos](https://www.trailjournals.com/photos/appalachian_trail)
+- [AT Books](https://www.trailjournals.com/books/appalachian_trail)
+- [Appalachian Trail](http://www.appalachiantrail.org/)
+
+[Join](https://www.trailjournals.com/join) [Login](https://www.trailjournals.com/user/login)
+
+[RSS](https://www.trailjournals.com/journal/rss/10467/xml)
+
+# Uncle Frank's 2010  Appalachian Trail Journal
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/306441) [Next](https://www.trailjournals.com/journal/entry/306443) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+Tuesday, April 20, 2010
+
+Destination:Gravel Springs Hut
+
+Today's Miles:17.50
+
+Start Location:Byrd's Nest #3
+
+Trip Miles:942.90
+
+Destination:Gravel Springs Hut
+
+Start Location:Byrd's Nest #3
+
+Today's Miles:17.50
+
+Trip Miles:942.90
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/306441) [Next](https://www.trailjournals.com/journal/entry/306443) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+### Hiker Entries April 20, 2010
+
+|  | Journalist | Destination | Trail |
+| --- | --- | --- | --- |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2007IPOD_5637TN.jpg) | [IPOD](https://www.trailjournals.com/journal/about/5637) | [Waynesboro](https://www.trailjournals.com/journal/entry/350438) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DidgeridudeandDoodlebug_9852TN.jpg) | [Didgeridude and Doodlebug](https://www.trailjournals.com/journal/about/9852) | [Bald Mtn Shelter](https://www.trailjournals.com/journal/entry/334633) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2014Sundance_6768TN.jpg) | [Sundance](https://www.trailjournals.com/journal/about/6768) | [Jerry Cabin Shelter](https://www.trailjournals.com/journal/entry/333760) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010EUREKA!_10324TN.jpg) | [Jerry from Kentucky](https://www.trailjournals.com/journal/about/10324) | [Bald Mtn Shelter](https://www.trailjournals.com/journal/entry/333254) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010BruceCook_9777TN.jpg) | [HooYaa!](https://www.trailjournals.com/journal/about/9777) | [Winding Stair Gap](https://www.trailjournals.com/journal/entry/331939) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Superman_10150TN.jpg) | [Superman](https://www.trailjournals.com/journal/about/10150) | [Deals Gap Motel & Gas Station](https://www.trailjournals.com/journal/entry/330113) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Peru_10969TN.jpg) | [Peru](https://www.trailjournals.com/journal/about/10969) | [NOC](https://www.trailjournals.com/journal/entry/325331) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Dilly Dally & Cubbie](https://www.trailjournals.com/journal/about/10450) | [Standing Bear Hostel](https://www.trailjournals.com/journal/entry/324877) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DannyGrady_10127TN.jpg) | [Teen Wolf](https://www.trailjournals.com/journal/about/10127) | [Hiawasee Inn](https://www.trailjournals.com/journal/entry/319049) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Opus](https://www.trailjournals.com/journal/about/10015) | [Standing Bear Farm](https://www.trailjournals.com/journal/entry/315232) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| [More...](https://www.trailjournals.com/entries/2010/04/20) [Grouped By Trail...](https://www.trailjournals.com/entries/2010/04/20/trail) |
+
+|     |
+| --- |
+| Hiking through the Maine woods this morning, I couldn't help but notice how green they were. The pines are green and the floor of the forest is covered with mosses in various shades of green.... <br>[Dallas](https://www.trailjournals.com/journal/entry/474291) —<br>[Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail) [2014](https://www.trailjournals.com/journals/appalachian_trail/2014) |
+
+[![Trailjournals](https://www.trailjournals.com/images/logo.png)](https://www.trailjournals.com/)
+
+#### Hiking
+
+- [Trails](https://www.trailjournals.com/trails/list)
+- [Journals](https://www.trailjournals.com/journals)
+- [Photos](https://www.trailjournals.com/photos)
+- [Calendar](https://www.trailjournals.com/calendar)
+- Gear
+- [Links](https://www.trailjournals.com/links)
+
+#### Partners
+
+- [ULA Equipment](https://ula-equipment.sjv.io/drN9K)
+- [REI](http://www.avantlink.com/click.php?tt=ml&ti=45265&pw=68025)
+- [Patagonia](http://www.avantlink.com/click.php?tt=ml&ti=45781&pw=68025)
+
+#### Network
+
+- [Trail Forums](http://www.trailforums.com/)
+- Trail News
+
+#### About Us
+
+- [Contact](https://www.trailjournals.com/about/contact)
+- [Donate](https://www.trailjournals.com/about/donate)
+- [Join](https://www.trailjournals.com/join)
+- [Login](https://www.trailjournals.com/user/login)
+- [Help](https://www.trailjournals.com/help)
+
+#### Follow Us
+
+- [Facebook](https://www.facebook.com/trailjournals)
+- [Instagram](https://instagram.com/trailjournals/)
+- [Twitter](https://twitter.com/trailjournals)
+- [Pinterest](https://www.pinterest.com/trailjournals/)
+- [Linkedin](https://www.linkedin.com/company/trailjournals-llc)
+
+Top Photo © Cindy - The Appalachian Trail,
+04/01/2002 by
+[MrsGorp](https://www.trailjournals.com/journal/569)
+
+Trailjournals LLC © 2026
+All Rights Reserved. [privacy policy](https://www.trailjournals.com/about/privacy)
+
+Newburyport, MA 01950
+
+[Terms under which this service is provided to you.](https://www.trailjournals.com/about/privacy)
+
+Build: 20210226:165913 [Manage Settings](https://www.trailjournals.com/about/settings)
+---
+
+# Wednesday, April 21, 2010 — Dick's Dome Shelter
+**Start Location:** Gravel Springs Hut
+**Miles Today:** 28.60
+**Trip Miles:** 971.50
+
+Toggle navigation[Trail Journals](https://www.trailjournals.com/)
+
+- [Journals](https://www.trailjournals.com/journal/entry/306443#)  - [Journals](https://www.trailjournals.com/journals)
+  - [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail/2026)
+  - [Pacific Crest Trail](https://www.trailjournals.com/journals/pacific_crest_trail/2026)
+  - [Colorado Trail](https://www.trailjournals.com/journals/colorado_trail/2026)
+  - [Continental Divide Trail](https://www.trailjournals.com/journals/continental_divide_trail/2026)
+  - [Long Trail - Vermont](https://www.trailjournals.com/journals/the_long_trail_-_vermont/2026)
+  - [Florida Trail](https://www.trailjournals.com/journals/the_florida_trail/2026)
+  - [Arizona Trail](https://www.trailjournals.com/journals/arizona_trail/2026)
+  - [John Muir Trail](https://www.trailjournals.com/journals/john_muir_trail/2026)
+  - [Camino de Santiago](https://www.trailjournals.com/journals/camino_de_santiago/2026)
+  - [American Discovery Trail](https://www.trailjournals.com/journals/american_discovery_trail/2026)
+  - [Coast to Coast Walk](https://www.trailjournals.com/journals/coast_to_coast_walk/2026)
+  - [More...](https://www.trailjournals.com/journals/)
+- [Trails](https://www.trailjournals.com/trails/)
+- [Photos](https://www.trailjournals.com/photos/2026)
+- [Gear](https://www.trailjournals.com/journal/entry/306443#)  - [Current Sales](https://www.trailjournals.com/gear/deals/onsale)
+  - [REI](https://www.trailjournals.com/gear/rei)
+  - [ULA](https://www.trailjournals.com/gear/ula)
+  - [Patagonia](https://www.trailjournals.com/gear/patagonia)
+  - [Cabela's](https://www.trailjournals.com/gear/cabela)
+- [Planning](https://www.trailjournals.com/journal/entry/306443#)  - [Plan Your Hike](https://www.trailjournals.com/planning/)
+  - [Gear](https://www.trailjournals.com/gear/)
+  - [Books](https://www.trailjournals.com/books/)
+  - [Links](https://www.trailjournals.com/links/)
+- [Search](https://www.trailjournals.com/search/)
+- [About](https://www.trailjournals.com/journal/entry/306443#)  - [About Trailjournals](https://www.trailjournals.com/about/)
+  - [Login](https://www.trailjournals.com/user/login)
+  - [Join](https://www.trailjournals.com/join)
+  - [Support Trailjournals](https://www.trailjournals.com/about/donate/)
+  - [Contact](https://www.trailjournals.com/about/contact)
+  - [Store](https://www.trailjournals.com/store/)
+
+Backpacking Journals and Photos from Long Distance Hikers
+
+1. [Home](https://www.trailjournals.com/)
+2. [Journals](https://www.trailjournals.com/journals)
+3. [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail)
+4. [2010](https://www.trailjournals.com/journals/appalachian_trail/2010)
+5. [Uncle Frank](https://www.trailjournals.com/journal/10467)
+6. [Entries](https://www.trailjournals.com/journal/entries/10467/uncle%20-frank)
+7. April 21, 2010
+
+Toggle navigation
+
+- [Journal](https://www.trailjournals.com/journal/10467)
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+- [My Journals](https://www.trailjournals.com/myjournals/10467)
+- [View Guest Book](https://www.trailjournals.com/journal/guestbook/10467)
+- [Sign Guest Book](https://www.trailjournals.com/journal/guestbook/sign/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/8a.gif)![](https://www.trailjournals.com/images/2a.gif)
+
+[Journal](https://www.trailjournals.com/journal/10467)
+
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+
+--Choose--01/21/1002/06/1002/07/1002/08/1002/09/1002/10/1002/11/1002/12/1002/13/1002/14/1002/15/1002/16/1002/17/1002/18/1002/19/1002/20/1002/21/1002/22/1002/23/1002/24/1002/25/1002/26/1002/27/1002/28/1003/01/1003/02/1003/03/1003/04/1003/05/1003/06/1003/07/1003/08/1003/09/1003/11/1003/12/1003/13/1003/14/1003/15/1003/16/1003/17/1003/18/1003/19/1003/20/1003/21/1003/24/1003/25/1003/26/1003/27/1003/28/1003/29/1003/30/1003/31/1004/01/1004/02/1004/03/1004/04/1004/05/1004/06/1004/07/1004/08/1004/09/1004/10/1004/11/1004/12/1004/13/1004/14/1004/15/1004/16/1004/17/1004/18/1004/19/1004/20/1004/21/1004/23/1004/24/1004/25/1004/26/1004/27/1004/28/1004/29/1004/30/1005/01/1005/02/1005/03/1005/04/1005/05/1005/06/1005/07/1005/08/1005/09/1005/10/1005/11/1005/12/1005/13/1005/14/1005/15/1005/16/1005/17/1005/18/1005/19/1005/20/1005/21/1005/22/1005/23/1005/24/1005/25/1005/26/1005/27/1005/28/1005/29/1005/30/1005/31/1006/01/1006/02/1006/03/1006/04/1006/05/1006/06/1006/07/1006/08/1006/09/1006/10/1006/11/1006/12/1006/13/1006/14/1006/15/1006/16/1006/17/1006/18/1006/19/1006/20/1006/21/10
+
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+
+Guest Book
+
+- [Sign](https://www.trailjournals.com/journal/guestbook/sign/10467)
+- [View](https://www.trailjournals.com/journal/guestbook/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/8a.gif)![](https://www.trailjournals.com/images/2a.gif)
+
+- [AT Journals](https://www.trailjournals.com/journals/appalachian_trail)
+- [AT Photos](https://www.trailjournals.com/photos/appalachian_trail)
+- [AT Books](https://www.trailjournals.com/books/appalachian_trail)
+- [Appalachian Trail](http://www.appalachiantrail.org/)
+
+[Join](https://www.trailjournals.com/join) [Login](https://www.trailjournals.com/user/login)
+
+[RSS](https://www.trailjournals.com/journal/rss/10467/xml)
+
+# Uncle Frank's 2010  Appalachian Trail Journal
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/306442) [Next](https://www.trailjournals.com/journal/entry/306446) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+Wednesday, April 21, 2010
+
+Destination:Dick's Dome Shelter
+
+Today's Miles:28.60
+
+Start Location:Gravel Springs Hut
+
+Trip Miles:971.50
+
+Destination:Dick's Dome Shelter
+
+Start Location:Gravel Springs Hut
+
+Today's Miles:28.60
+
+Trip Miles:971.50
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/306442) [Next](https://www.trailjournals.com/journal/entry/306446) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+### Hiker Entries April 21, 2010
+
+|  | Journalist | Destination | Trail |
+| --- | --- | --- | --- |
+|  | [Deluxe](https://www.trailjournals.com/journal/about/21877) | [\-\- View Entry --](https://www.trailjournals.com/journal/entry/566478) | [Nepal Trekking](https://www.trailjournals.com/journals/Nepal%20_Trekking) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2007IPOD_5637TN.jpg) | [IPOD](https://www.trailjournals.com/journal/about/5637) | [middle of nowhere](https://www.trailjournals.com/journal/entry/350439) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DidgeridudeandDoodlebug_9852TN.jpg) | [Didgeridude and Doodlebug](https://www.trailjournals.com/journal/about/9852) | [No Business Knob Shelter](https://www.trailjournals.com/journal/entry/334635) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2014Sundance_6768TN.jpg) | [Sundance](https://www.trailjournals.com/journal/about/6768) | [Hogback Ridge Shelter](https://www.trailjournals.com/journal/entry/333761) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010EUREKA!_10324TN.jpg) | [Jerry from Kentucky](https://www.trailjournals.com/journal/about/10324) | [Erwin](https://www.trailjournals.com/journal/entry/333256) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010BruceCook_9777TN.jpg) | [HooYaa!](https://www.trailjournals.com/journal/about/9777) | [Wayah Shelter](https://www.trailjournals.com/journal/entry/331940) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Superman_10150TN.jpg) | [Superman](https://www.trailjournals.com/journal/about/10150) | [Fontana Dam](https://www.trailjournals.com/journal/entry/330115) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DannyGrady_10127TN.jpg) | [Teen Wolf](https://www.trailjournals.com/journal/about/10127) | [\-\- View Entry --](https://www.trailjournals.com/journal/entry/329682) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Psycho_10726TN.jpg) | [Psycho & Apricots](https://www.trailjournals.com/journal/about/10726) | [Warner Springs](https://www.trailjournals.com/journal/entry/329536) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Peru_10969TN.jpg) | [Peru](https://www.trailjournals.com/journal/about/10969) | [NOC](https://www.trailjournals.com/journal/entry/325332) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| [More...](https://www.trailjournals.com/entries/2010/04/21) [Grouped By Trail...](https://www.trailjournals.com/entries/2010/04/21/trail) |
+
+|     |
+| --- |
+| It has been another great day on the Trail in spite of the rain. Tomorrow's forecast is for more rain but we'll take what comes. That's life on the Trail...you can't beat it!!... <br>[Footsteps](https://www.trailjournals.com/journal/entry/8770) —<br>[Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail) [2001](https://www.trailjournals.com/journals/appalachian_trail/2001) |
+
+[![Trailjournals](https://www.trailjournals.com/images/logo.png)](https://www.trailjournals.com/)
+
+#### Hiking
+
+- [Trails](https://www.trailjournals.com/trails/list)
+- [Journals](https://www.trailjournals.com/journals)
+- [Photos](https://www.trailjournals.com/photos)
+- [Calendar](https://www.trailjournals.com/calendar)
+- Gear
+- [Links](https://www.trailjournals.com/links)
+
+#### Partners
+
+- [ULA Equipment](https://ula-equipment.sjv.io/drN9K)
+- [REI](http://www.avantlink.com/click.php?tt=ml&ti=45265&pw=68025)
+- [Patagonia](http://www.avantlink.com/click.php?tt=ml&ti=45781&pw=68025)
+
+#### Network
+
+- [Trail Forums](http://www.trailforums.com/)
+- Trail News
+
+#### About Us
+
+- [Contact](https://www.trailjournals.com/about/contact)
+- [Donate](https://www.trailjournals.com/about/donate)
+- [Join](https://www.trailjournals.com/join)
+- [Login](https://www.trailjournals.com/user/login)
+- [Help](https://www.trailjournals.com/help)
+
+#### Follow Us
+
+- [Facebook](https://www.facebook.com/trailjournals)
+- [Instagram](https://instagram.com/trailjournals/)
+- [Twitter](https://twitter.com/trailjournals)
+- [Pinterest](https://www.pinterest.com/trailjournals/)
+- [Linkedin](https://www.linkedin.com/company/trailjournals-llc)
+
+Top Photo © Cindy - The Appalachian Trail,
+04/01/2002 by
+[MrsGorp](https://www.trailjournals.com/journal/569)
+
+Trailjournals LLC © 2026
+All Rights Reserved. [privacy policy](https://www.trailjournals.com/about/privacy)
+
+Newburyport, MA 01950
+
+[Terms under which this service is provided to you.](https://www.trailjournals.com/about/privacy)
+
+Build: 20210226:165913 [Manage Settings](https://www.trailjournals.com/about/settings)
+---
+
+# Friday, April 23, 2010 — Bear's Den Hostel
+**Start Location:** Dick's Dome Shelter
+**Miles Today:** 18.30
+**Trip Miles:** 989.80
+
+Toggle navigation[Trail Journals](https://www.trailjournals.com/)
+
+- [Journals](https://www.trailjournals.com/journal/entry/306446#)  - [Journals](https://www.trailjournals.com/journals)
+  - [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail/2026)
+  - [Pacific Crest Trail](https://www.trailjournals.com/journals/pacific_crest_trail/2026)
+  - [Colorado Trail](https://www.trailjournals.com/journals/colorado_trail/2026)
+  - [Continental Divide Trail](https://www.trailjournals.com/journals/continental_divide_trail/2026)
+  - [Long Trail - Vermont](https://www.trailjournals.com/journals/the_long_trail_-_vermont/2026)
+  - [Florida Trail](https://www.trailjournals.com/journals/the_florida_trail/2026)
+  - [Arizona Trail](https://www.trailjournals.com/journals/arizona_trail/2026)
+  - [John Muir Trail](https://www.trailjournals.com/journals/john_muir_trail/2026)
+  - [Camino de Santiago](https://www.trailjournals.com/journals/camino_de_santiago/2026)
+  - [American Discovery Trail](https://www.trailjournals.com/journals/american_discovery_trail/2026)
+  - [Coast to Coast Walk](https://www.trailjournals.com/journals/coast_to_coast_walk/2026)
+  - [More...](https://www.trailjournals.com/journals/)
+- [Trails](https://www.trailjournals.com/trails/)
+- [Photos](https://www.trailjournals.com/photos/2026)
+- [Gear](https://www.trailjournals.com/journal/entry/306446#)  - [Current Sales](https://www.trailjournals.com/gear/deals/onsale)
+  - [REI](https://www.trailjournals.com/gear/rei)
+  - [ULA](https://www.trailjournals.com/gear/ula)
+  - [Patagonia](https://www.trailjournals.com/gear/patagonia)
+  - [Cabela's](https://www.trailjournals.com/gear/cabela)
+- [Planning](https://www.trailjournals.com/journal/entry/306446#)  - [Plan Your Hike](https://www.trailjournals.com/planning/)
+  - [Gear](https://www.trailjournals.com/gear/)
+  - [Books](https://www.trailjournals.com/books/)
+  - [Links](https://www.trailjournals.com/links/)
+- [Search](https://www.trailjournals.com/search/)
+- [About](https://www.trailjournals.com/journal/entry/306446#)  - [About Trailjournals](https://www.trailjournals.com/about/)
+  - [Login](https://www.trailjournals.com/user/login)
+  - [Join](https://www.trailjournals.com/join)
+  - [Support Trailjournals](https://www.trailjournals.com/about/donate/)
+  - [Contact](https://www.trailjournals.com/about/contact)
+  - [Store](https://www.trailjournals.com/store/)
+
+Backpacking Journals and Photos from Long Distance Hikers
+
+1. [Home](https://www.trailjournals.com/)
+2. [Journals](https://www.trailjournals.com/journals)
+3. [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail)
+4. [2010](https://www.trailjournals.com/journals/appalachian_trail/2010)
+5. [Uncle Frank](https://www.trailjournals.com/journal/10467)
+6. [Entries](https://www.trailjournals.com/journal/entries/10467/uncle%20-frank)
+7. April 23, 2010
+
+Toggle navigation
+
+- [Journal](https://www.trailjournals.com/journal/10467)
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+- [My Journals](https://www.trailjournals.com/myjournals/10467)
+- [View Guest Book](https://www.trailjournals.com/journal/guestbook/10467)
+- [Sign Guest Book](https://www.trailjournals.com/journal/guestbook/sign/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/8a.gif)
+
+[Journal](https://www.trailjournals.com/journal/10467)
+
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+
+--Choose--01/21/1002/06/1002/07/1002/08/1002/09/1002/10/1002/11/1002/12/1002/13/1002/14/1002/15/1002/16/1002/17/1002/18/1002/19/1002/20/1002/21/1002/22/1002/23/1002/24/1002/25/1002/26/1002/27/1002/28/1003/01/1003/02/1003/03/1003/04/1003/05/1003/06/1003/07/1003/08/1003/09/1003/11/1003/12/1003/13/1003/14/1003/15/1003/16/1003/17/1003/18/1003/19/1003/20/1003/21/1003/24/1003/25/1003/26/1003/27/1003/28/1003/29/1003/30/1003/31/1004/01/1004/02/1004/03/1004/04/1004/05/1004/06/1004/07/1004/08/1004/09/1004/10/1004/11/1004/12/1004/13/1004/14/1004/15/1004/16/1004/17/1004/18/1004/19/1004/20/1004/21/1004/23/1004/24/1004/25/1004/26/1004/27/1004/28/1004/29/1004/30/1005/01/1005/02/1005/03/1005/04/1005/05/1005/06/1005/07/1005/08/1005/09/1005/10/1005/11/1005/12/1005/13/1005/14/1005/15/1005/16/1005/17/1005/18/1005/19/1005/20/1005/21/1005/22/1005/23/1005/24/1005/25/1005/26/1005/27/1005/28/1005/29/1005/30/1005/31/1006/01/1006/02/1006/03/1006/04/1006/05/1006/06/1006/07/1006/08/1006/09/1006/10/1006/11/1006/12/1006/13/1006/14/1006/15/1006/16/1006/17/1006/18/1006/19/1006/20/1006/21/10
+
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+
+Guest Book
+
+- [Sign](https://www.trailjournals.com/journal/guestbook/sign/10467)
+- [View](https://www.trailjournals.com/journal/guestbook/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/8a.gif)
+
+- [AT Journals](https://www.trailjournals.com/journals/appalachian_trail)
+- [AT Photos](https://www.trailjournals.com/photos/appalachian_trail)
+- [AT Books](https://www.trailjournals.com/books/appalachian_trail)
+- [Appalachian Trail](http://www.appalachiantrail.org/)
+
+[Join](https://www.trailjournals.com/join) [Login](https://www.trailjournals.com/user/login)
+
+[RSS](https://www.trailjournals.com/journal/rss/10467/xml)
+
+# Uncle Frank's 2010  Appalachian Trail Journal
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/306443) [Next](https://www.trailjournals.com/journal/entry/307855) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+Friday, April 23, 2010
+
+Destination:Bear's Den Hostel
+
+Today's Miles:18.30
+
+Start Location:Dick's Dome Shelter
+
+Trip Miles:989.80
+
+Destination:Bear's Den Hostel
+
+Start Location:Dick's Dome Shelter
+
+Today's Miles:18.30
+
+Trip Miles:989.80
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/306443) [Next](https://www.trailjournals.com/journal/entry/307855) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+### Hiker Entries April 23, 2010
+
+|  | Journalist | Destination | Trail |
+| --- | --- | --- | --- |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DriveThruHikers_23038TN.jpg) | [Drive Thru Hikers](https://www.trailjournals.com/journal/about/23038) | [Pa 72, Swatara Gap](https://www.trailjournals.com/journal/entry/599583) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Transient](https://www.trailjournals.com/journal/about/13775) | [Lake Moreno](https://www.trailjournals.com/journal/entry/380532) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+|  | [RuhRoh](https://www.trailjournals.com/journal/about/13023) | [Harpers Ferry](https://www.trailjournals.com/journal/entry/366122) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010BigDaddy_5653TN.jpg) | [Big Daddy](https://www.trailjournals.com/journal/about/5653) | [Frazier Discovery trail](https://www.trailjournals.com/journal/entry/352581) | [Camino de Portugues](https://www.trailjournals.com/journals/Camino%20_de%20_Portugues) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2007IPOD_5637TN.jpg) | [IPOD](https://www.trailjournals.com/journal/about/5637) | [Frazier Discovery Trail](https://www.trailjournals.com/journal/entry/350441) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DidgeridudeandDoodlebug_9852TN.jpg) | [Didgeridude and Doodlebug](https://www.trailjournals.com/journal/about/9852) | [Unaka mtn](https://www.trailjournals.com/journal/entry/334637) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2014Sundance_6768TN.jpg) | [Sundance](https://www.trailjournals.com/journal/about/6768) | [Erwin TN](https://www.trailjournals.com/journal/entry/333763) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DannyGrady_10127TN.jpg) | [Teen Wolf](https://www.trailjournals.com/journal/about/10127) | [\-\- View Entry --](https://www.trailjournals.com/journal/entry/333586) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010EUREKA!_10324TN.jpg) | [Jerry from Kentucky](https://www.trailjournals.com/journal/about/10324) | [Beauty Spot](https://www.trailjournals.com/journal/entry/333258) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Conservation Branch Trail](https://www.trailjournals.com/journal/about/11319) | [Darien Lake Lean-to (Darien Lakes State Park)](https://www.trailjournals.com/journal/entry/332311) | [Finger Lakes Trail](https://www.trailjournals.com/journals/Finger%20_Lakes%20_Trail) |
+| [More...](https://www.trailjournals.com/entries/2010/04/23) [Grouped By Trail...](https://www.trailjournals.com/entries/2010/04/23/trail) |
+
+|     |
+| --- |
+| It's amazing while you sit home planning your hike and all the logistics that go with it. You start forming these images in your head of how the towns you will be walking through will look like or how the trail meanders through the mountains.<br>Boy was I off base... Pretty much just the opposite of what I envisioned.... <br>[Goliath](https://www.trailjournals.com/journal/entry/517326) —<br>[Pacific Crest Trail](https://www.trailjournals.com/journals/pacific_crest_trail) [2018](https://www.trailjournals.com/journals/pacific_crest_trail/2018) |
+
+[![Trailjournals](https://www.trailjournals.com/images/logo.png)](https://www.trailjournals.com/)
+
+#### Hiking
+
+- [Trails](https://www.trailjournals.com/trails/list)
+- [Journals](https://www.trailjournals.com/journals)
+- [Photos](https://www.trailjournals.com/photos)
+- [Calendar](https://www.trailjournals.com/calendar)
+- Gear
+- [Links](https://www.trailjournals.com/links)
+
+#### Partners
+
+- [ULA Equipment](https://ula-equipment.sjv.io/drN9K)
+- [REI](http://www.avantlink.com/click.php?tt=ml&ti=45265&pw=68025)
+- [Patagonia](http://www.avantlink.com/click.php?tt=ml&ti=45781&pw=68025)
+
+#### Network
+
+- [Trail Forums](http://www.trailforums.com/)
+- Trail News
+
+#### About Us
+
+- [Contact](https://www.trailjournals.com/about/contact)
+- [Donate](https://www.trailjournals.com/about/donate)
+- [Join](https://www.trailjournals.com/join)
+- [Login](https://www.trailjournals.com/user/login)
+- [Help](https://www.trailjournals.com/help)
+
+#### Follow Us
+
+- [Facebook](https://www.facebook.com/trailjournals)
+- [Instagram](https://instagram.com/trailjournals/)
+- [Twitter](https://twitter.com/trailjournals)
+- [Pinterest](https://www.pinterest.com/trailjournals/)
+- [Linkedin](https://www.linkedin.com/company/trailjournals-llc)
+
+Top Photo © Cindy - The Appalachian Trail,
+04/01/2002 by
+[MrsGorp](https://www.trailjournals.com/journal/569)
+
+Trailjournals LLC © 2026
+All Rights Reserved. [privacy policy](https://www.trailjournals.com/about/privacy)
+
+Newburyport, MA 01950
+
+[Terms under which this service is provided to you.](https://www.trailjournals.com/about/privacy)
+
+Build: 20210226:165913 [Manage Settings](https://www.trailjournals.com/about/settings)
+---
+
+# Saturday, April 24, 2010 — Blackburn Trail Center
+**Start Location:** Bear's Den Hostel
+**Miles Today:** 8
+**Trip Miles:** 997.80
+
+It was raining when I left the gazebo at Bear's Den. Several miles into the last leg of the "Roller Coaster", I hid from the wind and crawled under a slab of stone for a nap. I woke up feeling discouraged and angry. I planned on meeting Sean in Harper's Ferry that day (18 miles), but a mid-day stop at Blackburn Trail Center became my stop for the night. Here's why: Cold, hungry and above all immensely bored of walking (to the point of anger), I arrived at Blackburn after a measely 8 miles from Bear's Den. The the door a lady loaded groceries from the car trunk, and I offered a hand. Rita was a long-time ATC employee who now works with local schoolteachers to incorporate the Appalachian Trail into the curriculum. That very moment, a high school group was hiking towards the Trail Center for an end-of-semester field trip. They would hike in, spend the night, and hike out the next day. Rita was unloading groceries to feed the group, and she tried convince me to stay for dinner while feeding me strawberries, cheese, and salad greens. The kids would love to meet a thru-hiker, she said. Her food bribe worked and I called Sean to change plans.
+
+Sean arrived around dusk and we ate with the group. After dinner, we drove to Harper's Ferry and skateboarded around town and drank beer by the railroad tracks. A train flattened a penny and I decided I'd carry it the rest of the way to Maine. On the way home we did some doughnuts in a field and stopped to shoot pellets at empty cans.
+
+It was a great night, and I really appreciated all the energy Sean brought into a phase in my hike which, at the moment, was feeling pretty drab.
+---
+
+# Sunday, April 25, 2010 — Harper's Ferry Hostel
+**Start Location:** Blackburn Trail Center
+**Miles Today:** 12.50
+**Trip Miles:** 1010.30
+
+Sean and I slept in the car that night. We got up, yogi-ed from pineapple juice and scrambled eggs from the high school group. By 9 o'clock we were hiking on the AT to a gap 5 miles away, where a parent chaperone kindly agreed to shuttle Sean's car. Sean and had some good conversation, which honestly we don't do much of. When I'm with Sean it's alot of action and not alot of idle chit-chat, but a causual hike was a good combination of the two.
+
+For the first time in the trip, I decided to skip a 7-mile section from the road to Harper's Ferry, so Sean and I drove into town to eat and drop me off at the hostel for the night. A quick disclaimer on the trail-skipping: First of all, I ended up going back that day and hiking the section, so I didn't end up skipping any miles. It was less guilt than boredom that led me to hitch back to the trail (after a thousand miles my trail-morals are going gray). I just didn't feel like sitting around the hostel until the owner returned.
+
+Well, the rest of the hike was nice. I trail-ran most of the way (with no food my pack was light as a feather), stopping every couple minutes to listen to the thunder of a a swift-approaching thunderstorm. At the Potomac River I yipped and yelled and danced across the bridge. Cars honked at me and I honked back. I was excited because Harper's Ferry was the half-way point, and I was crossing into it. One of those trip milestones.
+
+At Harper's Ferry the storm hit. I still had 4 miles to cover, including a time-consuming stop to register as a "thru-hiker" at the Appalachian Trail Conservancy HQ. I chatted with lady at the AT HQ and decided that, though she was maybe 40, I would have asked her on a date had the time been right. Nomads don't go on dates.
+
+Lightning exploded overhead and torrential rain came rushing down the old stone steps into downtown Harper's Ferry (the trail passes right through town). I thought about the probability of being struck and decided it wasn't high enough to warrant a stop, so I kept hiking towards the hostel.
+
+The storm cleared and I arrived at the hostel at dusk. I sure do love a post-storm evening, when the air smells like rain and lightening and the birds aren't sure if they should come back out or call it for the night. At the hostel I tore into a maildrop and chowed on a bag of home-made muffins (THANKS MA!!!). I greeted Kevin, my Smoky-Mountains hiking partner, after nearly 2 months of separation. Pancakes were free, so I cooked a couple before bed. Kevin, Muffin-Mit and I planned to hike 40 miles the next day (a.k.a. the Maryland Challenge, where hikers enter Maryland from W.Va and leave it into Penn. in the same 40-mile day.).
+---
+
+# Monday, April 26, 2010 — Pine Knob Shelter
+**Start Location:** Harper's Ferry Hostel
+**Miles Today:** 22.90
+**Trip Miles:** 1033.20
+
+A rainy day and lonely hike to Pine Knob. Failed the Maryland Challenege thanks to a big pancake breakfast, a late start, and a steady, disheartening downpour throughout the day. Talked to myself in Spanish and a New Zealand accent for several hours out of boredom. Spent an hour in a shelter writing a rap song while the lightening passed. Got the Pine Knob in the dark.
+---
+
+# Tuesday, April 27, 2010 — near Devil's Racecourse Shelter
+**Start Location:** Pine Knob Shelter
+**Miles Today:** 13.10
+**Trip Miles:** 1046.30
+
+A really crappy day. I'd been excited at the hostel to run into two fellow thru-hikers (I was desperate for some company for motivation), but one was already a day ahead and another a day behind. I was alone again, and it had it's effects. I trudged along all day, eating way too much food and covering way too few miles. I stopped at the trailhead leading to Devil's Racecourse Shelter and didn't even have the motivation to walk the 0.3 miles to the shelter itself, so I rolled out my sleeping bag right there and fell asleep for the night. What a bad day.
+---
+
+# Wednesday, April 28, 2010 — Tumbling Run Shelters
+**Start Location:** near Devil's Racecourse Shelter
+**Miles Today:** 13.20
+**Trip Miles:** 1059.50
+
+Met up with the Georgia boys today. Like a dream-come-true, the caught up to me near the Pennsylvania-Maryland border as I stood on the railroad tracks looking dazed and confused (which I was). An hour before, I'd curled up in a bathroom in a park and awoken to a old man poking me with his trash-picker. "Wake up! What are you doing here," he demanded. I told him the wind was cold and I was a tired hiker, and he told me to fetch some fried chicken and a half-drinken bottle of lemonade. I had a piece left, and I gave it to the Georgia boys to split. Reckless and Boomerang were they're names, and I let out a sigh of relief: I'd found some good hiking partners at last.
+
+We hiked to the Tumbling Run Shelters that night, only a 13 mile day for me but a 26 mile day for them. There were two shelters, one for "SNORING" and the other labeled "NON-SNORING". Boomerang carries a guitar, so he played an old Texas tune as I drifted to sleep. I slept outside the shelter on the picnic table and woke up to some brilliant stars.
+---
+
+# Thursday, April 29, 2010 — Tom's Run Shelters
+**Start Location:** Tumbling Run Shelters
+**Miles Today:** 25.80
+**Trip Miles:** 1085.30
+
+A good day with the Georgia boys. I left early and hiked the first 10 miles alone, and at noon we met up and hiked together for the last 16 miles. During our lunchbreak, we bummmed fresh milk, carrots, bananas, and pretzels off a state-sponsored pre-school group that had extra. "They give us way too much food," said the chaperone. A black girl about our age swatted at gnats and asked us how we'd spend 2 months in the woods. "I'm like...\*swat\*...like I can't stand it out here!," she said. We laughed. We talked about how much we'd like to see a pretty girl, and Reckless produced a zip-lock back. He showed us a photo of his pretty girlfriend and unzipped the bag to let us smell the contents, a perfumed-scented letter from her. He smiled proudly.
+
+We made it to the shelter in good time that night, and I boiled water over the fire with my pot. I was hungry and out of food (thanks to gorging 2 days before), and I went to bed with my stomach growling. The next morning, we planned to pass the official halfway point of the AT (Milepost 1089.55) and continue three miles into Pine Furnace State Park to accomplish the "Half-Gallon Challenge". As tradition goes, thru-hikers mark the mid-point by consuming an absurd amount of ice-cream.
+
+"I'm listening to Boomerang sing 'Ain't Never Gonna Be Satisfied' on his guitar, and I'm thinking about the 1/2 Gallon Challenge tomorrow and wondering how true that is," said my entry into the shelter logbook.
+---
+
+# Friday, April 30, 2010 — north of Boiling Springs
+**Start Location:** Tom's Run Shelters
+**Miles Today:** 27.80
+**Trip Miles:** 1113.10
+
+A good hard day of hiking. After waiting around until noon for the owner of the general store, we abandoned the "1/2 Gallon Challenge" and started hiking. For nearly 7 hours we hiked hard, racing across the 22 miles to Boiling Springs. I was ahead of the Georgia Boys by an hour, and I met up with a couple at Boiling Springs and they invited me for a picnic. Fresh flatbread with roastbeef, cheese and mustard, triscuts with hummus, grapes and an apple, fig-newtons, and several cups of fruit juice! I thanked them and moved on around sunset. This area, called the Cumberland Gap, was the first break in mountains on the AT. The Georgia Boys stayed in town, but I ambled along into the night down narrow corridors of woods between huge corn fields. I stopped to watch a big fireworks show by some locals. I slept in a field under the moon and stars. Tomorrow, I'd meet up with my dad.
+---
+
+# Saturday, May 01, 2010 — Red Roof Inn (Duncannon, PA)
+**Start Location:** north of Boiling Springs
+**Miles Today:** 20.70
+**Trip Miles:** 1133.80
+
+Hiked relentlessly through the heat to meet my Dad at the gap by noon. Stopped to get some water from a farm hose and a cyclist rode by and said, "You're not going to get there by sitting here!". Thanks, man.
+
+From the shade I saw a day-hiker walk by. Yes! The motivation of company! I followed behind the day-hiker, a local lawyer, to ride out my exhaustion. Several miles from the gap, I took off running and made it just as my Dad pulled up. We hugged, laughed, high-fived, and hugged again. It was good to feel back home again, even it I was in Pennslyvania.
+
+The rest of the hike was only 10 miles, but I was struggling. The sprint to meet my Dad had bruised my feet, so I was in alot of pain as we climbed the last ridge before Duncannon. It was great being with Dad, however. His dry humor and lemonade-out-of-lemons attitude really kept me going. He also got to see me feeling crappy and how I dealt with it, which I appreciated. Now he knows.
+
+We limped into town and got Gatorades, and it was the best-tasting Gatorate I've ever had. Maybe it was the heat, maybe it was the hunger, but I swear it was the best Gatorade I've ever had. We got to his car, and ate Mom's blond-brownies on the way to the hotel. That night we went to an Italian resaurant to eat. I had an AWESOME grilled salmon. We got coffee afterwards, bought some atheletic shorts and new socks, and hung out at the bookstore until 11. I stayed up until 2:30 getting my iPod all "synced". That's right, Ford Prior has let an iPod infiltrate his pure, all-natural AT "vision-quest". Let me just say this: it's necessity, okay? I'm about to die of boredome here. The other day I told a lady I was bored out of my mind and she said, "How do you get bored of these beautiful woods?!" I bit my tongue but wished to say, "Listen, lady: YOU hike 1,000+ miles and then come talk to me."
+
+I took my sleeping medicine for the first time in 2+ weeks and I slept great that night.
+---
+
+# Sunday, May 02, 2010 — Peters Mountain Shelter
+**Start Location:** Red Roof Inn (Duncannon, PA)
+**Miles Today:** 11.20
+**Trip Miles:** 1145
+
+I woke up early, about 6:30, and was stirring around. Dad got up quick like he always used to do, looking in need of a cup of coffee yet somehow also ready for the day. I love waking up with Dad. It reminds me of getting up at sunrise with him at the beach and taking long walks along the surf.
+
+Dad went and got some coffee while I packed up my things. We got in the car and drove to Cracker Barrel. I had 2 eggs, 2 slices of bacon, and 2 pancakes logged with maple syrup. We laughed and joked around.
+
+Next we drove to the grocery. I needed a resupply, and so Dad and I walked the aisles with a 4-day food plan written on a wrinkled notepad. It was a surprisingly tedious and consequently stressful affair. Each item's location in the store had nothing to do with the other items' locations. No easy A,B,C, arrangement; no map to follow; few employees to show the way. I left the grocery feeling wound up and taking a deep breath.
+
+It was 11:00 am. I was to hit the trail at 2:30, so Dad and I spend the next couple hours lounging at the bookstore. He patiently read a book while I updated my journal and drank coffee. Outside, the clouds looked ominous; heavy rains were fore casted for the afternoon. For an hour or two we hung out in the bookstore. I wish we could've chatted and played putt-putt or something.
+
+It was time to part ways, and I could feel in my stomach. We got 5 Guys for lunch and drove back to Duncannon. I hated it, sitting there about to leave, taping my feet and packing my pack with Dad right there. "Wanna get a beer?" I pleaded. No, he said. I had to get going. We hugged and I said "Damn it" and shook my head. It really sucked, and I kept shaking my head as I turned and walked off. Too bad I had to go my way and he had to go his. Too bad we couldn't of just gone together. I love my Dad, man. I've said it before and I'll say it again: he's my best friend.
+
+It was 4:00 PM and I waited for the downpour. Skies were gloomy and loaded with wetness. For 11 miles I walked with ease, listening to a Fleet Foxes album and a Corey Widmer sermon about wisdom. "The sages of Proverbs say that there are two paths before us: the path of Life and the path of Death," he said. He said our walk is a crooked march for Life that always draws like a magnet towards the path of Death. As we stumble between the two paths, we're confronted by situations that confuse us. These situations are entirely unique. They're unhelped by extensive self-help knowledge and generally-accepted tricks and unhelped by an understanding of black-and-white lines of morality. That is, these situations need WISDOM from above because Self-Help books and the 10 Commandments don't cut it. He mentioned that wisdom is a path to follow, not just some door to open. I took off my iPod and decided to listen to the birds (a little wiser, eh?).
+
+The rain held off on me all the way to the shelter. Only at the very end did it come down. At the shelter I met up with Reckless and Boomerang, including 2 flip-floppers and another thru-hiker named Muffin-Mittens. I broke out the banana bread from Mom and everyone dug in.
+
+The rain came down hard that night, and I filled up my water bottle with brown-tinted rainwater pouring from the gutters. Unhealthy? Most likely.
+---
+
+# Monday, May 03, 2010 — Rausch Gap Shelter
+**Start Location:** Peters Mountain Shelter
+**Miles Today:** 18
+**Trip Miles:** 1163
+
+Oh, what a day. I left before 7am, while the rest were still asleep. The rain was gone but the forest was dripping and moist, and sharp-toothed gnats swarmed my face (these gnats are a bold species, unafraid to kamakazi into the ears and eyes). For some reason I was very tired, so I covered myself with a poncho and laid down for a nap nearly 10 miles into the day. I got up again, and again was overwhelmed with sleepiness. By mid-morning the last of the northbound pack passed me. I woke up and tried to catch up but still fatigue struck me down. Let me say here that it's times like these that I hate my narcolepsy; it's times like these that if feels like a real disability. I don't get angry at it. I just feel wronged by it sometimes.
+
+After my 3rd nap, I woke up and began walking. If I walked fast enough, I'd catch the group taking their lunchbreak. Well, I walked in the wrong direction...for 1.5 hours. I ran into Sampson (the flip-flopper), who I thought had passed me. "Hey man, did you turn around?" I said, quickly realizing by his face that something was amiss. "You're not heading North, are you?". He affirmed. I cursed aloud several times in front of Sampson, thanked him, and turned around. I cursed again and again. Between 6 and 8 miles lost. I was very angry. Rain showers came and went.
+
+Just before sundown I arrived at Rausch Gap Shelter. Sampson was there (he passed me during another nap) with another flip-flopper named Rewind. I ate and put up my feet. It would be another 14 miles to catch the others, and 14 miles meant a long night of hiking. HYOH (Hike Your Own Hike), I said to myself: I just didn't feel like moving along. It was a bad day and it felt better at the shelter. Happily, I shucked off the guilt of not hiking on and settled down for the night. That decision redeemed my day. By the way, Rausch Gap Shelter is awesome. Someone built a spring-fed retangular dish that constantly overflows with cold water. That night I slept great.
+---
+
+# Tuesday, May 04, 2010 — The Pavilion (Port Clinton, PA)
+**Start Location:** Rausch Gap Shelter
+**Miles Today:** 42
+**Trip Miles:** 1205
+
+That's right: 42 miles! Hard to believe but here it goes:
+
+It all started with a fresh start at sunrise. At the shelter the orange sun broke through the green canopy. The air was moist and filled with energy. I hit the trail at 6:45 and listened to my iPod for about an hour while munching on Muenster cheese. I stopped under an overpass for a 40-minute nap at about 9:15 am. An hour later, I had to throw my pack over a deep stream and leap over (kinda fun). For the 13 miles between my nap and the shelter I felt great. It was about noon, and I decided that I'd catch up that night. 42 was a big number, but I didn't really think about that. I just decided to go and went.
+
+At the 501 Shelter I found some instant coffee mix and shook up at water bottle of extremely-strong brew, probably as powerful as an espresso. I ate sunflower seeds and sipped on the potion as I march on. No foot or joint problems, no debilitating sleepiness. I felt strong as a bull. I never listened to my iPod. I was fine without it, rather enjoying rapping to myself with surprising flow (I'm secretly convinced that I could be a rapper if I tried). A strange isolated storm blew up from nowhere and narrowly missed me.
+
+It was almost dusk and I was about 16 miles from Port Clinton. I found myself staring at the sky at a road crossing, and suddenly an SUV came speeding akwardly towards me IN REVERSE. The car had slammed on the brakes and reversed back up to meet, and an Amish-looking bearded man rolled down the window. "You thru-hiking?" I said yes. "How does a fresh hot meal sound?". "Ahhhhh," I said, "I'm kinda on a time schedule. It's already going to be a late night." Then I paused and thought: you know, this may never happen again. Meanwhile, his son stared awkwardly. "You now what, screw it man! I'd love a hot meal." I hopped in.
+
+His name was Longnecker, and this was "Longnecker Country," he said. Sure enough, we passed his brother's house, his father's house, his sister's house, and the homes of several other family members on the way to Longnecker's place. It sat on the hilltop with a beautiful view of the valley. He had an enormous family, I guess a tradition of the Church of the Bretheren. I waded through kids to get from the car to the front door--actually, they kind of parted for me and stared curiously as I walked through. Upon entering the house (of modest size, I should note), Longnecker told his wife that "I've brought home a hiker! Can you hurry up? He needs to get back to the trail." She was a kind woman. Before dinner, I sat on the couch and talked to Longnecker. At least 10 kids surrounded us and listened quietly. At dinner call we all seated ourselves around a large table. Enchiladas, a salad, cookies, and a glass of milk was the dinner, and it was DELICIOUS. Everyone (even both parents), dipped their cookies in the milk. In fact, the mother even broke up a cookie for the smallest child and dipped it in for her! I thought that was interesting. A "thank you" and back to the trail.
+For the first hour I listened to the iPod, but soon darkness fell and I put it away (the night always makes me paranoid). It was a long and hard 16 miles but at last it was over. I trudged proudly into the shelter at 12:30 AM and collapsed. My feet were in bad shape, which I only realized after stopping for several minutes. The skin was white and blisters blood-red. I looked in the trashcan: three half-empty ice cream containers told me the boys had attempted the "Half-Gallon Challenge" and failed miserably. I polished off a box of cookie dough and fell asleep.
+---
+
+# Wednesday, May 05, 2010 — Allentown Hiking Club Shelter
+**Start Location:** The Pavilion (Port Clinton, PA)
+**Miles Today:** 22.60
+**Trip Miles:** 1227.60
+
+In the morning my feet were really feeling the 42 miles from the day (night) before. My legs, too. We took a late start and walked over to 3 C's Diner for some pancakes and eggs. By 11:30 we left Port Clinton for Allentown, only 23 miles away.
+
+I napped at the first shelter and everyone passed me (as usual). I wasn't concerned by being behind, and lounged at the shelter for over an hour. The rest of the day was nice and kind of boring. You know, I'm kinda getting used to these long boring days in the sunlight. The gnats were obnoxious and I did get immensely bored with myself, but overall it wasn't so bad. I didn't even listen to the iPod much. I saw a couple day-hikers but not many people. The terrain was mild. For the last 2 hours I listened to the Lewis & Clark audiobook (Undaunted Courage), but at nightfall I cut it off. For 30 minutes I walked over sharp stones in near-darkness, impressed with my own depth-perception in dim light. When I saw the shelter I almost giggled with joy. I joked with the boys and ate some jerky before falling asleep. I woke up and ate some more nibbles.
+---
+
+# Thursday, May 06, 2010 — The Jailhouse Hostel (Palmerton, PA)
+**Start Location:** Allentown Hiking Club Shelter
+**Miles Today:** 18
+**Trip Miles:** 1245.60
+
+Not a bad day (it's funny how negativity is the standard...that is, a day is expected to be bad and it's worth noting if it's not). I hiked alone until I got tired of hiking alone, then waited for the others to catch up. For the rest of the day we all hiked together, talking and laughing and stopping at a shelter for lunch. On the way down to Palmerton, Boomerang fell hard with his 45 lbs. pack and busted his knee, so I gave him 6 ibuprofen and carried his pack the rest of the 8 miles into town. I parted wit the boys and hitched to the Fine Lodge in Slatington to grab a mail-drop. We'd meet in Palmerton that evening. It was 4:00. My ride was a boisterous dad with black sunglasses and a black sleeveless t-shirt driving a big shiny black SUV. He had two sons and was a big Steelers fan. The Fine Lodge was a strange place. Disheveled people milled about listlessly, and I wondered where they were headed in life. I waited about 45 minutes for the proprietor to give me a free ride to Palmerton, and ate all my Mom's brownies.
+
+I dropped my pack in the hostel (the basement of the Police Station) and walked out to find the boys. I questioned some old ladies about their whereabouts ("I think they passed by. No they didn't. Wait, they did!"), a waitress who gave me a dirty look, a weird guy walking around with his shirt off, and several mentally-retarded guys sitting on a park bench (they couldn't really communicate, but I talked to them like they weren't disabled at all. I think ignoring their disability is the greatest gift a stranger can give the disabled) It was a strange town. I found the boys at a Pizza place. A guy pestered us and interrupted our conversation with stupid questions about hiking, and I told him I carried a pistol at all times.
+
+That night I took a shower and slept alright. A flip-flopper named Biff was snoring terribly and keeping all of us awake (we were having a conversation about how bad it was as Biff snored on), so I woke him up and asked him to roll over. That did it and the rest of the night was soundless.
+---
+
+# Friday, May 07, 2010 — Kirkridge Shelter
+**Start Location:** The Jailhouse Hostel (Palmerton, PA)
+**Miles Today:** 29.80
+**Trip Miles:** 1275.40
+
+I had an early breakfast of a Farmer's Omelet at the diner before Duane the Pest Control Man shuttled us back to the trail head. The first ascent of the day as a near-vertical rock climb. Shocked my the ridiculous angle, Reckless paused to take a photo of me. We'd switched iPods because he wanted to hear the Into Thin Air audiobook. The next 8 miles traversed a mountainside leveled for zinc-mining many years before and still classified as a Superfund Site. It was strangely open and grassy and, in fact, prettier than the rest of PA. Several hours of fast and strong hiking brought us (Reckless, Boomerang, Muffin Mittens and I) to a grassy spot in the woods. I had a good conversation with Muffin Mittens about his 6 years of service in the U.S. Army. I took a nap and the group moved on.
+
+The naps multiplied as often do, and soon I was hours behind the group. I just didn't care. I made it to the shelter after a long and obnoxious night hike through some of the worst rocky sections we'd yet crossed. My feet were killing me.
+
+Oh yea! And tonight we caught up with Fahma and Klipspringer. More on that later, but for tonight I slept well.
+---
+
+# Saturday, May 08, 2010 — Church of the Mountain Hostel (Delaware-Water Gap)
+**Start Location:** Kirkridge Shelter
+**Miles Today:** 6.50
+**Trip Miles:** 1281.90
+
+Our "near-o" day. Late start, time alone at shelter, sunny walk down to town, Ben & Jerry's Pint, beer and pizza, pie and hotdog, homemade cookies, alot of old hikers, early bedtime
+---
+
+# Sunday, May 09, 2010 — Brink Rd. Shelter
+**Start Location:** Church of the Mountain Hostel (Delaware-Water Gap)
+**Miles Today:** 25
+**Trip Miles:** 1306.90
+
+Breakfast (2 eggs and 2 bacon between 2 slices of Rainsin bread smeared w/ honey), good quick day (I kept up and didn't nap until last 3 miles), MOuntain House w/ water boiled over fire, NO BEARS, 1st Day in NJ ain't bad
+---
+
+# Monday, May 10, 2010 — The Mayor's House (Unionville, NY)
+**Start Location:** Brink Rd. Shelter
+**Miles Today:** 27
+**Trip Miles:** 1333.90
+
+We awoke in the shelter shivering. It had been a cold night, and I was just warm enough to sleep. I didn't want to get out of my bag, but at last I unzipped and jumped to my feet. A quick pack-up and we hit the road to Unionville, some 27 miles away. The first several hours of hiking were pleasant. We stopped at a deli for a breakfast sandwich and coffee, then continued sleepily. Today we talked and joked happily, and the miles passed by quickly. For 2 hours I listened to Guns, Germs, and Steel on audiobook. Before I knew it, we were only 9 miles from Unionville, and Reckless did a commendable job keeping me awake. At one point, he saw I was dragging with sleepiness and screamed as loud as he could. The scream jerked me awake and I was fine for the rest of the day. I owe him one for that.
+
+At the road, the hostel owner picked us up. "If you call me sir one more time I'm gonna hit you," he told Reckless. He was a hilarious guy, hilarious not in a clever way but in a ridiculous way. "We're gonna bust your balls," he said. "You get one free beer and the rest are 50 cents. You must take a shower. Dinner'll be ready soon so get showered quickly." He did a great job of making us feel at home, and that, he said, was his mission: "You see that sign by the door? It says, 'When you leave this home, you are friends.' The last word should be 'brothers,'" he said. He believed strongly in the verse: I am my brother's keeper, and I deeply respected him for it. In return, "We think what you guys are doing is f\*\*\*ing stupid, but we respect you for it," he said. "The Mayor beleives in starting what you finnish."
+
+the old guy cussing, visit to the grocery store, the video of britians got talent, finding out about kevin
+
+It's 2:49 am, I'm dead tired, and the Mayor is getting us up at 6:30 tomorrow so I've got to cut this short. THanks for reading everyone. Until next entry.
+---
+
+# Tuesday, May 11, 2010 — Linden Motel pool house (Greenwood Lake, NY)
+**Start Location:** The Mayor's House (Unionville, NY)
+**Miles Today:** 26.80
+**Trip Miles:** 1360.70
+
+Old Bill, the miserable cursing caretaker at the Mayor's House ("You wanna buy a house? It comes with a dishwasher. His name's Bill," said Butch) woke us up at precisely 6:30 for a breakfast of sausage, eggs and hashbrowns. I drank several cups of strong black coffee and scarfed down the food. Several hours later, Butch was driving us to the trailhead. The morning passed nicely through cool forests and warm fields. Before noon we stopped at a rocky overlook for a 20-minute snack break. We marched on.
+
+As morning passed to afternoon, sleepiness came over me; still, I kept walking. By 4:00 I could barely walk out of weariness. Boomerang and Reckless tried in vain to keep me awake (we'd been hiking together all day), and I say with no exaggeration that it was the most tired I'd ever been. At last I collapsed on the trail for a 10-minute combat nap. The Georgia boys walked on. Within 30 minutes of awakening I caught up to cover the last 8 miles with them. The smooth blue of Greenwood Lake lay down in the valley, looking flat and pure against the patchy green-cottonball mountains. The lake was huge, perfect for sailing.
+Greenwood Village, situated on the lake's shore and .9 miles from the AT, was a nice town. Kids played backyard ball and on playgrounds, filling the evening with the sounds of summer. "I'm feelin' that summer vibe," I told the Georgia boys, "and I like it." A guy gave us a lift to the Chinese Buffet in town, and after eating (I didn't eat much) walked over to the Linden Motel. Anticipating bad weather that night, we had arranged to sleep in the Linden's poolhouse for free. I bought a Snickers bar and went to sleep with knife in hand.
+---
+
+# Wednesday, May 12, 2010 — Fingerboard Shelter
+**Start Location:** Linden Motel pool house (Greenwood Lake, NY)
+**Miles Today:** 16.40
+**Trip Miles:** 1377.10
+
+An Indian man stood at the side of the poolhouse, looking in. I got up to shake his hand and explain our being there. Luckily, it was the same manager who'd OK'd it earlier. We walked over to the gas station and I got a honeybun for breakfast, then walked down to a diner for another breakfast. It was a small pastry shop owned by a spunky middle-aged woman. I watched hwe and her assistant, a teenage girl, joke and carry on behind the counter. I asked them questions about their life and they willingly answered. Customers entered, grabbed their breakfasts-to-go, and exited. One customer stayed to eat, and I got to talking to her. Lisa was a local pet-sitter. As a local, she was very knowledgeable about the area's history and (to my delight) geology. We talked about local attitudes, the Rainbow Coalition, and hitching trains. Boomerang entered and got breakfast next to me. When she left, Lisa picked up both of our $5.00 tabs. She saif "God Bless" and left. Rain fell and the air was cold, and there was a silent consensus between the Georgia boys and I: we would wait a while before hiking.
+Down at the library, I updated my journal and took a nap in a chair. I met Raury, a long-distance runner from Manhattan. He looked like your classic crazy black man bum and plague to the local library, but he spoke articulately like a Harvard scholar. He was big into long-distance running and had completed countless marathons. He offered to give us a ride anywhere we wanted. I took his phone number and walked to the pizza shop to meet the Georgia boys. The prettiest girl in the world was behind the counter. She smiled and asked me about the trip. I thought about her for the rest of the day. I called Raury and he took us to the trailhead. It was drizzling and cold.
+It was already 1:00, a late start out of Greenwood Lakes. We marched 16-some miles into a beautiful state park, scrambling incredible rock faces and passing sleepy lakes. The park was teeming with wildlife--huge woodpeckers darting about, bushy squirrels bounding to trees, muscular deer staring at us, songbirds singing, and a great owl flappig silently away.
+At the shelter, an ancient stone edifice with dual chimneys, we settled down for the night. Night fell and so did I into sleep.
+---
+
+# Thursday, May 13, 2010 — Graymore Spriritual Center
+**Start Location:** Fingerboard Shelter
+**Miles Today:** 21
+**Trip Miles:** 1398.10
+
+Alot of highs today: Hiking in the morning through the state park (a meadowy open forest), hopping a 10-foot barbed-wire fence for water, seeing the zoo at Bear Mountain State Park, talking to the Sisters of Life nuns, getting a 101 lesson from a party of birdwatchers, crossing the Bear Mountain Bridge, drinking a Coors Light tallboy on the trail, talking in Spanish to an Ecuadorian store owner, and SEEING THE NEW YORK CITY SKYLINE! The sight of NYC was, by far, the most awe-inspiring thing I've yet seen. I almost lost my breath, like I'd just seen a miracle performed. I just couldn't beleive it: I simply cannot put into words the feelings I felt then.
+Lows? Getting lost was frusterating (I missed Bear Mountain and crossed several almost-as-high peaks to the east, then hit the 1777 Trail that followed back to the State Park), and that night a queer Southbounder in the shelter snored incessantly.
+---
+
+# Friday, May 14, 2010 — Morgan Steward Shelter
+**Start Location:** Graymore Spriritual Center
+**Miles Today:** 28
+**Trip Miles:** 1426.10
+
+Highs: Hiking with Dave (or Boomerang) for a while, running into a Yale philosophy major with an upcoming fellowship at Cambridge, ENG, the rains cleared up by noon and the sun poured down to redeem the day, chomping into a pizza at the roadside deli, s'mores that night at the shelter (thanks to come guys from West Point).
+Lows: my feet got serious blisters (not bloody but very close), finding Kevin at the shelter (an awkward situation given his denial of some unproven yet highly-probable section-skipping), and laboring to catch up after napping always sucks.
+---
+
+# Saturday, May 15, 2010 — Bill's House (Ridgefield, CT)
+**Start Location:** Morgan Steward Shelter
+**Miles Today:** 22
+**Trip Miles:** 1448.10
+
+Highs: meeting up with Uncle Bill at the day's end was the climax of the day; I enjoyed meeting a group of young Brooklyners who had taken the day off from stressful city life. Seeing those kids really reawoke a nagging desire I have to move to NYC for a short time...it's so magical! The SUNSHINE! brought up the temps and made the day ideal for hiking; I enjoyed trail-running along a gentler trail than the day before; that night, Bill treatd the Georgia boys and I to wings, a reuben, a beer, AND desert at the Corner Pub. Bill also showed us his masterpiece, a year-long garage/workshop/office/guest house he built from scratch.OH YEA!- I saw the biggest oak on the AT! It was a beautiful monster (see the pic I found on the internet...No, that's not me in the photo)
+
+Lows: none to speak of. Honestly, I felt great today. My pack without food and water (its most common state, as I'm carrying only 1-2 days of food these days) is 12 lbs. at most makes the going easy for my joints, muscles, and most of all feet. I skip up hills and run down the backsides. On the contrary, the Georgia boys were hurting as usual (their packs are significantly heavier than mine).
+
+A quick word on the spirit. Like I've said, the weather is dandy these days. The pain and misery has died down, yet so has the volume of the Lord's voice. I just don't hear God anymore like I used to, and I don't know whether to remedy the silence or embrace it for what it is. Maybe he's showed me what he wanted to show me - you know, demonstrated Truth - and now the ball is in MY court. Maybe I'm supposed to activate change. I don't know. But still, though I'm more faithful now thanks to the hardships of winter, I still long for those days. When I could really hear and feel him by my side.
+
+Thanks everyone for reading this journal and for all your support! I'm currently at Mile 1,448 (only 731 from Katahdin!) and still can't beleive I've made it this far. Leave a comment in my "Guest Book"...it says almost 10,000 people have read my journal since last week so I'm kinda curious who exactly these 10,000 people are.
+---
+
+# Sunday, May 16, 2010 — Stewart Hollow Brook Lean-to
+**Start Location:** Bill's House (Ridgefield, CT)
+**Miles Today:** 14
+**Trip Miles:** 1462.10
+
+Toggle navigation[Trail Journals](https://www.trailjournals.com/)
+
+- [Journals](https://www.trailjournals.com/journal/entry/311304#)  - [Journals](https://www.trailjournals.com/journals)
+  - [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail/2026)
+  - [Pacific Crest Trail](https://www.trailjournals.com/journals/pacific_crest_trail/2026)
+  - [Colorado Trail](https://www.trailjournals.com/journals/colorado_trail/2026)
+  - [Continental Divide Trail](https://www.trailjournals.com/journals/continental_divide_trail/2026)
+  - [Long Trail - Vermont](https://www.trailjournals.com/journals/the_long_trail_-_vermont/2026)
+  - [Florida Trail](https://www.trailjournals.com/journals/the_florida_trail/2026)
+  - [Arizona Trail](https://www.trailjournals.com/journals/arizona_trail/2026)
+  - [John Muir Trail](https://www.trailjournals.com/journals/john_muir_trail/2026)
+  - [Camino de Santiago](https://www.trailjournals.com/journals/camino_de_santiago/2026)
+  - [American Discovery Trail](https://www.trailjournals.com/journals/american_discovery_trail/2026)
+  - [Coast to Coast Walk](https://www.trailjournals.com/journals/coast_to_coast_walk/2026)
+  - [More...](https://www.trailjournals.com/journals/)
+- [Trails](https://www.trailjournals.com/trails/)
+- [Photos](https://www.trailjournals.com/photos/2026)
+- [Gear](https://www.trailjournals.com/journal/entry/311304#)  - [Current Sales](https://www.trailjournals.com/gear/deals/onsale)
+  - [REI](https://www.trailjournals.com/gear/rei)
+  - [ULA](https://www.trailjournals.com/gear/ula)
+  - [Patagonia](https://www.trailjournals.com/gear/patagonia)
+  - [Cabela's](https://www.trailjournals.com/gear/cabela)
+- [Planning](https://www.trailjournals.com/journal/entry/311304#)  - [Plan Your Hike](https://www.trailjournals.com/planning/)
+  - [Gear](https://www.trailjournals.com/gear/)
+  - [Books](https://www.trailjournals.com/books/)
+  - [Links](https://www.trailjournals.com/links/)
+- [Search](https://www.trailjournals.com/search/)
+- [About](https://www.trailjournals.com/journal/entry/311304#)  - [About Trailjournals](https://www.trailjournals.com/about/)
+  - [Login](https://www.trailjournals.com/user/login)
+  - [Join](https://www.trailjournals.com/join)
+  - [Support Trailjournals](https://www.trailjournals.com/about/donate/)
+  - [Contact](https://www.trailjournals.com/about/contact)
+  - [Store](https://www.trailjournals.com/store/)
+
+Backpacking Journals and Photos from Long Distance Hikers
+
+1. [Home](https://www.trailjournals.com/)
+2. [Journals](https://www.trailjournals.com/journals)
+3. [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail)
+4. [2010](https://www.trailjournals.com/journals/appalachian_trail/2010)
+5. [Uncle Frank](https://www.trailjournals.com/journal/10467)
+6. [Entries](https://www.trailjournals.com/journal/entries/10467/uncle%20-frank)
+7. May 16, 2010
+
+Toggle navigation
+
+- [Journal](https://www.trailjournals.com/journal/10467)
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+- [My Journals](https://www.trailjournals.com/myjournals/10467)
+- [View Guest Book](https://www.trailjournals.com/journal/guestbook/10467)
+- [Sign Guest Book](https://www.trailjournals.com/journal/guestbook/sign/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/9a.gif)![](https://www.trailjournals.com/images/7a.gif)
+
+[Journal](https://www.trailjournals.com/journal/10467)
+
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+
+--Choose--01/21/1002/06/1002/07/1002/08/1002/09/1002/10/1002/11/1002/12/1002/13/1002/14/1002/15/1002/16/1002/17/1002/18/1002/19/1002/20/1002/21/1002/22/1002/23/1002/24/1002/25/1002/26/1002/27/1002/28/1003/01/1003/02/1003/03/1003/04/1003/05/1003/06/1003/07/1003/08/1003/09/1003/11/1003/12/1003/13/1003/14/1003/15/1003/16/1003/17/1003/18/1003/19/1003/20/1003/21/1003/24/1003/25/1003/26/1003/27/1003/28/1003/29/1003/30/1003/31/1004/01/1004/02/1004/03/1004/04/1004/05/1004/06/1004/07/1004/08/1004/09/1004/10/1004/11/1004/12/1004/13/1004/14/1004/15/1004/16/1004/17/1004/18/1004/19/1004/20/1004/21/1004/23/1004/24/1004/25/1004/26/1004/27/1004/28/1004/29/1004/30/1005/01/1005/02/1005/03/1005/04/1005/05/1005/06/1005/07/1005/08/1005/09/1005/10/1005/11/1005/12/1005/13/1005/14/1005/15/1005/16/1005/17/1005/18/1005/19/1005/20/1005/21/1005/22/1005/23/1005/24/1005/25/1005/26/1005/27/1005/28/1005/29/1005/30/1005/31/1006/01/1006/02/1006/03/1006/04/1006/05/1006/06/1006/07/1006/08/1006/09/1006/10/1006/11/1006/12/1006/13/1006/14/1006/15/1006/16/1006/17/1006/18/1006/19/1006/20/1006/21/10
+
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+
+Guest Book
+
+- [Sign](https://www.trailjournals.com/journal/guestbook/sign/10467)
+- [View](https://www.trailjournals.com/journal/guestbook/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/9a.gif)![](https://www.trailjournals.com/images/7a.gif)
+
+- [AT Journals](https://www.trailjournals.com/journals/appalachian_trail)
+- [AT Photos](https://www.trailjournals.com/photos/appalachian_trail)
+- [AT Books](https://www.trailjournals.com/books/appalachian_trail)
+- [Appalachian Trail](http://www.appalachiantrail.org/)
+
+[Join](https://www.trailjournals.com/join) [Login](https://www.trailjournals.com/user/login)
+
+[RSS](https://www.trailjournals.com/journal/rss/10467/xml)
+
+# Uncle Frank's 2010  Appalachian Trail Journal
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/310335) [Next](https://www.trailjournals.com/journal/entry/311305) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+Sunday, May 16, 2010
+
+Destination:Stewart Hollow Brook Lean-to
+
+Today's Miles:14
+
+Start Location:Bill's House (Ridgefield, CT)
+
+Trip Miles:1462.10
+
+Destination:Stewart Hollow Brook Lean-to
+
+Start Location:Bill's House (Ridgefield, CT)
+
+Today's Miles:14
+
+Trip Miles:1462.10
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/310335) [Next](https://www.trailjournals.com/journal/entry/311305) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+### Hiker Entries May 16, 2010
+
+|  | Journalist | Destination | Trail |
+| --- | --- | --- | --- |
+|  | [Dreams](https://www.trailjournals.com/journal/about/28321) | [Past Fuller Ridge (193.0)](https://www.trailjournals.com/journal/entry/679362) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+|  | [Deluxe](https://www.trailjournals.com/journal/about/21877) | [\-\- View Entry --](https://www.trailjournals.com/journal/entry/566497) | [Nepal Trekking](https://www.trailjournals.com/journals/Nepal%20_Trekking) |
+|  | [Arius](https://www.trailjournals.com/journal/about/14527) | [Spence Field](https://www.trailjournals.com/journal/entry/404800) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Transient](https://www.trailjournals.com/journal/about/13775) | [Wrightwood](https://www.trailjournals.com/journal/entry/380564) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Troll_3506TN.jpg) | [Troll](https://www.trailjournals.com/journal/about/3506) | [Atkins](https://www.trailjournals.com/journal/entry/355108) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [perager](https://www.trailjournals.com/journal/about/4262) | [Waynesboro, Va](https://www.trailjournals.com/journal/entry/342171) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DidgeridudeandDoodlebug_9852TN.jpg) | [Didgeridude and Doodlebug](https://www.trailjournals.com/journal/about/9852) | [Trail Days](https://www.trailjournals.com/journal/entry/334664) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | ["Dances with Wolfie"](https://www.trailjournals.com/journal/about/7342) | [Trindle road](https://www.trailjournals.com/journal/entry/333573) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Locomotive Breath](https://www.trailjournals.com/journal/about/10836) | [Pearisburg Shuttle for Hyway](https://www.trailjournals.com/journal/entry/327054) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Peru_10969TN.jpg) | [Peru](https://www.trailjournals.com/journal/about/10969) | [Hot Springs](https://www.trailjournals.com/journal/entry/325375) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| [More...](https://www.trailjournals.com/entries/2010/05/16) [Grouped By Trail...](https://www.trailjournals.com/entries/2010/05/16/trail) |
+
+|     |
+| --- |
+| I rarely ever dreamt about hiking on the trail while I was out there in the woods. Many others said that they dreamed about it every night. Now that I'm home I think and dream about it constantly and have been waking up prepared to hike in the morning. ... <br>[Terodactyle](https://www.trailjournals.com/journal/entry/547885) —<br>[Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail) [2016](https://www.trailjournals.com/journals/appalachian_trail/2016) |
+
+[![Trailjournals](https://www.trailjournals.com/images/logo.png)](https://www.trailjournals.com/)
+
+#### Hiking
+
+- [Trails](https://www.trailjournals.com/trails/list)
+- [Journals](https://www.trailjournals.com/journals)
+- [Photos](https://www.trailjournals.com/photos)
+- [Calendar](https://www.trailjournals.com/calendar)
+- Gear
+- [Links](https://www.trailjournals.com/links)
+
+#### Partners
+
+- [ULA Equipment](https://ula-equipment.sjv.io/drN9K)
+- [REI](http://www.avantlink.com/click.php?tt=ml&ti=45265&pw=68025)
+- [Patagonia](http://www.avantlink.com/click.php?tt=ml&ti=45781&pw=68025)
+
+#### Network
+
+- [Trail Forums](http://www.trailforums.com/)
+- Trail News
+
+#### About Us
+
+- [Contact](https://www.trailjournals.com/about/contact)
+- [Donate](https://www.trailjournals.com/about/donate)
+- [Join](https://www.trailjournals.com/join)
+- [Login](https://www.trailjournals.com/user/login)
+- [Help](https://www.trailjournals.com/help)
+
+#### Follow Us
+
+- [Facebook](https://www.facebook.com/trailjournals)
+- [Instagram](https://instagram.com/trailjournals/)
+- [Twitter](https://twitter.com/trailjournals)
+- [Pinterest](https://www.pinterest.com/trailjournals/)
+- [Linkedin](https://www.linkedin.com/company/trailjournals-llc)
+
+Top Photo © Gary Wright - The Appalachin Trail,
+08/28/2002 by
+[Radar](https://www.trailjournals.com/journal/543)
+
+Trailjournals LLC © 2026
+All Rights Reserved. [privacy policy](https://www.trailjournals.com/about/privacy)
+
+Newburyport, MA 01950
+
+[Terms under which this service is provided to you.](https://www.trailjournals.com/about/privacy)
+
+Build: 20210226:165913 [Manage Settings](https://www.trailjournals.com/about/settings)
+---
+
+# Monday, May 17, 2010 — Vanessa's Place (Salibury, CT)
+**Start Location:** Stewart Hollow Brook Lean-to
+**Miles Today:** 26.40
+**Trip Miles:** 1488.50
+
+Toggle navigation[Trail Journals](https://www.trailjournals.com/)
+
+- [Journals](https://www.trailjournals.com/journal/entry/311305#)  - [Journals](https://www.trailjournals.com/journals)
+  - [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail/2026)
+  - [Pacific Crest Trail](https://www.trailjournals.com/journals/pacific_crest_trail/2026)
+  - [Colorado Trail](https://www.trailjournals.com/journals/colorado_trail/2026)
+  - [Continental Divide Trail](https://www.trailjournals.com/journals/continental_divide_trail/2026)
+  - [Long Trail - Vermont](https://www.trailjournals.com/journals/the_long_trail_-_vermont/2026)
+  - [Florida Trail](https://www.trailjournals.com/journals/the_florida_trail/2026)
+  - [Arizona Trail](https://www.trailjournals.com/journals/arizona_trail/2026)
+  - [John Muir Trail](https://www.trailjournals.com/journals/john_muir_trail/2026)
+  - [Camino de Santiago](https://www.trailjournals.com/journals/camino_de_santiago/2026)
+  - [American Discovery Trail](https://www.trailjournals.com/journals/american_discovery_trail/2026)
+  - [Coast to Coast Walk](https://www.trailjournals.com/journals/coast_to_coast_walk/2026)
+  - [More...](https://www.trailjournals.com/journals/)
+- [Trails](https://www.trailjournals.com/trails/)
+- [Photos](https://www.trailjournals.com/photos/2026)
+- [Gear](https://www.trailjournals.com/journal/entry/311305#)  - [Current Sales](https://www.trailjournals.com/gear/deals/onsale)
+  - [REI](https://www.trailjournals.com/gear/rei)
+  - [ULA](https://www.trailjournals.com/gear/ula)
+  - [Patagonia](https://www.trailjournals.com/gear/patagonia)
+  - [Cabela's](https://www.trailjournals.com/gear/cabela)
+- [Planning](https://www.trailjournals.com/journal/entry/311305#)  - [Plan Your Hike](https://www.trailjournals.com/planning/)
+  - [Gear](https://www.trailjournals.com/gear/)
+  - [Books](https://www.trailjournals.com/books/)
+  - [Links](https://www.trailjournals.com/links/)
+- [Search](https://www.trailjournals.com/search/)
+- [About](https://www.trailjournals.com/journal/entry/311305#)  - [About Trailjournals](https://www.trailjournals.com/about/)
+  - [Login](https://www.trailjournals.com/user/login)
+  - [Join](https://www.trailjournals.com/join)
+  - [Support Trailjournals](https://www.trailjournals.com/about/donate/)
+  - [Contact](https://www.trailjournals.com/about/contact)
+  - [Store](https://www.trailjournals.com/store/)
+
+Backpacking Journals and Photos from Long Distance Hikers
+
+1. [Home](https://www.trailjournals.com/)
+2. [Journals](https://www.trailjournals.com/journals)
+3. [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail)
+4. [2010](https://www.trailjournals.com/journals/appalachian_trail/2010)
+5. [Uncle Frank](https://www.trailjournals.com/journal/10467)
+6. [Entries](https://www.trailjournals.com/journal/entries/10467/uncle%20-frank)
+7. May 17, 2010
+
+Toggle navigation
+
+- [Journal](https://www.trailjournals.com/journal/10467)
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+- [My Journals](https://www.trailjournals.com/myjournals/10467)
+- [View Guest Book](https://www.trailjournals.com/journal/guestbook/10467)
+- [Sign Guest Book](https://www.trailjournals.com/journal/guestbook/sign/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/9a.gif)![](https://www.trailjournals.com/images/7a.gif)
+
+[Journal](https://www.trailjournals.com/journal/10467)
+
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+
+--Choose--01/21/1002/06/1002/07/1002/08/1002/09/1002/10/1002/11/1002/12/1002/13/1002/14/1002/15/1002/16/1002/17/1002/18/1002/19/1002/20/1002/21/1002/22/1002/23/1002/24/1002/25/1002/26/1002/27/1002/28/1003/01/1003/02/1003/03/1003/04/1003/05/1003/06/1003/07/1003/08/1003/09/1003/11/1003/12/1003/13/1003/14/1003/15/1003/16/1003/17/1003/18/1003/19/1003/20/1003/21/1003/24/1003/25/1003/26/1003/27/1003/28/1003/29/1003/30/1003/31/1004/01/1004/02/1004/03/1004/04/1004/05/1004/06/1004/07/1004/08/1004/09/1004/10/1004/11/1004/12/1004/13/1004/14/1004/15/1004/16/1004/17/1004/18/1004/19/1004/20/1004/21/1004/23/1004/24/1004/25/1004/26/1004/27/1004/28/1004/29/1004/30/1005/01/1005/02/1005/03/1005/04/1005/05/1005/06/1005/07/1005/08/1005/09/1005/10/1005/11/1005/12/1005/13/1005/14/1005/15/1005/16/1005/17/1005/18/1005/19/1005/20/1005/21/1005/22/1005/23/1005/24/1005/25/1005/26/1005/27/1005/28/1005/29/1005/30/1005/31/1006/01/1006/02/1006/03/1006/04/1006/05/1006/06/1006/07/1006/08/1006/09/1006/10/1006/11/1006/12/1006/13/1006/14/1006/15/1006/16/1006/17/1006/18/1006/19/1006/20/1006/21/10
+
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+
+Guest Book
+
+- [Sign](https://www.trailjournals.com/journal/guestbook/sign/10467)
+- [View](https://www.trailjournals.com/journal/guestbook/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/9a.gif)![](https://www.trailjournals.com/images/7a.gif)
+
+- [AT Journals](https://www.trailjournals.com/journals/appalachian_trail)
+- [AT Photos](https://www.trailjournals.com/photos/appalachian_trail)
+- [AT Books](https://www.trailjournals.com/books/appalachian_trail)
+- [Appalachian Trail](http://www.appalachiantrail.org/)
+
+[Join](https://www.trailjournals.com/join) [Login](https://www.trailjournals.com/user/login)
+
+[RSS](https://www.trailjournals.com/journal/rss/10467/xml)
+
+# Uncle Frank's 2010  Appalachian Trail Journal
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/311304) [Next](https://www.trailjournals.com/journal/entry/311306) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+Monday, May 17, 2010
+
+Destination:Vanessa's Place (Salibury, CT)
+
+Today's Miles:26.40
+
+Start Location:Stewart Hollow Brook Lean-to
+
+Trip Miles:1488.50
+
+Destination:Vanessa's Place (Salibury, CT)
+
+Start Location:Stewart Hollow Brook Lean-to
+
+Today's Miles:26.40
+
+Trip Miles:1488.50
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/311304) [Next](https://www.trailjournals.com/journal/entry/311306) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+### Hiker Entries May 17, 2010
+
+|  | Journalist | Destination | Trail |
+| --- | --- | --- | --- |
+|  | [Dreams](https://www.trailjournals.com/journal/about/28321) | [Whitewater Trout Farm (217.6)](https://www.trailjournals.com/journal/entry/679363) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+|  | [Deluxe](https://www.trailjournals.com/journal/about/21877) | [\-\- View Entry --](https://www.trailjournals.com/journal/entry/566501) | [Nepal Trekking](https://www.trailjournals.com/journals/Nepal%20_Trekking) |
+|  | [Arius](https://www.trailjournals.com/journal/about/14527) | [Mtn. Collins](https://www.trailjournals.com/journal/entry/404801) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Transient](https://www.trailjournals.com/journal/about/13775) | [South Fork Campground](https://www.trailjournals.com/journal/entry/380565) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Troll_3506TN.jpg) | [Troll](https://www.trailjournals.com/journal/about/3506) | [Atkins](https://www.trailjournals.com/journal/entry/355109) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [perager](https://www.trailjournals.com/journal/about/4262) | [Calf Mtn shelter](https://www.trailjournals.com/journal/entry/342172) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DidgeridudeandDoodlebug_9852TN.jpg) | [Didgeridude and Doodlebug](https://www.trailjournals.com/journal/about/9852) | [Trimpi Shelter](https://www.trailjournals.com/journal/entry/334665) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | ["Dances with Wolfie"](https://www.trailjournals.com/journal/about/7342) | [Darlington Shelter](https://www.trailjournals.com/journal/entry/333574) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Superman_10150TN.jpg) | [Superman](https://www.trailjournals.com/journal/about/10150) | [VA601 Beech Mountain Road](https://www.trailjournals.com/journal/entry/330130) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Locomotive Breath](https://www.trailjournals.com/journal/about/10836) | [Trimpi Shelter](https://www.trailjournals.com/journal/entry/327055) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| [More...](https://www.trailjournals.com/entries/2010/05/17) [Grouped By Trail...](https://www.trailjournals.com/entries/2010/05/17/trail) |
+
+|     |
+| --- |
+| I was enjoying the day and came across some horses which seemed as happy as I was to have some company.... <br>[YOYO](https://www.trailjournals.com/journal/entry/550905) —<br>[American Discovery Trail](https://www.trailjournals.com/journals/american_discovery_trail) [2016](https://www.trailjournals.com/journals/american_discovery_trail/2016) |
+
+[![Trailjournals](https://www.trailjournals.com/images/logo.png)](https://www.trailjournals.com/)
+
+#### Hiking
+
+- [Trails](https://www.trailjournals.com/trails/list)
+- [Journals](https://www.trailjournals.com/journals)
+- [Photos](https://www.trailjournals.com/photos)
+- [Calendar](https://www.trailjournals.com/calendar)
+- Gear
+- [Links](https://www.trailjournals.com/links)
+
+#### Partners
+
+- [ULA Equipment](https://ula-equipment.sjv.io/drN9K)
+- [REI](http://www.avantlink.com/click.php?tt=ml&ti=45265&pw=68025)
+- [Patagonia](http://www.avantlink.com/click.php?tt=ml&ti=45781&pw=68025)
+
+#### Network
+
+- [Trail Forums](http://www.trailforums.com/)
+- Trail News
+
+#### About Us
+
+- [Contact](https://www.trailjournals.com/about/contact)
+- [Donate](https://www.trailjournals.com/about/donate)
+- [Join](https://www.trailjournals.com/join)
+- [Login](https://www.trailjournals.com/user/login)
+- [Help](https://www.trailjournals.com/help)
+
+#### Follow Us
+
+- [Facebook](https://www.facebook.com/trailjournals)
+- [Instagram](https://instagram.com/trailjournals/)
+- [Twitter](https://twitter.com/trailjournals)
+- [Pinterest](https://www.pinterest.com/trailjournals/)
+- [Linkedin](https://www.linkedin.com/company/trailjournals-llc)
+
+Top Photo © Gary Wright - The Appalachin Trail,
+08/28/2002 by
+[Radar](https://www.trailjournals.com/journal/543)
+
+Trailjournals LLC © 2026
+All Rights Reserved. [privacy policy](https://www.trailjournals.com/about/privacy)
+
+Newburyport, MA 01950
+
+[Terms under which this service is provided to you.](https://www.trailjournals.com/about/privacy)
+
+Build: 20210226:165913 [Manage Settings](https://www.trailjournals.com/about/settings)
+---
+
+# Tuesday, May 18, 2010 — Tom Lenoard Lean-to
+**Start Location:** Vanessa's Place (Salibury, CT)
+**Miles Today:** 27.80
+**Trip Miles:** 1516.30
+
+Toggle navigation[Trail Journals](https://www.trailjournals.com/)
+
+- [Journals](https://www.trailjournals.com/journal/entry/311306#)  - [Journals](https://www.trailjournals.com/journals)
+  - [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail/2026)
+  - [Pacific Crest Trail](https://www.trailjournals.com/journals/pacific_crest_trail/2026)
+  - [Colorado Trail](https://www.trailjournals.com/journals/colorado_trail/2026)
+  - [Continental Divide Trail](https://www.trailjournals.com/journals/continental_divide_trail/2026)
+  - [Long Trail - Vermont](https://www.trailjournals.com/journals/the_long_trail_-_vermont/2026)
+  - [Florida Trail](https://www.trailjournals.com/journals/the_florida_trail/2026)
+  - [Arizona Trail](https://www.trailjournals.com/journals/arizona_trail/2026)
+  - [John Muir Trail](https://www.trailjournals.com/journals/john_muir_trail/2026)
+  - [Camino de Santiago](https://www.trailjournals.com/journals/camino_de_santiago/2026)
+  - [American Discovery Trail](https://www.trailjournals.com/journals/american_discovery_trail/2026)
+  - [Coast to Coast Walk](https://www.trailjournals.com/journals/coast_to_coast_walk/2026)
+  - [More...](https://www.trailjournals.com/journals/)
+- [Trails](https://www.trailjournals.com/trails/)
+- [Photos](https://www.trailjournals.com/photos/2026)
+- [Gear](https://www.trailjournals.com/journal/entry/311306#)  - [Current Sales](https://www.trailjournals.com/gear/deals/onsale)
+  - [REI](https://www.trailjournals.com/gear/rei)
+  - [ULA](https://www.trailjournals.com/gear/ula)
+  - [Patagonia](https://www.trailjournals.com/gear/patagonia)
+  - [Cabela's](https://www.trailjournals.com/gear/cabela)
+- [Planning](https://www.trailjournals.com/journal/entry/311306#)  - [Plan Your Hike](https://www.trailjournals.com/planning/)
+  - [Gear](https://www.trailjournals.com/gear/)
+  - [Books](https://www.trailjournals.com/books/)
+  - [Links](https://www.trailjournals.com/links/)
+- [Search](https://www.trailjournals.com/search/)
+- [About](https://www.trailjournals.com/journal/entry/311306#)  - [About Trailjournals](https://www.trailjournals.com/about/)
+  - [Login](https://www.trailjournals.com/user/login)
+  - [Join](https://www.trailjournals.com/join)
+  - [Support Trailjournals](https://www.trailjournals.com/about/donate/)
+  - [Contact](https://www.trailjournals.com/about/contact)
+  - [Store](https://www.trailjournals.com/store/)
+
+Backpacking Journals and Photos from Long Distance Hikers
+
+1. [Home](https://www.trailjournals.com/)
+2. [Journals](https://www.trailjournals.com/journals)
+3. [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail)
+4. [2010](https://www.trailjournals.com/journals/appalachian_trail/2010)
+5. [Uncle Frank](https://www.trailjournals.com/journal/10467)
+6. [Entries](https://www.trailjournals.com/journal/entries/10467/uncle%20-frank)
+7. May 18, 2010
+
+Toggle navigation
+
+- [Journal](https://www.trailjournals.com/journal/10467)
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+- [My Journals](https://www.trailjournals.com/myjournals/10467)
+- [View Guest Book](https://www.trailjournals.com/journal/guestbook/10467)
+- [Sign Guest Book](https://www.trailjournals.com/journal/guestbook/sign/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/9a.gif)![](https://www.trailjournals.com/images/9a.gif)
+
+[Journal](https://www.trailjournals.com/journal/10467)
+
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+
+--Choose--01/21/1002/06/1002/07/1002/08/1002/09/1002/10/1002/11/1002/12/1002/13/1002/14/1002/15/1002/16/1002/17/1002/18/1002/19/1002/20/1002/21/1002/22/1002/23/1002/24/1002/25/1002/26/1002/27/1002/28/1003/01/1003/02/1003/03/1003/04/1003/05/1003/06/1003/07/1003/08/1003/09/1003/11/1003/12/1003/13/1003/14/1003/15/1003/16/1003/17/1003/18/1003/19/1003/20/1003/21/1003/24/1003/25/1003/26/1003/27/1003/28/1003/29/1003/30/1003/31/1004/01/1004/02/1004/03/1004/04/1004/05/1004/06/1004/07/1004/08/1004/09/1004/10/1004/11/1004/12/1004/13/1004/14/1004/15/1004/16/1004/17/1004/18/1004/19/1004/20/1004/21/1004/23/1004/24/1004/25/1004/26/1004/27/1004/28/1004/29/1004/30/1005/01/1005/02/1005/03/1005/04/1005/05/1005/06/1005/07/1005/08/1005/09/1005/10/1005/11/1005/12/1005/13/1005/14/1005/15/1005/16/1005/17/1005/18/1005/19/1005/20/1005/21/1005/22/1005/23/1005/24/1005/25/1005/26/1005/27/1005/28/1005/29/1005/30/1005/31/1006/01/1006/02/1006/03/1006/04/1006/05/1006/06/1006/07/1006/08/1006/09/1006/10/1006/11/1006/12/1006/13/1006/14/1006/15/1006/16/1006/17/1006/18/1006/19/1006/20/1006/21/10
+
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+
+Guest Book
+
+- [Sign](https://www.trailjournals.com/journal/guestbook/sign/10467)
+- [View](https://www.trailjournals.com/journal/guestbook/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/9a.gif)![](https://www.trailjournals.com/images/9a.gif)
+
+- [AT Journals](https://www.trailjournals.com/journals/appalachian_trail)
+- [AT Photos](https://www.trailjournals.com/photos/appalachian_trail)
+- [AT Books](https://www.trailjournals.com/books/appalachian_trail)
+- [Appalachian Trail](http://www.appalachiantrail.org/)
+
+[Join](https://www.trailjournals.com/join) [Login](https://www.trailjournals.com/user/login)
+
+[RSS](https://www.trailjournals.com/journal/rss/10467/xml)
+
+# Uncle Frank's 2010  Appalachian Trail Journal
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/311305) [Next](https://www.trailjournals.com/journal/entry/311307) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+Tuesday, May 18, 2010
+
+Destination:Tom Lenoard Lean-to
+
+Today's Miles:27.80
+
+Start Location:Vanessa's Place (Salibury, CT)
+
+Trip Miles:1516.30
+
+Destination:Tom Lenoard Lean-to
+
+Start Location:Vanessa's Place (Salibury, CT)
+
+Today's Miles:27.80
+
+Trip Miles:1516.30
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/311305) [Next](https://www.trailjournals.com/journal/entry/311307) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+### Hiker Entries May 18, 2010
+
+|  | Journalist | Destination | Trail |
+| --- | --- | --- | --- |
+|  | [Dreams](https://www.trailjournals.com/journal/about/28321) | [Mission Creek headwaters (238.0)](https://www.trailjournals.com/journal/entry/679364) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+|  | [Deluxe](https://www.trailjournals.com/journal/about/21877) | [\-\- View Entry --](https://www.trailjournals.com/journal/entry/566504) | [Nepal Trekking](https://www.trailjournals.com/journals/Nepal%20_Trekking) |
+|  | [Arius](https://www.trailjournals.com/journal/about/14527) | [Tri-Corner Knob](https://www.trailjournals.com/journal/entry/404804) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Transient](https://www.trailjournals.com/journal/about/13775) | [Mount Emma Road](https://www.trailjournals.com/journal/entry/380567) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+|  | [perager](https://www.trailjournals.com/journal/about/4262) | [Prep Section Hike](https://www.trailjournals.com/journal/entry/342173) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DidgeridudeandDoodlebug_9852TN.jpg) | [Didgeridude and Doodlebug](https://www.trailjournals.com/journal/about/9852) | [past Brushy Mtn](https://www.trailjournals.com/journal/entry/334666) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | ["Dances with Wolfie"](https://www.trailjournals.com/journal/about/7342) | [The Doyle](https://www.trailjournals.com/journal/entry/334469) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010EUREKA!_10324TN.jpg) | [Jerry from Kentucky](https://www.trailjournals.com/journal/about/10324) | [Sarver Mountain Shelter](https://www.trailjournals.com/journal/entry/333278) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Superman_10150TN.jpg) | [Superman](https://www.trailjournals.com/journal/about/10150) | [East Fork of Big Wilson](https://www.trailjournals.com/journal/entry/330131) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Locomotive Breath](https://www.trailjournals.com/journal/about/10836) | [Partnership Shelter](https://www.trailjournals.com/journal/entry/327116) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| [More...](https://www.trailjournals.com/entries/2010/05/18) [Grouped By Trail...](https://www.trailjournals.com/entries/2010/05/18/trail) |
+
+|     |
+| --- |
+| What a sight to see a shelter. I was so glad to be in it, as I threw my pack down, sat on the wooden planks with the protective roof above and just gave out a big 'whew'.... <br>[Figgy](https://www.trailjournals.com/journal/entry/464964) —<br>[Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail) [2014](https://www.trailjournals.com/journals/appalachian_trail/2014) |
+
+[![Trailjournals](https://www.trailjournals.com/images/logo.png)](https://www.trailjournals.com/)
+
+#### Hiking
+
+- [Trails](https://www.trailjournals.com/trails/list)
+- [Journals](https://www.trailjournals.com/journals)
+- [Photos](https://www.trailjournals.com/photos)
+- [Calendar](https://www.trailjournals.com/calendar)
+- Gear
+- [Links](https://www.trailjournals.com/links)
+
+#### Partners
+
+- [ULA Equipment](https://ula-equipment.sjv.io/drN9K)
+- [REI](http://www.avantlink.com/click.php?tt=ml&ti=45265&pw=68025)
+- [Patagonia](http://www.avantlink.com/click.php?tt=ml&ti=45781&pw=68025)
+
+#### Network
+
+- [Trail Forums](http://www.trailforums.com/)
+- Trail News
+
+#### About Us
+
+- [Contact](https://www.trailjournals.com/about/contact)
+- [Donate](https://www.trailjournals.com/about/donate)
+- [Join](https://www.trailjournals.com/join)
+- [Login](https://www.trailjournals.com/user/login)
+- [Help](https://www.trailjournals.com/help)
+
+#### Follow Us
+
+- [Facebook](https://www.facebook.com/trailjournals)
+- [Instagram](https://instagram.com/trailjournals/)
+- [Twitter](https://twitter.com/trailjournals)
+- [Pinterest](https://www.pinterest.com/trailjournals/)
+- [Linkedin](https://www.linkedin.com/company/trailjournals-llc)
+
+Top Photo © Gary Wright - The Appalachin Trail,
+08/28/2002 by
+[Radar](https://www.trailjournals.com/journal/543)
+
+Trailjournals LLC © 2026
+All Rights Reserved. [privacy policy](https://www.trailjournals.com/about/privacy)
+
+Newburyport, MA 01950
+
+[Terms under which this service is provided to you.](https://www.trailjournals.com/about/privacy)
+
+Build: 20210226:165913 [Manage Settings](https://www.trailjournals.com/about/settings)
+---
+
+# Wednesday, May 19, 2010 — A pavillion (Lee, MA)
+**Start Location:** Tom Lenoard Lean-to
+**Miles Today:** 23
+**Trip Miles:** 1539.30
+
+Toggle navigation[Trail Journals](https://www.trailjournals.com/)
+
+- [Journals](https://www.trailjournals.com/journal/entry/311307#)  - [Journals](https://www.trailjournals.com/journals)
+  - [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail/2026)
+  - [Pacific Crest Trail](https://www.trailjournals.com/journals/pacific_crest_trail/2026)
+  - [Colorado Trail](https://www.trailjournals.com/journals/colorado_trail/2026)
+  - [Continental Divide Trail](https://www.trailjournals.com/journals/continental_divide_trail/2026)
+  - [Long Trail - Vermont](https://www.trailjournals.com/journals/the_long_trail_-_vermont/2026)
+  - [Florida Trail](https://www.trailjournals.com/journals/the_florida_trail/2026)
+  - [Arizona Trail](https://www.trailjournals.com/journals/arizona_trail/2026)
+  - [John Muir Trail](https://www.trailjournals.com/journals/john_muir_trail/2026)
+  - [Camino de Santiago](https://www.trailjournals.com/journals/camino_de_santiago/2026)
+  - [American Discovery Trail](https://www.trailjournals.com/journals/american_discovery_trail/2026)
+  - [Coast to Coast Walk](https://www.trailjournals.com/journals/coast_to_coast_walk/2026)
+  - [More...](https://www.trailjournals.com/journals/)
+- [Trails](https://www.trailjournals.com/trails/)
+- [Photos](https://www.trailjournals.com/photos/2026)
+- [Gear](https://www.trailjournals.com/journal/entry/311307#)  - [Current Sales](https://www.trailjournals.com/gear/deals/onsale)
+  - [REI](https://www.trailjournals.com/gear/rei)
+  - [ULA](https://www.trailjournals.com/gear/ula)
+  - [Patagonia](https://www.trailjournals.com/gear/patagonia)
+  - [Cabela's](https://www.trailjournals.com/gear/cabela)
+- [Planning](https://www.trailjournals.com/journal/entry/311307#)  - [Plan Your Hike](https://www.trailjournals.com/planning/)
+  - [Gear](https://www.trailjournals.com/gear/)
+  - [Books](https://www.trailjournals.com/books/)
+  - [Links](https://www.trailjournals.com/links/)
+- [Search](https://www.trailjournals.com/search/)
+- [About](https://www.trailjournals.com/journal/entry/311307#)  - [About Trailjournals](https://www.trailjournals.com/about/)
+  - [Login](https://www.trailjournals.com/user/login)
+  - [Join](https://www.trailjournals.com/join)
+  - [Support Trailjournals](https://www.trailjournals.com/about/donate/)
+  - [Contact](https://www.trailjournals.com/about/contact)
+  - [Store](https://www.trailjournals.com/store/)
+
+Backpacking Journals and Photos from Long Distance Hikers
+
+1. [Home](https://www.trailjournals.com/)
+2. [Journals](https://www.trailjournals.com/journals)
+3. [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail)
+4. [2010](https://www.trailjournals.com/journals/appalachian_trail/2010)
+5. [Uncle Frank](https://www.trailjournals.com/journal/10467)
+6. [Entries](https://www.trailjournals.com/journal/entries/10467/uncle%20-frank)
+7. May 19, 2010
+
+Toggle navigation
+
+- [Journal](https://www.trailjournals.com/journal/10467)
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+- [My Journals](https://www.trailjournals.com/myjournals/10467)
+- [View Guest Book](https://www.trailjournals.com/journal/guestbook/10467)
+- [Sign Guest Book](https://www.trailjournals.com/journal/guestbook/sign/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/4a.gif)![](https://www.trailjournals.com/images/0a.gif)![](https://www.trailjournals.com/images/3a.gif)
+
+[Journal](https://www.trailjournals.com/journal/10467)
+
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+
+--Choose--01/21/1002/06/1002/07/1002/08/1002/09/1002/10/1002/11/1002/12/1002/13/1002/14/1002/15/1002/16/1002/17/1002/18/1002/19/1002/20/1002/21/1002/22/1002/23/1002/24/1002/25/1002/26/1002/27/1002/28/1003/01/1003/02/1003/03/1003/04/1003/05/1003/06/1003/07/1003/08/1003/09/1003/11/1003/12/1003/13/1003/14/1003/15/1003/16/1003/17/1003/18/1003/19/1003/20/1003/21/1003/24/1003/25/1003/26/1003/27/1003/28/1003/29/1003/30/1003/31/1004/01/1004/02/1004/03/1004/04/1004/05/1004/06/1004/07/1004/08/1004/09/1004/10/1004/11/1004/12/1004/13/1004/14/1004/15/1004/16/1004/17/1004/18/1004/19/1004/20/1004/21/1004/23/1004/24/1004/25/1004/26/1004/27/1004/28/1004/29/1004/30/1005/01/1005/02/1005/03/1005/04/1005/05/1005/06/1005/07/1005/08/1005/09/1005/10/1005/11/1005/12/1005/13/1005/14/1005/15/1005/16/1005/17/1005/18/1005/19/1005/20/1005/21/1005/22/1005/23/1005/24/1005/25/1005/26/1005/27/1005/28/1005/29/1005/30/1005/31/1006/01/1006/02/1006/03/1006/04/1006/05/1006/06/1006/07/1006/08/1006/09/1006/10/1006/11/1006/12/1006/13/1006/14/1006/15/1006/16/1006/17/1006/18/1006/19/1006/20/1006/21/10
+
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+
+Guest Book
+
+- [Sign](https://www.trailjournals.com/journal/guestbook/sign/10467)
+- [View](https://www.trailjournals.com/journal/guestbook/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/4a.gif)![](https://www.trailjournals.com/images/0a.gif)![](https://www.trailjournals.com/images/3a.gif)
+
+- [AT Journals](https://www.trailjournals.com/journals/appalachian_trail)
+- [AT Photos](https://www.trailjournals.com/photos/appalachian_trail)
+- [AT Books](https://www.trailjournals.com/books/appalachian_trail)
+- [Appalachian Trail](http://www.appalachiantrail.org/)
+
+[Join](https://www.trailjournals.com/join) [Login](https://www.trailjournals.com/user/login)
+
+[RSS](https://www.trailjournals.com/journal/rss/10467/xml)
+
+# Uncle Frank's 2010  Appalachian Trail Journal
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/311306) [Next](https://www.trailjournals.com/journal/entry/311308) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+Wednesday, May 19, 2010
+
+Destination:A pavillion (Lee, MA)
+
+Today's Miles:23
+
+Start Location:Tom Lenoard Lean-to
+
+Trip Miles:1539.30
+
+Destination:A pavillion (Lee, MA)
+
+Start Location:Tom Lenoard Lean-to
+
+Today's Miles:23
+
+Trip Miles:1539.30
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/311306) [Next](https://www.trailjournals.com/journal/entry/311308) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+### Hiker Entries May 19, 2010
+
+|  | Journalist | Destination | Trail |
+| --- | --- | --- | --- |
+|  | [Dreams](https://www.trailjournals.com/journal/about/28321) | [Big Bear City (265.3)](https://www.trailjournals.com/journal/entry/679365) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+|  | [Deluxe](https://www.trailjournals.com/journal/about/21877) | [\-\- View Entry --](https://www.trailjournals.com/journal/entry/566509) | [Nepal Trekking](https://www.trailjournals.com/journals/Nepal%20_Trekking) |
+|  | [Arius](https://www.trailjournals.com/journal/about/14527) | [Green Corner RD (SBF Hostel)](https://www.trailjournals.com/journal/entry/404805) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Transient](https://www.trailjournals.com/journal/about/13775) | [Mattox Canyon Creek](https://www.trailjournals.com/journal/entry/380569) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DidgeridudeandDoodlebug_9852TN.jpg) | [Didgeridude and Doodlebug](https://www.trailjournals.com/journal/about/9852) | [Rambunny's Atkins](https://www.trailjournals.com/journal/entry/334667) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | ["Dances with Wolfie"](https://www.trailjournals.com/journal/about/7342) | [Peters Mountain Shelter](https://www.trailjournals.com/journal/entry/334470) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Superman_10150TN.jpg) | [Superman](https://www.trailjournals.com/journal/about/10150) | [Troutdale](https://www.trailjournals.com/journal/entry/330132) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Locomotive Breath](https://www.trailjournals.com/journal/about/10836) | [Happy Hiker Hostel, Atkins](https://www.trailjournals.com/journal/entry/327117) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Peru_10969TN.jpg) | [Peru](https://www.trailjournals.com/journal/about/10969) | [Bald Mtn Shelter](https://www.trailjournals.com/journal/entry/325384) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Dilly Dally & Cubbie](https://www.trailjournals.com/journal/about/10450) | [Thunder Hill Shelter](https://www.trailjournals.com/journal/entry/325245) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| [More...](https://www.trailjournals.com/entries/2010/05/19) [Grouped By Trail...](https://www.trailjournals.com/entries/2010/05/19/trail) |
+
+|     |
+| --- |
+| I started a 6.5 mile ascent through the most beautiful snow covered trails. I have developed a good aerobic hiking pace and feel strong of limb and spirit. The cold morning air, constant movement and mental focus made this portion of the trail my favorite to date.... <br>[Arthur Veilleux](https://www.trailjournals.com/journal/entry/485986) —<br>[Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail) [2015](https://www.trailjournals.com/journals/appalachian_trail/2015) |
+
+[![Trailjournals](https://www.trailjournals.com/images/logo.png)](https://www.trailjournals.com/)
+
+#### Hiking
+
+- [Trails](https://www.trailjournals.com/trails/list)
+- [Journals](https://www.trailjournals.com/journals)
+- [Photos](https://www.trailjournals.com/photos)
+- [Calendar](https://www.trailjournals.com/calendar)
+- Gear
+- [Links](https://www.trailjournals.com/links)
+
+#### Partners
+
+- [ULA Equipment](https://ula-equipment.sjv.io/drN9K)
+- [REI](http://www.avantlink.com/click.php?tt=ml&ti=45265&pw=68025)
+- [Patagonia](http://www.avantlink.com/click.php?tt=ml&ti=45781&pw=68025)
+
+#### Network
+
+- [Trail Forums](http://www.trailforums.com/)
+- Trail News
+
+#### About Us
+
+- [Contact](https://www.trailjournals.com/about/contact)
+- [Donate](https://www.trailjournals.com/about/donate)
+- [Join](https://www.trailjournals.com/join)
+- [Login](https://www.trailjournals.com/user/login)
+- [Help](https://www.trailjournals.com/help)
+
+#### Follow Us
+
+- [Facebook](https://www.facebook.com/trailjournals)
+- [Instagram](https://instagram.com/trailjournals/)
+- [Twitter](https://twitter.com/trailjournals)
+- [Pinterest](https://www.pinterest.com/trailjournals/)
+- [Linkedin](https://www.linkedin.com/company/trailjournals-llc)
+
+Top Photo © Gary Wright - The Appalachin Trail,
+08/28/2002 by
+[Radar](https://www.trailjournals.com/journal/543)
+
+Trailjournals LLC © 2026
+All Rights Reserved. [privacy policy](https://www.trailjournals.com/about/privacy)
+
+Newburyport, MA 01950
+
+[Terms under which this service is provided to you.](https://www.trailjournals.com/about/privacy)
+
+Build: 20210226:165913 [Manage Settings](https://www.trailjournals.com/about/settings)
+---
+
+# Thursday, May 20, 2010 — Tom Levardi's home (Dalton, MA)
+**Start Location:** A pavillion (Lee, MA)
+**Miles Today:** 19
+**Trip Miles:** 1558.30
+
+Toggle navigation[Trail Journals](https://www.trailjournals.com/)
+
+- [Journals](https://www.trailjournals.com/journal/entry/311308#)  - [Journals](https://www.trailjournals.com/journals)
+  - [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail/2026)
+  - [Pacific Crest Trail](https://www.trailjournals.com/journals/pacific_crest_trail/2026)
+  - [Colorado Trail](https://www.trailjournals.com/journals/colorado_trail/2026)
+  - [Continental Divide Trail](https://www.trailjournals.com/journals/continental_divide_trail/2026)
+  - [Long Trail - Vermont](https://www.trailjournals.com/journals/the_long_trail_-_vermont/2026)
+  - [Florida Trail](https://www.trailjournals.com/journals/the_florida_trail/2026)
+  - [Arizona Trail](https://www.trailjournals.com/journals/arizona_trail/2026)
+  - [John Muir Trail](https://www.trailjournals.com/journals/john_muir_trail/2026)
+  - [Camino de Santiago](https://www.trailjournals.com/journals/camino_de_santiago/2026)
+  - [American Discovery Trail](https://www.trailjournals.com/journals/american_discovery_trail/2026)
+  - [Coast to Coast Walk](https://www.trailjournals.com/journals/coast_to_coast_walk/2026)
+  - [More...](https://www.trailjournals.com/journals/)
+- [Trails](https://www.trailjournals.com/trails/)
+- [Photos](https://www.trailjournals.com/photos/2026)
+- [Gear](https://www.trailjournals.com/journal/entry/311308#)  - [Current Sales](https://www.trailjournals.com/gear/deals/onsale)
+  - [REI](https://www.trailjournals.com/gear/rei)
+  - [ULA](https://www.trailjournals.com/gear/ula)
+  - [Patagonia](https://www.trailjournals.com/gear/patagonia)
+  - [Cabela's](https://www.trailjournals.com/gear/cabela)
+- [Planning](https://www.trailjournals.com/journal/entry/311308#)  - [Plan Your Hike](https://www.trailjournals.com/planning/)
+  - [Gear](https://www.trailjournals.com/gear/)
+  - [Books](https://www.trailjournals.com/books/)
+  - [Links](https://www.trailjournals.com/links/)
+- [Search](https://www.trailjournals.com/search/)
+- [About](https://www.trailjournals.com/journal/entry/311308#)  - [About Trailjournals](https://www.trailjournals.com/about/)
+  - [Login](https://www.trailjournals.com/user/login)
+  - [Join](https://www.trailjournals.com/join)
+  - [Support Trailjournals](https://www.trailjournals.com/about/donate/)
+  - [Contact](https://www.trailjournals.com/about/contact)
+  - [Store](https://www.trailjournals.com/store/)
+
+Backpacking Journals and Photos from Long Distance Hikers
+
+1. [Home](https://www.trailjournals.com/)
+2. [Journals](https://www.trailjournals.com/journals)
+3. [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail)
+4. [2010](https://www.trailjournals.com/journals/appalachian_trail/2010)
+5. [Uncle Frank](https://www.trailjournals.com/journal/10467)
+6. [Entries](https://www.trailjournals.com/journal/entries/10467/uncle%20-frank)
+7. May 20, 2010
+
+Toggle navigation
+
+- [Journal](https://www.trailjournals.com/journal/10467)
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+- [My Journals](https://www.trailjournals.com/myjournals/10467)
+- [View Guest Book](https://www.trailjournals.com/journal/guestbook/10467)
+- [Sign Guest Book](https://www.trailjournals.com/journal/guestbook/sign/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/4a.gif)![](https://www.trailjournals.com/images/0a.gif)![](https://www.trailjournals.com/images/6a.gif)
+
+[Journal](https://www.trailjournals.com/journal/10467)
+
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+
+--Choose--01/21/1002/06/1002/07/1002/08/1002/09/1002/10/1002/11/1002/12/1002/13/1002/14/1002/15/1002/16/1002/17/1002/18/1002/19/1002/20/1002/21/1002/22/1002/23/1002/24/1002/25/1002/26/1002/27/1002/28/1003/01/1003/02/1003/03/1003/04/1003/05/1003/06/1003/07/1003/08/1003/09/1003/11/1003/12/1003/13/1003/14/1003/15/1003/16/1003/17/1003/18/1003/19/1003/20/1003/21/1003/24/1003/25/1003/26/1003/27/1003/28/1003/29/1003/30/1003/31/1004/01/1004/02/1004/03/1004/04/1004/05/1004/06/1004/07/1004/08/1004/09/1004/10/1004/11/1004/12/1004/13/1004/14/1004/15/1004/16/1004/17/1004/18/1004/19/1004/20/1004/21/1004/23/1004/24/1004/25/1004/26/1004/27/1004/28/1004/29/1004/30/1005/01/1005/02/1005/03/1005/04/1005/05/1005/06/1005/07/1005/08/1005/09/1005/10/1005/11/1005/12/1005/13/1005/14/1005/15/1005/16/1005/17/1005/18/1005/19/1005/20/1005/21/1005/22/1005/23/1005/24/1005/25/1005/26/1005/27/1005/28/1005/29/1005/30/1005/31/1006/01/1006/02/1006/03/1006/04/1006/05/1006/06/1006/07/1006/08/1006/09/1006/10/1006/11/1006/12/1006/13/1006/14/1006/15/1006/16/1006/17/1006/18/1006/19/1006/20/1006/21/10
+
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+
+Guest Book
+
+- [Sign](https://www.trailjournals.com/journal/guestbook/sign/10467)
+- [View](https://www.trailjournals.com/journal/guestbook/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/4a.gif)![](https://www.trailjournals.com/images/0a.gif)![](https://www.trailjournals.com/images/6a.gif)
+
+- [AT Journals](https://www.trailjournals.com/journals/appalachian_trail)
+- [AT Photos](https://www.trailjournals.com/photos/appalachian_trail)
+- [AT Books](https://www.trailjournals.com/books/appalachian_trail)
+- [Appalachian Trail](http://www.appalachiantrail.org/)
+
+[Join](https://www.trailjournals.com/join) [Login](https://www.trailjournals.com/user/login)
+
+[RSS](https://www.trailjournals.com/journal/rss/10467/xml)
+
+# Uncle Frank's 2010  Appalachian Trail Journal
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/311307) [Next](https://www.trailjournals.com/journal/entry/311313) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+Thursday, May 20, 2010
+
+Destination:Tom Levardi's home (Dalton, MA)
+
+Today's Miles:19
+
+Start Location:A pavillion (Lee, MA)
+
+Trip Miles:1558.30
+
+Destination:Tom Levardi's home (Dalton, MA)
+
+Start Location:A pavillion (Lee, MA)
+
+Today's Miles:19
+
+Trip Miles:1558.30
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/311307) [Next](https://www.trailjournals.com/journal/entry/311313) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+### Hiker Entries May 20, 2010
+
+|  | Journalist | Destination | Trail |
+| --- | --- | --- | --- |
+|  | [Dreams](https://www.trailjournals.com/journal/about/28321) | [Van Dusen Canyon (274.0)](https://www.trailjournals.com/journal/entry/679366) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+|  | [Deluxe](https://www.trailjournals.com/journal/about/21877) | [\-\- View Entry --](https://www.trailjournals.com/journal/entry/566512) | [Nepal Trekking](https://www.trailjournals.com/journals/Nepal%20_Trekking) |
+|  | [Transient](https://www.trailjournals.com/journal/about/13775) | [KOA Campground](https://www.trailjournals.com/journal/entry/380570) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DidgeridudeandDoodlebug_9852TN.jpg) | [Didgeridude and Doodlebug](https://www.trailjournals.com/journal/about/9852) | [stealth camp](https://www.trailjournals.com/journal/entry/334668) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | ["Dances with Wolfie"](https://www.trailjournals.com/journal/about/7342) | [Yellow Spring Village Campsite](https://www.trailjournals.com/journal/entry/334471) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Ohibro_10264TN.jpg) | [Ohibro](https://www.trailjournals.com/journal/about/10264) | [Chillicothe, Ohio](https://www.trailjournals.com/journal/entry/333706) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010EUREKA!_10324TN.jpg) | [Jerry from Kentucky](https://www.trailjournals.com/journal/about/10324) | [Catawba Mtn Shelter](https://www.trailjournals.com/journal/entry/333279) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Superman_10150TN.jpg) | [Superman](https://www.trailjournals.com/journal/about/10150) | [Bushy Mountain](https://www.trailjournals.com/journal/entry/330133) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Locomotive Breath](https://www.trailjournals.com/journal/about/10836) | [Shoulder of Garden Mountain](https://www.trailjournals.com/journal/entry/327118) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Peru_10969TN.jpg) | [Peru](https://www.trailjournals.com/journal/about/10969) | [Uncle Johnny's](https://www.trailjournals.com/journal/entry/325385) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| [More...](https://www.trailjournals.com/entries/2010/05/20) [Grouped By Trail...](https://www.trailjournals.com/entries/2010/05/20/trail) |
+
+|     |
+| --- |
+| It's definitely starting to feel like a new lifestyle out here, rather than just another weekend backpack trip. And boy does it feel great! If you're reading this, quit your job now and go for a long walk. You won't regret it.... <br>[Red Beard](https://www.trailjournals.com/journal/entry/412774) —<br>[Pacific Crest Trail](https://www.trailjournals.com/journals/pacific_crest_trail) [2013](https://www.trailjournals.com/journals/pacific_crest_trail/2013) |
+
+[![Trailjournals](https://www.trailjournals.com/images/logo.png)](https://www.trailjournals.com/)
+
+#### Hiking
+
+- [Trails](https://www.trailjournals.com/trails/list)
+- [Journals](https://www.trailjournals.com/journals)
+- [Photos](https://www.trailjournals.com/photos)
+- [Calendar](https://www.trailjournals.com/calendar)
+- Gear
+- [Links](https://www.trailjournals.com/links)
+
+#### Partners
+
+- [ULA Equipment](https://ula-equipment.sjv.io/drN9K)
+- [REI](http://www.avantlink.com/click.php?tt=ml&ti=45265&pw=68025)
+- [Patagonia](http://www.avantlink.com/click.php?tt=ml&ti=45781&pw=68025)
+
+#### Network
+
+- [Trail Forums](http://www.trailforums.com/)
+- Trail News
+
+#### About Us
+
+- [Contact](https://www.trailjournals.com/about/contact)
+- [Donate](https://www.trailjournals.com/about/donate)
+- [Join](https://www.trailjournals.com/join)
+- [Login](https://www.trailjournals.com/user/login)
+- [Help](https://www.trailjournals.com/help)
+
+#### Follow Us
+
+- [Facebook](https://www.facebook.com/trailjournals)
+- [Instagram](https://instagram.com/trailjournals/)
+- [Twitter](https://twitter.com/trailjournals)
+- [Pinterest](https://www.pinterest.com/trailjournals/)
+- [Linkedin](https://www.linkedin.com/company/trailjournals-llc)
+
+Top Photo © Gary Wright - The Appalachin Trail,
+08/28/2002 by
+[Radar](https://www.trailjournals.com/journal/543)
+
+Trailjournals LLC © 2026
+All Rights Reserved. [privacy policy](https://www.trailjournals.com/about/privacy)
+
+Newburyport, MA 01950
+
+[Terms under which this service is provided to you.](https://www.trailjournals.com/about/privacy)
+
+Build: 20210226:165913 [Manage Settings](https://www.trailjournals.com/about/settings)
+---
+
+# Friday, May 21, 2010 — Tom Levardi's home (Dalton, MA)
+**Start Location:** Tom Levardi's home (Dalton, MA)
+**Miles Today:** 24
+**Trip Miles:** 1582.30
+
+I was up and adam this morning before 6 o'clock, sitting upright and alert on the couch where I slept. I was thrilled to be so awake. If I had been in the woods, I decided, I'd be on the trail. The house was warm and kept out the chilly morning, a chilly morning that would've normally paralyzed me in my sleeping bag. A general law of hking: the colder the morning the slower the rise.
+
+We all walked over to a diner for breakfast at 6:45 - Tom, the Georgia Boys and I. I spent $4.75 on the special (a heap of homefries, 2 eggs, toast and bottomless coffee) and a blueberry muffin that the waitress offered to "grill" (she brought it back blackened on both sides). I drank like five cups of coffee. Still out of money, the Georgia Boys spotted me on the bill.
+
+Tom drove us 24 miles North to where the AT intersects Williamstown (from there, we would walk back to his home via the AT). For once freed from our backpacks, and weexpected to cover the 24 miles up and over Graylock Mountain with leisure and ease. I was quite angry thanks to yet another baffled attempt at recieving my maildrop in Williamstown, but I swallowed and decided to forget about it for the day. This day was sunny and mine, and neither dark clouds nor or stresses were about to ruin it. I felt fresh as we parted ways and began walking.
+
+The 6-mile ascent to Graylock wasn't too bad. I sat at the top, spit sunflower seeds, and looked out across the most expansive view we'd seen for 500 miles. The view was mighty and powerful like a hammer, falling smooth yet strong. I don't know how to describe it, but it resonated inside and out.
+
+For the rest of the day (the last 18 miles), I hiked alone. I ran sometimes, walked others, and just calmly took in the day. The colors were outstanding, confined to the greens, blues and browns of the forest yet somehow glowing in a million shades. I sat on a soft bed of moss and thought about how LIFE lay around me. The walls and metal and plastics of the home aren't alive-they don't live. But there's something profound about sitting with LIFe around you. You can almost feel it breathing.
+
+Before 5 o'clock I arrived back in Dalton. I took a shower, a nap, and ate another excellent dinner prepared by Tom. A boiled medely of cabbage, carrots, and potatoes served with a salad, 2 cobs of corn and hot dogs. It was the first healthy meal I had in many weeks, and I gorged.
+---
+
+# Saturday, May 22, 2010 — Goddard Shelter
+**Start Location:** Tom Levardi's home (Dalton, MA)
+**Miles Today:** 28.60
+**Trip Miles:** 1610.90
+
+Three thirty-mile days into Rutland: that was my plan when Tom Levardi dropped me off at Massachusetts Rt. 2. It was 8:45 in the morning, and warm. I was alone and feeling fresh. Thirty miles lay ahead and I felt ready for them. The Georgia boys were about an hour behind.
+At dusk, I lay at the foot of a mountain. I was hungry, very hungry. I had scant food supply and hunger had set in early that day, so by sunset I felt like a skeleton. Thirty miles and I had one more mountain to climb. I couldn't breathe. I couldn't believe I was this hungry.
+A word on hunger: sometimes it sucks, sometimes it invigorates. For the affluent American, hunger is a negative state that usually occurs as an active choice that lasts, perhaps, for several short hours at the end of the day. In such cases, hunger is sought after. For relatively complacent Americans, a couple hours of monk-like discipline offers a hunger that makes one feel lean inside, potent, alive. But the pleasant sound of tummy-rumbles, coming just before a home-cooked meal after a long day at work, are invigorating yet entirely self-imposed. But the rumbles are not so pleasant when you're in the woods.
+Hunger bears down upon me in the mountains. Hiking hungry is okay from time to time, but after a while it begins to feel urgent. It oppresses morale, dims the spirit, and weakens the body. And there's nothing I can do about it. It is hopelessly out of my control. This is true hunger, I believe, and there's no romanticism to be found. In summary, I now understand the animalism awakened by this persistent, maddening sort of hunger. Looking at video footage of starving people in Africa, all I can say is that I understand like I didn't before. I know how it feels to be truly hungry, at least for three days (the collapse on the mountain was Day 1 of 3).
+Well, I made it to the shelter at the top of the mountain. There, a fire awaited me and, around it, three young guys drinking whiskey. I collapsed in the high grass. We exchanged glances. "You want some cheese and pepperoni, man?" I must have looked pretty bad. As the night wore on I drank whiskey and ate more cheese and pepperoni by the fire. Their names were Candyman, Bug Bite, and Clamspoon. Bug Bite said he was trapped in Vermont and that he was going to San Francisco to start over. I felt sort of inspired by that.
+---
+
+# Sunday, May 23, 2010 — Next to VT Route 11 (Manchester Center, VT)
+**Start Location:** Goddard Shelter
+**Miles Today:** 30
+**Trip Miles:** 1640.90
+
+I got up early and took off before Candyman & Co. stirred. A short hike to the summit presented a tall fire-tower. I climbed it. At the top, the blue whisps of cloud raced by and a panoramic view flooded out in all directions.
+At the next shelter (Kidd Gore) I devoured a banana-nut bread Clif Bar. The sun was out strong and the view from the shelter was nice, so I hung around and continued eating (ripping into next day's bags). An hour later I'd eaten to the point of nausea and condemning myself to two days of constant hunger and begging along the trail. Self-control? At this point I have none.
+At the next shelter (Story Spring) I waited for the Georgia boys. They'd started their day 8 miles behind me, but by 2:00 pm they'd caught up. For the next several hours I hiked with them. At the top of Stratton Pond Mountain, the fire-tower view was, without a doubt, the most beautiful view yet in 1,700 miles. I cannot describe it here, but I will remember it forever. The blues, the greens, the whites. The lakes, the forests, the peaks. It all rang out in the core.
+I left the Georgia boys at the next shelter and moved on into the sunset. The bugs were terrible, so I was glad as night fell. My plan was to hike a 40-mile day, but I abandoned it for a 30 to Vermont Rt. 11. I fell asleep under the stars next to the highway.
+---
+
+# Monday, May 24, 2010 — Minerva-Hinchey Shelter
+**Start Location:** Next to VT Route 11 (Manchester Center, VT)
+**Miles Today:** 30
+**Trip Miles:** 1670.90
+
+I was on the trail at 6:00am. Actually, I fell asleep there so I never left the trail in the first place. I walked into the sunrise and to the top of Bromley Mountain, where I took in another spectacular view. The summit was claimed by the ski resort, so it was packed with lift machines, snow-blowing equipment, ski lodges and big ski trail signs. I walked into a small warming hut and called my dad on a phone there, then moved on.
+It was a long and boring day, but I wasn't upset about it. I just walked. By 3:00 I'd covered 20 miles, and I weighed my three options: another 10 before dusk to make 30, or another 20 into the night to make 40, or another 30 into the early morning to make a record of 50 miles. The 50-miler was almost out of the question, the 40-miler would be a push in itself, and the 30-miler my conservative plan. I was hungry to exhaustion as I walked the next 10-mile leg, and when I got to the shelter at sunset I mulled over moving on. A Long Trail thru-hiker offered me food and I kicked off my boots. Once the belly was full and feet free, that was that. I called it a day at 30.
+One interesting change in the forest was the morph from New England hardwoods into a boreal forest. The forest felt like a cathedral, echoing with birds and spacey for nearly a hundred yards in every direction. There were trees, yes--old hemlocks, spruces, and firs--but no shrubbery choking the understory. It was all open and cast blue in the shade. It smelled of Christmas, and red squirrels darted about. The hiking hurt but the scenery was incredible.
+---
+
+# Tuesday, May 25, 2010 — Back Home Again Hostel (Rutland, VT)
+**Start Location:** Minerva-Hinchey Shelter
+**Miles Today:** 20
+**Trip Miles:** 1690.90
+
+Today took me up and over Mount Killington on a beautiful trail cloaked in hemlocks and firs. The sun was brutal, but not in the shade of the forest. I was almost sure I had giardia, and my abs cramped and I stopped to relieve myself all the way up. I didn't eat but a couple granola bars until walking down to the VT 4 highway. I waved a bus down and jumped on. Rutland at last!
+I slept for most of the 20-minute bus ride, but entering the city I awoke. Beautiful old stone churches graced almost every corner, and, on this Friday afternoon, people walked and rode bikes on the sidewalk. It was an enlivening scene. I envied the town life.
+I got off the bus and walked over to the Back Home Again Cafe, where I was greeted by an enthusiastic bearded man. He led me upstairs to the hostel and I opened my mail-drop. The contents were: 4 days of food, the Spot GPS, a cell phone + charger, an iPod charger, a camera + USB cord, a pair of Nike shoes, and 2 loaves of homemade banana bread. I grabbed a foil-wrapped loaf and went down to the cafe. I stared at it for a while--I'd been looking forward to this moment for a long time--then peeled back the foil. Inside, mold covered the bread. "Oh well. Just looking at it is enough," I said to "H", the bearded owner who'd sat down next to me. He jumped up and grabbed a muffin at the counter. "Take this. It's not Mom's, but it was baked this morning."
+I got a Reuben and a beer from next door and made some phone calls on the street--Rawlz, Diesel, Seth, Wesley, Corey, Mom & Dad. Suddenly, I was surrounded by four bearded men with ponytails. "Wanna come to our gathering?" "If I can get my Reuben in a to-go box," I replied. I got in the car with them The Twelve Tribes is a denomination of Christianity that practices many Amish-like customs with a hippie attitude, and a small community of them owned and operated the Back Home Again Cafe. Men wear beards, women wear dresses, and multiple families all live under the same roof, and, honestly, that's the only real difference between us and them. They took me back to their homes--they'd bought up a small cluster of old houses less than a mile from the cafe--and witnessed their 'gathering'. Everyone stood in a circle quietly. In this informal setting, some shared spiritual revelation and others recounted a enlightening experiences from that day--for example: "It was a sunny day and I was listening to a woman complain to her husband on the cell phone, and it hit me how much we worry ourselves about what's not the present." They sang a song and let me go. I went to the library and read up on giardia, and a strange man approached me as I munched on my Reuben outside. "This town is bad, man. Watch out at night," he said.
+It was getting late and I walked to Wal-Mart. I bought a bar of dark chocolate and a gatorade, then walked over to the movie theater. The guy at the counter wouldn't charge me for a ticket, so I just walked in kind of confused. Shrek was boring, and when I woke up the theater was all black and the movie over. I walked back to the hostel and went to sleep.
+---
+
+# Wednesday, May 26, 2010 — Stony Brook Shelter
+**Start Location:** Back Home Again Hostel (Rutland, VT)
+**Miles Today:** 10
+**Trip Miles:** 1700.90
+
+Today was my half-zero day in Rutland, and here's what I did: I got up early and packed my pack, received an early breakfast of 3 eggs, toast, and granola with milk, then did three hours of work-for-stay. In the kitchen I peeled bananas, cored tomatoes, sliced peppers, washed dishes, and mopped/swept the floor. I was actually pretty enjoyable because I got to talk to H, the quirky manager.
+After the work-for-stay, H ordered me a free smoothie and I walked over to the movie theater to see Robin Hood! I was so excited, and got a pint of Ben & Jerry's for the occassion. As I expected the movie was AWESOME, and I thought about it all that evening as I walked in the woods to the Stony Brook Shelter to meet the Georgia Boys. On the 10-mile march, I hung up my old boots on a large birch tree next to a huge boulder by a lake. In case I ever go back to Rutland, I'll come for them. It wasn't hard leaving Rutland, but it wasn't easy either. The folks there were so kind and the town itself so pretty and lively. Something tells me I'm going to always regret leaving places like Rutland before even getting to know them. At any rate, in the dark I trudged into the Stony Brook Shelter and hit the sack. Back in the woods again...
+---
+
+# Thursday, May 27, 2010 — Next to a road (Pomfret, VT)
+**Start Location:** Stony Brook Shelter
+**Miles Today:** 16
+**Trip Miles:** 1716.90
+
+I needed it, so today I lounged in the shelter while everyone else moved on. For nearly two hours I dozed in perfect silence, read Call of the Wild, and walked about the clearing. Eventually I hit the dusty trail, but my pace was slow all day. I just couldn't get "into it," and stopped again and again to sit on stumps and eat. By dusk, I hadn't even covered 20 miles! I didn't want to hike in the dark (and couldn't tolerate the overly-talkative fellow in the shelter), so I laid out my sleeping bag on the trail and fell asleep. The next morning I planned to rise before 6 and catch up with the Georgia Boys in the next shelter. I had dreams of alligators...
+---
+
+# Friday, May 28, 2010 — Bob Boon's Home
+**Start Location:** Next to a road (Pomfret, VT)
+**Miles Today:** 21
+**Trip Miles:** 1737.90
+
+|     |
+| --- |
+| [![](https://www.trailjournals.com/images/photos/journals/10467/tj10467_060410_112854_537283.jpg)](https://www.trailjournals.com/journal/photos/10467/537283/312661)<br>**_The work of Bob Boon_** |
+
+What a day! I really do want to go into detail and tell the world the story of how Bob Boon took us in, but I just can't here. I just had time to update a couple entires and I've got to hit the trail again...coming soon!
+---
+
+# Saturday, May 29, 2010 — Bob Boon's Home (Hanover, NH)
+**Start Location:** Bob Boon's Home
+**Miles Today:** 18
+**Trip Miles:** 1755.90
+
+|     |
+| --- |
+| [![](https://www.trailjournals.com/images/photos/journals/10467/tj10467_060410_114151_537288.jpg)](https://www.trailjournals.com/journal/photos/10467/537288/312885)<br>**_Slackpacking on Moose Mtn._** |
+
+Accepting charity is always a tricky thing to on and off the trail. My mantra is always "Just say yes; they're offering it for a reason," but the Georgia boys take a more shy and reserved approach. For example, when I'm sitting in the kitchen at Bob Boon's house and Bob says, "Help yourself to anything in the fridge," I have no qualms with pouring myself a glass of OJ; contrarily, the Georgia boys would take the offer as an empty formality and sit still. I can't say which is the best approach--one must be virtuous and the other not--but as I accumulate encounters with 'Trail Magic' I'm beginning to see myself as a sly beggar, a beggar with instincts trained to exploit the kindhearted. In a word, the trail has turned me into a dirty hobo with an insatiable appetite for mooching.
+---
+
+# Sunday, May 30, 2010 — Hikers Welcome Hostel
+**Start Location:** Bob Boon's Home (Hanover, NH)
+**Miles Today:** 25
+**Trip Miles:** 1780.90
+
+|     |
+| --- |
+| [![](https://www.trailjournals.com/images/photos/journals/10467/tj10467_060410_113145_537285.jpg)](https://www.trailjournals.com/journal/photos/10467/537285/313078)<br>**_View on Smarts Mountain_** |
+
+It was Sunday, and after enjoying Bob's breakfast (bacon-and-egg biscuts, doughnuts, bananas, and OJ), Bob drove us to the trail. We left his care and hit the trail, aiming for a shelter 9 miles away (Reckless had spent all night in the ER, so we shortened the day). I took my time like I do sometimes, taking long and frequent breaks to snack, nap, or just stare at the sky. I enjoyed an especially long lunch at the foot of the fire tower on Smarts Mtn., and the Georgia Boys went on far ahead. At the 9-mile shelter (Hexacube), I left a note and kept walking. "Onto Glen Cliffs for the night (signed) UF," it read. And that I did, stopping at another shelter halfway to convince Sore Foot to accompany me into the night. Sore Foot and I marched on a difficult night-hike marked only by nearly stumbling over a porcipine. We arrived at 11:20 pm at the Hikers Welcome Hostel. I ate a poptart and drank a soda before bed (as dinner I'd skipped), and took a deep breath for Moosilauke the following day.
+---
+
+# Monday, May 31, 2010 — Lonesome Lakes Hut
+**Start Location:** Hikers Welcome Hostel
+**Miles Today:** 23
+**Trip Miles:** 1803.90
+
+|     |
+| --- |
+| [![](https://www.trailjournals.com/images/photos/journals/10467/tj10467_060410_113605_537287.jpg)](https://www.trailjournals.com/journal/photos/10467/537287/313886)<br>**_Mount Moosilauke_** |
+
+Hey everyone! Sorry for the belated entries, but here's the next installment in Uncle Frank's trek to Maine...
+
+My feet were sore so I lounged the next morning at the Hikers Welcome Hostel, watching the news over coffee and chatting with the hostelliers. At 10:45, I hit the trail up Mt. Moosilauke (the hurdle of the infamous White Mountains) on fuel of 3 poptarts and 3 cups of coffee to match. In shelter sitting at the foot of Moosilauke, I found an old baseball to carry to Mt. Washington. Up the backside of Moosilauke I flew, stopping only once to provide isopropyl and medical tape for a lady who took a nasty spill on the rocks. Soon I was on top, standing in awe by the sign (Mt. Moosilauke 4802 ft). Here was the most beautiful thing I'd witnessed for 1,900 miles. I laughed like a lunatic, holding back the yips and yells that would've come out HAD so many day-hikers not shared the summit. I ate some sunflower seeds, a woman took my photo, and I tip-toed down the steep backside of the mountain. A beautiful stream cascaded down parallel to the trail, emitting a sweet-smelling mist. I ascented the next hurdle (name?), and the next, and encountered a memorably-painful three miles leading up to the Lonesome Lakes Hut. I'd covered 23 miles, a suprising feat given the terrain. The summits here are steep, unforgiving, leg-burning and calorie-sapping monsters, and their peaks demand a high-fee of pain for their spectacular views.
+
+It was dark when I knocked on the hut at Lonesome Lakes. Yellow light glowed inside, and I could soo several croo-members playing cards. One opened and I asked for some shelter in exchange for labor. Yes, they had some work-for-stay, so I entered and kicked off my shoes as the hutmaster gave me a huge can of cold beans with a spoon in it. A perfect dinner. I walked down to the lake for a bath. The night was clear and starry. The water was cool and black. I stripped down and flushed the sweat, blood, spider-webs and dead blackflies off my body. It felt so good to be clean. I walked back to the bunkhouse and collapsed into bed. An perfect end to an perfect day.
+---
+
+# Tuesday, June 01, 2010 — Galehead Hut
+**Start Location:** Lonesome Lakes Hut
+**Miles Today:** 16
+**Trip Miles:** 1819.90
+
+After making beds and organizing a food pantry, I bagged some granola/Lucky Charms and took a nap. By 11:00 (another late start), I was packed and on the trail. To Galehead Hut I marched, and the weather was nasty. Rain drizzled and poured, and winds blew hard. On the famed Franconia Ridge the views were all white-out (a minor disappointment). It was cold, windy, and wet above the tree-line, and I was miserable. I couldn't wait to get off the ridge and down to the forest. As I trudged I thought about the two-faced nature of this well-known ridge. It was either a maiden or a monster, either a cold and cloud-covered forced-march or a balmy cake-walk with spectacular views. The difference was a single day. Down at Galehead Hut, the croo served me warm soup and homemade pizza. I chatted with a very pretty girl (yea, that's a big deal). I couldn't believe the hospitality, and I fell asleep that night thinking, "I could get used to this." A perfect end to a not-perfect day.
+---
+
+# Wednesday, June 02, 2010 — Lakes of the Clouds Hut
+**Start Location:** Galehead Hut
+**Miles Today:** 26
+**Trip Miles:** 1845.90
+
+|     |
+| --- |
+| [![](https://www.trailjournals.com/images/photos/journals/10467/tj10467_060410_113004_537284.jpg)](https://www.trailjournals.com/journal/photos/10467/537284/313894)<br>**_Dusk on Mt. Franklin_** |
+
+"Redemption?": That was the first word out of my mouth that morning, spoken as I peered out of the window into beaming morning light. Believe it or not, the rain had moved out overnight and all clouds were gone. I layed out my wet gear in the sunlight to dry, and sat down at a set table for a croo-served breakfast of coffee and hot oatmeal with brown sugar, walnuts, strawberries, raisins, and apples. "No Brains", a warm-hearted section-hiker on his second-to-last leg, shared my complete awe of croo's degree of hospitality. We took turns singing praise to the croo, trying to convey gratitude that they would never understand in full. I scarfed down the breakfast and walked out to forage sticks to the compost, washed some dishes, and threw my pack on. It was 8:45, and off I marched to Lakes of the Clouds Hut, 26 miles away.
+
+The sun was beaming and each peak, one after another, grew higher and grander and more majestic than the last, until I was standing at sunset on Mt. Franklin. I stopped then, looking out as the heavens lay opened before me. It brought tears to my eyes, this most perfectly-beautiful place in the world. There's something about windy peaks that strikes a chord deep in the soul of man. Why can't a dense green forest strike it too? Perhaps, it's the feeling of nakedness of a mountaintop, where it's too high for those wordly distractions to grow. There it's pure, like life was meant to be. Up on those high-alpine peaks, perhaps we "haunted by the echoes of Eden."
+
+I descended down to the Lakes of the Clouds Hut, posted at the foot of Mt. Washington, the infamous jewel of the White Mountains crown. It was balmy and clear out, but ominous clouds engulfed the mountain, covering the peak from view.
+---
+
+# Thursday, June 03, 2010 — Hikers Paradise Hostel (Gorham, NH)
+**Start Location:** Lakes of the Clouds Hut
+**Miles Today:** 13.50
+**Trip Miles:** 1859.40
+
+|     |
+| --- |
+| [![](https://www.trailjournals.com/images/photos/journals/10467/tj10467_060410_113340_537286.jpg)](https://www.trailjournals.com/journal/photos/10467/537286/313908)<br>**_Gritting my Teeth on Mt. Washington_** |
+
+The next morning I awoke in The Dungeon, where the Lakes of th Clouds croo had put me up for the night. Just to give you an idea of what 'The Dungeon' implied, I'll simply say that the place was damper and smellier than my feet. Forecasts said the rain would blow over by 8am, so I awoke about that time. Dense fog cloaked the mountain and reduced visibility to zero, but the rains held off. Considering the ornery temperment of Mt. Washington, I decided weather was good enough to climb. So, I drank a protein shake and hit the trail at 7:45.
+
+The ascent was just as perilous as I expected. Visibility was near-zero, allowing just enough room to see from one mound of rocks to the next. All else was cloud. Wind speeds picked up as the rock mounds led up and up and up, soon strong enough to blow me off the trail. The terrain was 100% rocks. No vegetation dared grow. After 30 minutes of climbing I made out the shape of a mighty tower. I passed the tower, passed some buildings, and finally I was standing on the summit of Mount Washington, the high-point of AT-traversing past North Carolina. It snapped a photo and went inside the lodge (that's right, one of east-coast mountaineering's most covetted peaks has a yuppie LODGE on top, complete with Snickers, Sodas, and Hot Dogs...all of which I purchased). I hung out in the lodge for several hours, journaling and eating junk food in the warmth. At about noon I descending, taking a 7-mile short-cut around Mt.Adams, J.Q. Adams, and Madison because of the weather. It was a nasty day at the home of the worst weather in America, and I was eager to get down into the valley. At about 3pm, I arrived at Pinkham's Notch and hitched into Gorham. There, I got a bunk at the hostel and picked up a maildrop from home. Oh, Mom's muffins...
+---
+
+# Friday, June 04, 2010 — Doc's front porch (Gorham, NH)
+**Start Location:** Hikers Paradise Hostel (Gorham, NH)
+**Miles Today:** 21.10
+**Trip Miles:** 1880.50
+
+|     |
+| --- |
+| [![](https://www.trailjournals.com/images/photos/journals/10467/tj10467_061410_170842_541171.jpg)](https://www.trailjournals.com/journal/photos/10467/541171/315595)<br>**_Bedding on Doc's porch_** |
+
+At first light I was on my feet, as has been the case lately. I walked over to grab a muffin and Gatorade at the convenience store, then dined on my way back. It was warm out, sign of another gorgeous day in the White Mountains. I threw my pack on my back and strolled down for some caffeine stimulus before the library opened at 10 o'clock. The waitress smiled and moved excitedly about the cafe. At ten I entered the library and opened a tab for computer use at a dollar/half-hour (theft, in my opinion). At noon I grudgingly paid the clerk after almost three hours of updating trail journals and writing emails. "I bet yall make a fortune off hikers needing to use your computers," I said bitterly and left. Outside, a quick hitch to Pinkham Notch and I was on the trail.
+The trail was sunny and I took a nap on a couch in a ski patrol hut ontop Wildcat Mountain. Then, I descended to the Carter Notch Hut for a swim in the lake and a nature lesson from the hut's croo ("Friendly fir, spiny spruce," I learned). I had no gear, so I had to decline the hutmaster's offer for a meal and overnight stay. "I'll be back for the hut experience one day," I told him. I moved on. By evening I was back in town, devouring a foot-long sub after a hard day in the mountains. With permission, I bedded down on "Doc's" front porch as rain began to fall.
+---
+
+# Saturday, June 05, 2010 — Gentian Pond Shelter
+**Start Location:** Doc's front porch
+**Miles Today:** 11.80
+**Trip Miles:** 1892.30
+
+At 4 o'clock the next morning, I bought a ham-and-egg sandwhich, a honey bun, and some OJ at the convenience store, and as I packed my gear to go, a torrential rain began to fall. I cursed under my breath (visibe in the cold air, by the way), unrolled my sleeping bag, and went back to sleep. So much for a 5 o'clock start.
+At 7:30, I walked over for pancakes, bacon, and eggs, hoping that huge breakfast would somehow make the rain not-so-wet. I ate heartily and enjoyed it thoroughly. I've become the skinniest food glutton you've ever seen. I loved the waitresses New York accent.
+It took a while to get a hitch, but soon I was at the trailhead. After a frustrating episode trying to nap in a fog of mosquitoes and blackflies, I was on the trail at noon, moving towards the Full Goose Shelter 20 miles to the north. I ambled along lazily, not really wanting to be there but not really dissatisfied either. Just bored. I ate too much and found myself hiding in a shelter 10 miles short of Full Goose. A 70 year-old fellow named Grump really irritated me by talking my ear off. "If I'm talking too much, it's because I was a minister," he said. He was still talking as I drifted off to sleep.
+---
+
+# Sunday, June 06, 2010 — Carlo Col Shelter
+**Start Location:** Gentian Pond Shelter
+**Miles Today:** 5.60
+**Trip Miles:** 1897.90
+
+This morning, I waited. But the rain never left, and into the afternoon it still poured. I was paralyzed, I discovered, by an element not yet encountered: rain. I'd mastered snow and heat, but rain? I shuddered. Let me add also that this was not a warm summer shower; this was cold Maine rain. Hours passed quickly sitting in the shelter, sleeping and eating off and on, and soon it was 5 o'clock in the evening. At last, it was calm out. The rain had subsided. I risked it and moved on to the next shelter, only to have the rain start again. By the time I arrived at Carlo Col, I was soaked and shivering. Unfortunately, the shelter was packed like a refugee camp with AMC trainees. I told one I was going to Acadia with my family. "You're going to Acadia?!?", one exclaimed. "I'm already planning a trip on my next day off! And they have the best lobster!" I laughed and tried to bring my mind out of the cold and wet and into the future, done with the trail and with my family in Acadia.
+---
+
+# Monday, June 07, 2010 — The Cabin (Andover, ME)
+**Start Location:** Carlo Col Shelter
+**Miles Today:** 14.10
+**Trip Miles:** 1912
+
+|     |
+| --- |
+| [![](https://www.trailjournals.com/images/photos/journals/10467/tj10467_061410_170842_541175.jpg)](https://www.trailjournals.com/journal/photos/10467/541175/315600)<br>**_Morning view the way down to Rangely_** |
+
+I was out of the smelly, noisy shelter early. Up the first several ridged I climbed, cursing at the wind and cold. I felt like I was right back in the Smokies. It was all clouds, but at the top of one ridge I saw the sun glowing through. Suddenly it pierced through. The clouds broke and scattered, and I was surrounded by sweet blue sky. A panoramic view of rolling green mountains and cerulean lakes filled my eyes. Redemption! Still shivering, I called home to share the news. They said Corey was in the ICU, which re-clouded my sunny day. I'd been screaming with excitement; now I was silent and subdued. It hit me hard how far I was from home, how I'd let my family go in a big way. Homesickness swelled inside.
+Mahoosuc Notch was tricky, but it wasn't the dangerous mile of life-threatening bouldering I expected. I just kind of hopped through like a monkey. After Mahoosuc I made my way to the next road, where Earl from "The Cabin" waited for me in his pick-up. We met and he took me back to his home. I showered, laundered my clothes, changed into a clean set, and sat down for a dinner of grilled salmon, scallops, corn-on-the-cob, baked potatoes, and red wine. It was one of those meals I'll never forget. I cooked some maple-syrup pancakes (to take on the trail the next day) with some flour and syrup I found in a shelter the day before. I watched a movie on VHS (always a treat) and went to bed past midnight. It was the most comfortable night in recent memory.
+---
+
+# Tuesday, June 08, 2010 — Bemis Mountain Lean-to
+**Start Location:** The Cabin (Andover, ME)
+**Miles Today:** 29.10
+**Trip Miles:** 1941.10
+
+|     |
+| --- |
+| [![](https://www.trailjournals.com/images/photos/journals/10467/tj10467_061410_170842_541169.jpg)](https://www.trailjournals.com/journal/photos/10467/541169/315601)<br>**_A hard climb made worth it...Summit of N. Crocker Mtn._** |
+
+At 5:00 AM, Earl woke me up to leave. He dropped me back at the trail by 6:30 and I was off up the first mountain. It was bitterly cold, and it became dangerously cold as I ascended. Up and up and up the trail went, following nearly a mile along the mountain's exposed rocky ridgeline to its summit. I froze up there in my t-shirt and shorts. It was the lowest moment of the trip since that snowy day on Derrick's Knob in the Smokies. It was just so damn cold. After what seemed like hours I descended back into the trees, almost incredulous as to what just happened.
+I caught up with the Georgia boys and hiked with them to the Bemis Mountain Lean-to. It was a hard day, but then again every day is a hard day so I had nothing to complain about. There was laughing and there was complaining, as usual. I found web-like mold in my dinner and had to throw it out (I'd found it in a hiker box from last year, so I can't say I was surprised).
+---
+
+# Wednesday, June 09, 2010 — Bob's Hostel (Rangely, ME)
+**Start Location:** Bemis Mountain Lean-to
+**Miles Today:** 17.70
+**Trip Miles:** 1958.80
+
+|     |
+| --- |
+| [![](https://www.trailjournals.com/images/photos/journals/10467/tj10467_061410_170842_541172.jpg)](https://www.trailjournals.com/journal/photos/10467/541172/315602)<br>**_One of Maine's ten million lakes_** |
+
+The next day was a pleasant one, down into the small town of Rangely, Maine. We passed some pretty lakes, and seeing the lapping water made me miss home. I brought my right back to sailing the Hobie with the family in the Bay. By 2:00 we were at the road, trying to hitch. We waited, thumb out, for almost two hours. I'd all but given up on humanity when an ambulance pulled over. "Hop on in!," said the paramedic. All three of us boarded for a 10-minute ride into Rangely. I was faint with hunger, and consumed a beer and small pizza in several minutes. At Bob's Hostel, I ate 6 eggs, 2 apples, 2 oranges, and blackberries. The healthiest gorge ever. I went to bed late that night, again up making pancakes for the next day's rations.
+---
+
+# Thursday, June 10, 2010 — Spaulding Mountain Lean-to
+**Start Location:** Bob's Hostel (Rangely, ME)
+**Miles Today:** 10.70
+**Trip Miles:** 1969.50
+
+Toggle navigation[Trail Journals](https://www.trailjournals.com/)
+
+- [Journals](https://www.trailjournals.com/journal/entry/315603#)  - [Journals](https://www.trailjournals.com/journals)
+  - [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail/2026)
+  - [Pacific Crest Trail](https://www.trailjournals.com/journals/pacific_crest_trail/2026)
+  - [Colorado Trail](https://www.trailjournals.com/journals/colorado_trail/2026)
+  - [Continental Divide Trail](https://www.trailjournals.com/journals/continental_divide_trail/2026)
+  - [Long Trail - Vermont](https://www.trailjournals.com/journals/the_long_trail_-_vermont/2026)
+  - [Florida Trail](https://www.trailjournals.com/journals/the_florida_trail/2026)
+  - [Arizona Trail](https://www.trailjournals.com/journals/arizona_trail/2026)
+  - [John Muir Trail](https://www.trailjournals.com/journals/john_muir_trail/2026)
+  - [Camino de Santiago](https://www.trailjournals.com/journals/camino_de_santiago/2026)
+  - [American Discovery Trail](https://www.trailjournals.com/journals/american_discovery_trail/2026)
+  - [Coast to Coast Walk](https://www.trailjournals.com/journals/coast_to_coast_walk/2026)
+  - [More...](https://www.trailjournals.com/journals/)
+- [Trails](https://www.trailjournals.com/trails/)
+- [Photos](https://www.trailjournals.com/photos/2026)
+- [Gear](https://www.trailjournals.com/journal/entry/315603#)  - [Current Sales](https://www.trailjournals.com/gear/deals/onsale)
+  - [REI](https://www.trailjournals.com/gear/rei)
+  - [ULA](https://www.trailjournals.com/gear/ula)
+  - [Patagonia](https://www.trailjournals.com/gear/patagonia)
+  - [Cabela's](https://www.trailjournals.com/gear/cabela)
+- [Planning](https://www.trailjournals.com/journal/entry/315603#)  - [Plan Your Hike](https://www.trailjournals.com/planning/)
+  - [Gear](https://www.trailjournals.com/gear/)
+  - [Books](https://www.trailjournals.com/books/)
+  - [Links](https://www.trailjournals.com/links/)
+- [Search](https://www.trailjournals.com/search/)
+- [About](https://www.trailjournals.com/journal/entry/315603#)  - [About Trailjournals](https://www.trailjournals.com/about/)
+  - [Login](https://www.trailjournals.com/user/login)
+  - [Join](https://www.trailjournals.com/join)
+  - [Support Trailjournals](https://www.trailjournals.com/about/donate/)
+  - [Contact](https://www.trailjournals.com/about/contact)
+  - [Store](https://www.trailjournals.com/store/)
+
+Backpacking Journals and Photos from Long Distance Hikers
+
+1. [Home](https://www.trailjournals.com/)
+2. [Journals](https://www.trailjournals.com/journals)
+3. [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail)
+4. [2010](https://www.trailjournals.com/journals/appalachian_trail/2010)
+5. [Uncle Frank](https://www.trailjournals.com/journal/10467)
+6. [Entries](https://www.trailjournals.com/journal/entries/10467/uncle%20-frank)
+7. June 10, 2010
+
+Toggle navigation
+
+- [Journal](https://www.trailjournals.com/journal/10467)
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+- [My Journals](https://www.trailjournals.com/myjournals/10467)
+- [View Guest Book](https://www.trailjournals.com/journal/guestbook/10467)
+- [Sign Guest Book](https://www.trailjournals.com/journal/guestbook/sign/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/4a.gif)![](https://www.trailjournals.com/images/2a.gif)![](https://www.trailjournals.com/images/3a.gif)
+
+[Journal](https://www.trailjournals.com/journal/10467)
+
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+
+--Choose--01/21/1002/06/1002/07/1002/08/1002/09/1002/10/1002/11/1002/12/1002/13/1002/14/1002/15/1002/16/1002/17/1002/18/1002/19/1002/20/1002/21/1002/22/1002/23/1002/24/1002/25/1002/26/1002/27/1002/28/1003/01/1003/02/1003/03/1003/04/1003/05/1003/06/1003/07/1003/08/1003/09/1003/11/1003/12/1003/13/1003/14/1003/15/1003/16/1003/17/1003/18/1003/19/1003/20/1003/21/1003/24/1003/25/1003/26/1003/27/1003/28/1003/29/1003/30/1003/31/1004/01/1004/02/1004/03/1004/04/1004/05/1004/06/1004/07/1004/08/1004/09/1004/10/1004/11/1004/12/1004/13/1004/14/1004/15/1004/16/1004/17/1004/18/1004/19/1004/20/1004/21/1004/23/1004/24/1004/25/1004/26/1004/27/1004/28/1004/29/1004/30/1005/01/1005/02/1005/03/1005/04/1005/05/1005/06/1005/07/1005/08/1005/09/1005/10/1005/11/1005/12/1005/13/1005/14/1005/15/1005/16/1005/17/1005/18/1005/19/1005/20/1005/21/1005/22/1005/23/1005/24/1005/25/1005/26/1005/27/1005/28/1005/29/1005/30/1005/31/1006/01/1006/02/1006/03/1006/04/1006/05/1006/06/1006/07/1006/08/1006/09/1006/10/1006/11/1006/12/1006/13/1006/14/1006/15/1006/16/1006/17/1006/18/1006/19/1006/20/1006/21/10
+
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+
+Guest Book
+
+- [Sign](https://www.trailjournals.com/journal/guestbook/sign/10467)
+- [View](https://www.trailjournals.com/journal/guestbook/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/4a.gif)![](https://www.trailjournals.com/images/2a.gif)![](https://www.trailjournals.com/images/3a.gif)
+
+- [AT Journals](https://www.trailjournals.com/journals/appalachian_trail)
+- [AT Photos](https://www.trailjournals.com/photos/appalachian_trail)
+- [AT Books](https://www.trailjournals.com/books/appalachian_trail)
+- [Appalachian Trail](http://www.appalachiantrail.org/)
+
+[Join](https://www.trailjournals.com/join) [Login](https://www.trailjournals.com/user/login)
+
+[RSS](https://www.trailjournals.com/journal/rss/10467/xml)
+
+# Uncle Frank's 2010  Appalachian Trail Journal
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/315602) [Next](https://www.trailjournals.com/journal/entry/315604) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+Thursday, June 10, 2010
+
+Destination:Spaulding Mountain Lean-to
+
+Today's Miles:10.70
+
+Start Location:Bob's Hostel (Rangely, ME)
+
+Trip Miles:1969.50
+
+Destination:Spaulding Mountain Lean-to
+
+Start Location:Bob's Hostel (Rangely, ME)
+
+Today's Miles:10.70
+
+Trip Miles:1969.50
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/315602) [Next](https://www.trailjournals.com/journal/entry/315604) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+### Hiker Entries June 10, 2010
+
+|  | Journalist | Destination | Trail |
+| --- | --- | --- | --- |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DriveThruHikers_23038TN.jpg) | [Drive Thru Hikers](https://www.trailjournals.com/journal/about/23038) | [Hoosic River,Church St.](https://www.trailjournals.com/journal/entry/599738) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Deluxe](https://www.trailjournals.com/journal/about/21748) | [Lean To](https://www.trailjournals.com/journal/entry/566462) | [Northville-Placid Trail](https://www.trailjournals.com/journals/Northville-Placid%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2012FLTEndtoEnd_11316TN.jpg) | [FLT End to End](https://www.trailjournals.com/journal/about/11316) | [Perkins Pond Lean-to (Perkins Pond SF)](https://www.trailjournals.com/journal/entry/398915) | [Finger Lakes Trail](https://www.trailjournals.com/journals/Finger%20_Lakes%20_Trail) |
+|  | [Transient](https://www.trailjournals.com/journal/about/13775) | [Vidette Meadows](https://www.trailjournals.com/journal/entry/380600) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+|  | ["Dances with Wolfie"](https://www.trailjournals.com/journal/about/7342) | [Little Dam Lake](https://www.trailjournals.com/journal/entry/335964) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [FireBall](https://www.trailjournals.com/journal/about/9897) | [Still approaching Gunsight Pass](https://www.trailjournals.com/journal/entry/335133) | [Continental Divide Trail](https://www.trailjournals.com/journals/Continental%20_Divide%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010SilverSprings_10614TN.jpg) | [Silver Springs](https://www.trailjournals.com/journal/about/10614) | [\-\- View Entry --](https://www.trailjournals.com/journal/entry/332066) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Red Fox](https://www.trailjournals.com/journal/about/10662) | [Deep Gap](https://www.trailjournals.com/journal/entry/329863) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Trooper](https://www.trailjournals.com/journal/about/10644) | [1 Mile North of Mt. Baden-Powell Spur Trail](https://www.trailjournals.com/journal/entry/329384) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Peru_10969TN.jpg) | [Peru](https://www.trailjournals.com/journal/about/10969) | [Woods Hole Hostel](https://www.trailjournals.com/journal/entry/325466) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| [More...](https://www.trailjournals.com/entries/2010/06/10) [Grouped By Trail...](https://www.trailjournals.com/entries/2010/06/10/trail) |
+
+|     |
+| --- |
+| I have been helped by total strangers, some who speak a different dialect and/or language ... you know pilgrim when you see one, and I have gotten lost a few times even with a map ... but the locals always point me in the right direction ... it has taken away from my cynical nature towards humanity ... ... <br>[El Camino de Santiago](https://www.trailjournals.com/journal/entry/391229) —<br>[Camino de Santiago](https://www.trailjournals.com/journals/camino_de_santiago) [2012](https://www.trailjournals.com/journals/camino_de_santiago/2012) |
+
+[![Trailjournals](https://www.trailjournals.com/images/logo.png)](https://www.trailjournals.com/)
+
+#### Hiking
+
+- [Trails](https://www.trailjournals.com/trails/list)
+- [Journals](https://www.trailjournals.com/journals)
+- [Photos](https://www.trailjournals.com/photos)
+- [Calendar](https://www.trailjournals.com/calendar)
+- Gear
+- [Links](https://www.trailjournals.com/links)
+
+#### Partners
+
+- [ULA Equipment](https://ula-equipment.sjv.io/drN9K)
+- [REI](http://www.avantlink.com/click.php?tt=ml&ti=45265&pw=68025)
+- [Patagonia](http://www.avantlink.com/click.php?tt=ml&ti=45781&pw=68025)
+
+#### Network
+
+- [Trail Forums](http://www.trailforums.com/)
+- Trail News
+
+#### About Us
+
+- [Contact](https://www.trailjournals.com/about/contact)
+- [Donate](https://www.trailjournals.com/about/donate)
+- [Join](https://www.trailjournals.com/join)
+- [Login](https://www.trailjournals.com/user/login)
+- [Help](https://www.trailjournals.com/help)
+
+#### Follow Us
+
+- [Facebook](https://www.facebook.com/trailjournals)
+- [Instagram](https://instagram.com/trailjournals/)
+- [Twitter](https://twitter.com/trailjournals)
+- [Pinterest](https://www.pinterest.com/trailjournals/)
+- [Linkedin](https://www.linkedin.com/company/trailjournals-llc)
+
+Top Photo © Mathew Olsen - The Colorado Trail,
+06/22/2001 by
+[Leif](https://www.trailjournals.com/journal/97)
+
+Trailjournals LLC © 2026
+All Rights Reserved. [privacy policy](https://www.trailjournals.com/about/privacy)
+
+Newburyport, MA 01950
+
+[Terms under which this service is provided to you.](https://www.trailjournals.com/about/privacy)
+
+Build: 20210226:165913 [Manage Settings](https://www.trailjournals.com/about/settings)
+---
+
+# Friday, June 11, 2010 — Horns Pond Lean-to
+**Start Location:** Spaulding Mountain Lean-to
+**Miles Today:** 27
+**Trip Miles:** 1996.50
+
+|     |
+| --- |
+| [![](https://www.trailjournals.com/images/photos/journals/10467/tj10467_061410_170842_541174.jpg)](https://www.trailjournals.com/journal/photos/10467/541174/315604)<br>**_An evening view by Horn Pond_** |
+---
+
+# Saturday, June 12, 2010 — A swamp near Pierce Pond Lean-to
+**Start Location:** Horns Pond Lean-to
+**Miles Today:** 25
+**Trip Miles:** 2021.50
+
+Toggle navigation[Trail Journals](https://www.trailjournals.com/)
+
+- [Journals](https://www.trailjournals.com/journal/entry/315605#)  - [Journals](https://www.trailjournals.com/journals)
+  - [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail/2026)
+  - [Pacific Crest Trail](https://www.trailjournals.com/journals/pacific_crest_trail/2026)
+  - [Colorado Trail](https://www.trailjournals.com/journals/colorado_trail/2026)
+  - [Continental Divide Trail](https://www.trailjournals.com/journals/continental_divide_trail/2026)
+  - [Long Trail - Vermont](https://www.trailjournals.com/journals/the_long_trail_-_vermont/2026)
+  - [Florida Trail](https://www.trailjournals.com/journals/the_florida_trail/2026)
+  - [Arizona Trail](https://www.trailjournals.com/journals/arizona_trail/2026)
+  - [John Muir Trail](https://www.trailjournals.com/journals/john_muir_trail/2026)
+  - [Camino de Santiago](https://www.trailjournals.com/journals/camino_de_santiago/2026)
+  - [American Discovery Trail](https://www.trailjournals.com/journals/american_discovery_trail/2026)
+  - [Coast to Coast Walk](https://www.trailjournals.com/journals/coast_to_coast_walk/2026)
+  - [More...](https://www.trailjournals.com/journals/)
+- [Trails](https://www.trailjournals.com/trails/)
+- [Photos](https://www.trailjournals.com/photos/2026)
+- [Gear](https://www.trailjournals.com/journal/entry/315605#)  - [Current Sales](https://www.trailjournals.com/gear/deals/onsale)
+  - [REI](https://www.trailjournals.com/gear/rei)
+  - [ULA](https://www.trailjournals.com/gear/ula)
+  - [Patagonia](https://www.trailjournals.com/gear/patagonia)
+  - [Cabela's](https://www.trailjournals.com/gear/cabela)
+- [Planning](https://www.trailjournals.com/journal/entry/315605#)  - [Plan Your Hike](https://www.trailjournals.com/planning/)
+  - [Gear](https://www.trailjournals.com/gear/)
+  - [Books](https://www.trailjournals.com/books/)
+  - [Links](https://www.trailjournals.com/links/)
+- [Search](https://www.trailjournals.com/search/)
+- [About](https://www.trailjournals.com/journal/entry/315605#)  - [About Trailjournals](https://www.trailjournals.com/about/)
+  - [Login](https://www.trailjournals.com/user/login)
+  - [Join](https://www.trailjournals.com/join)
+  - [Support Trailjournals](https://www.trailjournals.com/about/donate/)
+  - [Contact](https://www.trailjournals.com/about/contact)
+  - [Store](https://www.trailjournals.com/store/)
+
+Backpacking Journals and Photos from Long Distance Hikers
+
+1. [Home](https://www.trailjournals.com/)
+2. [Journals](https://www.trailjournals.com/journals)
+3. [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail)
+4. [2010](https://www.trailjournals.com/journals/appalachian_trail/2010)
+5. [Uncle Frank](https://www.trailjournals.com/journal/10467)
+6. [Entries](https://www.trailjournals.com/journal/entries/10467/uncle%20-frank)
+7. June 12, 2010
+
+Toggle navigation
+
+- [Journal](https://www.trailjournals.com/journal/10467)
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+- [My Journals](https://www.trailjournals.com/myjournals/10467)
+- [View Guest Book](https://www.trailjournals.com/journal/guestbook/10467)
+- [Sign Guest Book](https://www.trailjournals.com/journal/guestbook/sign/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/4a.gif)![](https://www.trailjournals.com/images/2a.gif)![](https://www.trailjournals.com/images/6a.gif)
+
+[Journal](https://www.trailjournals.com/journal/10467)
+
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+
+--Choose--01/21/1002/06/1002/07/1002/08/1002/09/1002/10/1002/11/1002/12/1002/13/1002/14/1002/15/1002/16/1002/17/1002/18/1002/19/1002/20/1002/21/1002/22/1002/23/1002/24/1002/25/1002/26/1002/27/1002/28/1003/01/1003/02/1003/03/1003/04/1003/05/1003/06/1003/07/1003/08/1003/09/1003/11/1003/12/1003/13/1003/14/1003/15/1003/16/1003/17/1003/18/1003/19/1003/20/1003/21/1003/24/1003/25/1003/26/1003/27/1003/28/1003/29/1003/30/1003/31/1004/01/1004/02/1004/03/1004/04/1004/05/1004/06/1004/07/1004/08/1004/09/1004/10/1004/11/1004/12/1004/13/1004/14/1004/15/1004/16/1004/17/1004/18/1004/19/1004/20/1004/21/1004/23/1004/24/1004/25/1004/26/1004/27/1004/28/1004/29/1004/30/1005/01/1005/02/1005/03/1005/04/1005/05/1005/06/1005/07/1005/08/1005/09/1005/10/1005/11/1005/12/1005/13/1005/14/1005/15/1005/16/1005/17/1005/18/1005/19/1005/20/1005/21/1005/22/1005/23/1005/24/1005/25/1005/26/1005/27/1005/28/1005/29/1005/30/1005/31/1006/01/1006/02/1006/03/1006/04/1006/05/1006/06/1006/07/1006/08/1006/09/1006/10/1006/11/1006/12/1006/13/1006/14/1006/15/1006/16/1006/17/1006/18/1006/19/1006/20/1006/21/10
+
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+
+Guest Book
+
+- [Sign](https://www.trailjournals.com/journal/guestbook/sign/10467)
+- [View](https://www.trailjournals.com/journal/guestbook/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/4a.gif)![](https://www.trailjournals.com/images/2a.gif)![](https://www.trailjournals.com/images/6a.gif)
+
+- [AT Journals](https://www.trailjournals.com/journals/appalachian_trail)
+- [AT Photos](https://www.trailjournals.com/photos/appalachian_trail)
+- [AT Books](https://www.trailjournals.com/books/appalachian_trail)
+- [Appalachian Trail](http://www.appalachiantrail.org/)
+
+[Join](https://www.trailjournals.com/join) [Login](https://www.trailjournals.com/user/login)
+
+[RSS](https://www.trailjournals.com/journal/rss/10467/xml)
+
+# Uncle Frank's 2010  Appalachian Trail Journal
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/315604) [Next](https://www.trailjournals.com/journal/entry/315608) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+Saturday, June 12, 2010
+
+Destination:A swamp near Pierce Pond Lean-to
+
+Today's Miles:25
+
+Start Location:Horns Pond Lean-to
+
+Trip Miles:2021.50
+
+Destination:A swamp near Pierce Pond Lean-to
+
+Start Location:Horns Pond Lean-to
+
+Today's Miles:25
+
+Trip Miles:2021.50
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/315604) [Next](https://www.trailjournals.com/journal/entry/315608) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+### Hiker Entries June 12, 2010
+
+|  | Journalist | Destination | Trail |
+| --- | --- | --- | --- |
+|  | [Deluxe](https://www.trailjournals.com/journal/about/21748) | [\-\- View Entry --](https://www.trailjournals.com/journal/entry/566465) | [Northville-Placid Trail](https://www.trailjournals.com/journals/Northville-Placid%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2012FLTEndtoEnd_11316TN.jpg) | [FLT End to End](https://www.trailjournals.com/journal/about/11316) | [Site 154 (Bowman Lake SP)](https://www.trailjournals.com/journal/entry/398917) | [Finger Lakes Trail](https://www.trailjournals.com/journals/Finger%20_Lakes%20_Trail) |
+|  | [Transient](https://www.trailjournals.com/journal/about/13775) | [Lone Pine](https://www.trailjournals.com/journal/entry/380602) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010seeksit_11881TN.jpg) | [seeksit](https://www.trailjournals.com/journal/about/11881) | [loop hike](https://www.trailjournals.com/journal/entry/337777) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | ["Dances with Wolfie"](https://www.trailjournals.com/journal/about/7342) | [Graymoor Friary](https://www.trailjournals.com/journal/entry/335987) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [FireBall](https://www.trailjournals.com/journal/about/9897) | [Wolf Pass near South Fork](https://www.trailjournals.com/journal/entry/335134) | [Continental Divide Trail](https://www.trailjournals.com/journals/Continental%20_Divide%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/1999beaker_6183TN.jpg) | [beaker](https://www.trailjournals.com/journal/about/6183) | [Birch Run Shelter](https://www.trailjournals.com/journal/entry/334998) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DidgeridudeandDoodlebug_9852TN.jpg) | [Didgeridude and Doodlebug](https://www.trailjournals.com/journal/about/9852) | [Birch Run Shelter](https://www.trailjournals.com/journal/entry/334681) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Red Fox](https://www.trailjournals.com/journal/about/10662) | [Clyde Smith shlter](https://www.trailjournals.com/journal/entry/329865) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Trooper](https://www.trailjournals.com/journal/about/10644) | [PCT detour - KOA Soledad Canyon Rd.](https://www.trailjournals.com/journal/entry/329388) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+| [More...](https://www.trailjournals.com/entries/2010/06/12) [Grouped By Trail...](https://www.trailjournals.com/entries/2010/06/12/trail) |
+
+|     |
+| --- |
+| I always hike better in the evening. The canyon opens up its impressive walls to a wide open space. It sprinkles on and off. Absolutely beautiful out here. ... <br>[Noworries](https://www.trailjournals.com/journal/entry/536312) —<br>[Continental Divide Trail](https://www.trailjournals.com/journals/continental_divide_trail) [2016](https://www.trailjournals.com/journals/continental_divide_trail/2016) |
+
+[![Trailjournals](https://www.trailjournals.com/images/logo.png)](https://www.trailjournals.com/)
+
+#### Hiking
+
+- [Trails](https://www.trailjournals.com/trails/list)
+- [Journals](https://www.trailjournals.com/journals)
+- [Photos](https://www.trailjournals.com/photos)
+- [Calendar](https://www.trailjournals.com/calendar)
+- Gear
+- [Links](https://www.trailjournals.com/links)
+
+#### Partners
+
+- [ULA Equipment](https://ula-equipment.sjv.io/drN9K)
+- [REI](http://www.avantlink.com/click.php?tt=ml&ti=45265&pw=68025)
+- [Patagonia](http://www.avantlink.com/click.php?tt=ml&ti=45781&pw=68025)
+
+#### Network
+
+- [Trail Forums](http://www.trailforums.com/)
+- Trail News
+
+#### About Us
+
+- [Contact](https://www.trailjournals.com/about/contact)
+- [Donate](https://www.trailjournals.com/about/donate)
+- [Join](https://www.trailjournals.com/join)
+- [Login](https://www.trailjournals.com/user/login)
+- [Help](https://www.trailjournals.com/help)
+
+#### Follow Us
+
+- [Facebook](https://www.facebook.com/trailjournals)
+- [Instagram](https://instagram.com/trailjournals/)
+- [Twitter](https://twitter.com/trailjournals)
+- [Pinterest](https://www.pinterest.com/trailjournals/)
+- [Linkedin](https://www.linkedin.com/company/trailjournals-llc)
+
+Top Photo © Mathew Olsen - The Colorado Trail,
+06/22/2001 by
+[Leif](https://www.trailjournals.com/journal/97)
+
+Trailjournals LLC © 2026
+All Rights Reserved. [privacy policy](https://www.trailjournals.com/about/privacy)
+
+Newburyport, MA 01950
+
+[Terms under which this service is provided to you.](https://www.trailjournals.com/about/privacy)
+
+Build: 20210226:165913 [Manage Settings](https://www.trailjournals.com/about/settings)
+---
+
+# Sunday, June 13, 2010 — Shaw's Boarding House
+**Start Location:** A swamp near Pierce Pond Lean-to
+**Miles Today:** 40
+**Trip Miles:** 2061.50
+
+|     |
+| --- |
+| [![](https://www.trailjournals.com/images/photos/journals/10467/tj10467_061410_173417_541176.jpg)](https://www.trailjournals.com/journal/photos/10467/541176/315608)<br>**_The ferry over the Kennebec_** |
+
+What a day! It was only 4 o'clock, and it was dim out. But the morning summer light was growing as it does these days, permitting an early start on the trail. Out here, I've never seen the sun so wild. It sets later and rises earlier than it does living inside, and this morning I noticed its faint glow lighting up the sky well before my 4 o'clock departure. I guess I know the sun better than I used to.
+At 5:45 I arrived at the Pierce Pond Shelter and took a 5-minute blue-blaze trail to Harrison’s Camp, home to Harrison’s infamous 12-pancake breakfast. It was still dim and the place was silent, so I walked inside and passed out on a couch. I would’ve marched on for sake of time, but I needed this breakfast—those 12 pancakes would get me 40 miles to Monson by that night. By 9:30 I was, at last, stuffed with sausage, eggs, and twelve blueberry, apple, and cranberry pancakes (honestly, I was surprised at the feat). I moved swiftly on to the ferry at the Kennebec River.
+At the river bank, loons cooed and disappeared underwater. I made a “skalooo” sound, and heard a “skaloo” back from the woods across the river. A man with a straw hat pulled a canoe from the tree-line and paddled across. “Hillbilly Joe” was his name, owing perhaps to his missing teeth. “Thanks for the ferry, man!” I exclaimed enthusiastically. “That’s what I’m here for,” he replied. Across the river, I kept walking.
+The day passed by under sunny skies. Yeah, it hurt, but I was in the mood to hike. Also, the terrain was mild at last. Nervous that darkness would fall before I arrived in Monson (I had no headlamp), the whole day I kept checking my coordinates, counting my mileage and calculating my pace.
+Near sunset, I stopped in a shelter to ask for a headlamp. Perhaps, I figured, I could buy one off a hiker with an extra (a fat chance, right?). Unfortunately, none of the 4 hikers had one. As I went to leave, I heard “wait a minute…I might actually have one.” Believe it or not, he did! I almost kissed the guy. Back on the trail, I found two little boxes of raisins! Then a spring to fill my bottle! I knew it was just good luck but, deep down, God was looking out for me.
+Into the night I hiked. At mile 34, five outside Monson, I hit my limit and crashed at a shelter to rest.
+---
+
+# Monday, June 14, 2010 — Shaw's Boarding House
+**Start Location:** Shaw's Boarding House
+**Miles Today:** 0
+**Trip Miles:** 2061.50
+
+Toggle navigation[Trail Journals](https://www.trailjournals.com/)
+
+- [Journals](https://www.trailjournals.com/journal/entry/316907#)  - [Journals](https://www.trailjournals.com/journals)
+  - [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail/2026)
+  - [Pacific Crest Trail](https://www.trailjournals.com/journals/pacific_crest_trail/2026)
+  - [Colorado Trail](https://www.trailjournals.com/journals/colorado_trail/2026)
+  - [Continental Divide Trail](https://www.trailjournals.com/journals/continental_divide_trail/2026)
+  - [Long Trail - Vermont](https://www.trailjournals.com/journals/the_long_trail_-_vermont/2026)
+  - [Florida Trail](https://www.trailjournals.com/journals/the_florida_trail/2026)
+  - [Arizona Trail](https://www.trailjournals.com/journals/arizona_trail/2026)
+  - [John Muir Trail](https://www.trailjournals.com/journals/john_muir_trail/2026)
+  - [Camino de Santiago](https://www.trailjournals.com/journals/camino_de_santiago/2026)
+  - [American Discovery Trail](https://www.trailjournals.com/journals/american_discovery_trail/2026)
+  - [Coast to Coast Walk](https://www.trailjournals.com/journals/coast_to_coast_walk/2026)
+  - [More...](https://www.trailjournals.com/journals/)
+- [Trails](https://www.trailjournals.com/trails/)
+- [Photos](https://www.trailjournals.com/photos/2026)
+- [Gear](https://www.trailjournals.com/journal/entry/316907#)  - [Current Sales](https://www.trailjournals.com/gear/deals/onsale)
+  - [REI](https://www.trailjournals.com/gear/rei)
+  - [ULA](https://www.trailjournals.com/gear/ula)
+  - [Patagonia](https://www.trailjournals.com/gear/patagonia)
+  - [Cabela's](https://www.trailjournals.com/gear/cabela)
+- [Planning](https://www.trailjournals.com/journal/entry/316907#)  - [Plan Your Hike](https://www.trailjournals.com/planning/)
+  - [Gear](https://www.trailjournals.com/gear/)
+  - [Books](https://www.trailjournals.com/books/)
+  - [Links](https://www.trailjournals.com/links/)
+- [Search](https://www.trailjournals.com/search/)
+- [About](https://www.trailjournals.com/journal/entry/316907#)  - [About Trailjournals](https://www.trailjournals.com/about/)
+  - [Login](https://www.trailjournals.com/user/login)
+  - [Join](https://www.trailjournals.com/join)
+  - [Support Trailjournals](https://www.trailjournals.com/about/donate/)
+  - [Contact](https://www.trailjournals.com/about/contact)
+  - [Store](https://www.trailjournals.com/store/)
+
+Backpacking Journals and Photos from Long Distance Hikers
+
+1. [Home](https://www.trailjournals.com/)
+2. [Journals](https://www.trailjournals.com/journals)
+3. [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail)
+4. [2010](https://www.trailjournals.com/journals/appalachian_trail/2010)
+5. [Uncle Frank](https://www.trailjournals.com/journal/10467)
+6. [Entries](https://www.trailjournals.com/journal/entries/10467/uncle%20-frank)
+7. June 14, 2010
+
+Toggle navigation
+
+- [Journal](https://www.trailjournals.com/journal/10467)
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+- [My Journals](https://www.trailjournals.com/myjournals/10467)
+- [View Guest Book](https://www.trailjournals.com/journal/guestbook/10467)
+- [Sign Guest Book](https://www.trailjournals.com/journal/guestbook/sign/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/4a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/0a.gif)
+
+[Journal](https://www.trailjournals.com/journal/10467)
+
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+
+--Choose--01/21/1002/06/1002/07/1002/08/1002/09/1002/10/1002/11/1002/12/1002/13/1002/14/1002/15/1002/16/1002/17/1002/18/1002/19/1002/20/1002/21/1002/22/1002/23/1002/24/1002/25/1002/26/1002/27/1002/28/1003/01/1003/02/1003/03/1003/04/1003/05/1003/06/1003/07/1003/08/1003/09/1003/11/1003/12/1003/13/1003/14/1003/15/1003/16/1003/17/1003/18/1003/19/1003/20/1003/21/1003/24/1003/25/1003/26/1003/27/1003/28/1003/29/1003/30/1003/31/1004/01/1004/02/1004/03/1004/04/1004/05/1004/06/1004/07/1004/08/1004/09/1004/10/1004/11/1004/12/1004/13/1004/14/1004/15/1004/16/1004/17/1004/18/1004/19/1004/20/1004/21/1004/23/1004/24/1004/25/1004/26/1004/27/1004/28/1004/29/1004/30/1005/01/1005/02/1005/03/1005/04/1005/05/1005/06/1005/07/1005/08/1005/09/1005/10/1005/11/1005/12/1005/13/1005/14/1005/15/1005/16/1005/17/1005/18/1005/19/1005/20/1005/21/1005/22/1005/23/1005/24/1005/25/1005/26/1005/27/1005/28/1005/29/1005/30/1005/31/1006/01/1006/02/1006/03/1006/04/1006/05/1006/06/1006/07/1006/08/1006/09/1006/10/1006/11/1006/12/1006/13/1006/14/1006/15/1006/16/1006/17/1006/18/1006/19/1006/20/1006/21/10
+
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+
+Guest Book
+
+- [Sign](https://www.trailjournals.com/journal/guestbook/sign/10467)
+- [View](https://www.trailjournals.com/journal/guestbook/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/4a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/0a.gif)
+
+- [AT Journals](https://www.trailjournals.com/journals/appalachian_trail)
+- [AT Photos](https://www.trailjournals.com/photos/appalachian_trail)
+- [AT Books](https://www.trailjournals.com/books/appalachian_trail)
+- [Appalachian Trail](http://www.appalachiantrail.org/)
+
+[Join](https://www.trailjournals.com/join) [Login](https://www.trailjournals.com/user/login)
+
+[RSS](https://www.trailjournals.com/journal/rss/10467/xml)
+
+# Uncle Frank's 2010  Appalachian Trail Journal
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/315608) [Next](https://www.trailjournals.com/journal/entry/316908) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+Monday, June 14, 2010
+
+Destination:Shaw's Boarding House
+
+Today's Miles:0
+
+Start Location:Shaw's Boarding House
+
+Trip Miles:2061.50
+
+Destination:Shaw's Boarding House
+
+Start Location:Shaw's Boarding House
+
+Today's Miles:0
+
+Trip Miles:2061.50
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/315608) [Next](https://www.trailjournals.com/journal/entry/316908) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+### Hiker Entries June 14, 2010
+
+|  | Journalist | Destination | Trail |
+| --- | --- | --- | --- |
+|  | [RuhRoh](https://www.trailjournals.com/journal/about/13023) | [Peck's Corner Shelter](https://www.trailjournals.com/journal/entry/366124) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010seeksit_11881TN.jpg) | [seeksit](https://www.trailjournals.com/journal/about/11881) | [Soldier's Delight Natural Area](https://www.trailjournals.com/journal/entry/338075) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | ["Dances with Wolfie"](https://www.trailjournals.com/journal/about/7342) | [RPH Shelter](https://www.trailjournals.com/journal/entry/335991) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/1999beaker_6183TN.jpg) | [beaker](https://www.trailjournals.com/journal/about/6183) | [Boiling Springs](https://www.trailjournals.com/journal/entry/335000) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DidgeridudeandDoodlebug_9852TN.jpg) | [Didgeridude and Doodlebug](https://www.trailjournals.com/journal/about/9852) | [stream](https://www.trailjournals.com/journal/entry/334683) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010LittleFootTheLandBeforeTime_10864TN.jpg) | [Little Foot (The Land Before Time)](https://www.trailjournals.com/journal/about/10864) | [Nowheeeere](https://www.trailjournals.com/journal/entry/331374) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [bone lady](https://www.trailjournals.com/journal/about/11245) | [Norwich, CT](https://www.trailjournals.com/journal/entry/330816) | [The Long Trail - Vermont](https://www.trailjournals.com/journals/The%20_Long%20_Trail%20_-%20_Vermont) |
+|  | [Red Fox](https://www.trailjournals.com/journal/about/10662) | [19E](https://www.trailjournals.com/journal/entry/329868) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Trooper](https://www.trailjournals.com/journal/about/10644) | [San Francisquito Road](https://www.trailjournals.com/journal/entry/329331) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Peru_10969TN.jpg) | [Peru](https://www.trailjournals.com/journal/about/10969) | [War Spur Shelter](https://www.trailjournals.com/journal/entry/325470) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| [More...](https://www.trailjournals.com/entries/2010/06/14) [Grouped By Trail...](https://www.trailjournals.com/entries/2010/06/14/trail) |
+
+|     |
+| --- |
+| ...we hadn't planned a zero so soon, but it feels wonderful now and I am really looking forward to hiking out tomorrow. "Plans are worthless, but planning is everything". Dwight Eisenhower... <br>[Katwalk](https://www.trailjournals.com/journal/entry/485503) —<br>[Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail) [2015](https://www.trailjournals.com/journals/appalachian_trail/2015) |
+
+[![Trailjournals](https://www.trailjournals.com/images/logo.png)](https://www.trailjournals.com/)
+
+#### Hiking
+
+- [Trails](https://www.trailjournals.com/trails/list)
+- [Journals](https://www.trailjournals.com/journals)
+- [Photos](https://www.trailjournals.com/photos)
+- [Calendar](https://www.trailjournals.com/calendar)
+- Gear
+- [Links](https://www.trailjournals.com/links)
+
+#### Partners
+
+- [ULA Equipment](https://ula-equipment.sjv.io/drN9K)
+- [REI](http://www.avantlink.com/click.php?tt=ml&ti=45265&pw=68025)
+- [Patagonia](http://www.avantlink.com/click.php?tt=ml&ti=45781&pw=68025)
+
+#### Network
+
+- [Trail Forums](http://www.trailforums.com/)
+- Trail News
+
+#### About Us
+
+- [Contact](https://www.trailjournals.com/about/contact)
+- [Donate](https://www.trailjournals.com/about/donate)
+- [Join](https://www.trailjournals.com/join)
+- [Login](https://www.trailjournals.com/user/login)
+- [Help](https://www.trailjournals.com/help)
+
+#### Follow Us
+
+- [Facebook](https://www.facebook.com/trailjournals)
+- [Instagram](https://instagram.com/trailjournals/)
+- [Twitter](https://twitter.com/trailjournals)
+- [Pinterest](https://www.pinterest.com/trailjournals/)
+- [Linkedin](https://www.linkedin.com/company/trailjournals-llc)
+
+Top Photo © Mathew Olsen - The Colorado Trail,
+06/22/2001 by
+[Leif](https://www.trailjournals.com/journal/97)
+
+Trailjournals LLC © 2026
+All Rights Reserved. [privacy policy](https://www.trailjournals.com/about/privacy)
+
+Newburyport, MA 01950
+
+[Terms under which this service is provided to you.](https://www.trailjournals.com/about/privacy)
+
+Build: 20210226:165913 [Manage Settings](https://www.trailjournals.com/about/settings)
+---
+
+# Tuesday, June 15, 2010 — Wilson Valley Lean-to
+**Start Location:** Shaw's Boarding House
+**Miles Today:** 13.70
+**Trip Miles:** 2075.20
+
+Toggle navigation[Trail Journals](https://www.trailjournals.com/)
+
+- [Journals](https://www.trailjournals.com/journal/entry/316908#)  - [Journals](https://www.trailjournals.com/journals)
+  - [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail/2026)
+  - [Pacific Crest Trail](https://www.trailjournals.com/journals/pacific_crest_trail/2026)
+  - [Colorado Trail](https://www.trailjournals.com/journals/colorado_trail/2026)
+  - [Continental Divide Trail](https://www.trailjournals.com/journals/continental_divide_trail/2026)
+  - [Long Trail - Vermont](https://www.trailjournals.com/journals/the_long_trail_-_vermont/2026)
+  - [Florida Trail](https://www.trailjournals.com/journals/the_florida_trail/2026)
+  - [Arizona Trail](https://www.trailjournals.com/journals/arizona_trail/2026)
+  - [John Muir Trail](https://www.trailjournals.com/journals/john_muir_trail/2026)
+  - [Camino de Santiago](https://www.trailjournals.com/journals/camino_de_santiago/2026)
+  - [American Discovery Trail](https://www.trailjournals.com/journals/american_discovery_trail/2026)
+  - [Coast to Coast Walk](https://www.trailjournals.com/journals/coast_to_coast_walk/2026)
+  - [More...](https://www.trailjournals.com/journals/)
+- [Trails](https://www.trailjournals.com/trails/)
+- [Photos](https://www.trailjournals.com/photos/2026)
+- [Gear](https://www.trailjournals.com/journal/entry/316908#)  - [Current Sales](https://www.trailjournals.com/gear/deals/onsale)
+  - [REI](https://www.trailjournals.com/gear/rei)
+  - [ULA](https://www.trailjournals.com/gear/ula)
+  - [Patagonia](https://www.trailjournals.com/gear/patagonia)
+  - [Cabela's](https://www.trailjournals.com/gear/cabela)
+- [Planning](https://www.trailjournals.com/journal/entry/316908#)  - [Plan Your Hike](https://www.trailjournals.com/planning/)
+  - [Gear](https://www.trailjournals.com/gear/)
+  - [Books](https://www.trailjournals.com/books/)
+  - [Links](https://www.trailjournals.com/links/)
+- [Search](https://www.trailjournals.com/search/)
+- [About](https://www.trailjournals.com/journal/entry/316908#)  - [About Trailjournals](https://www.trailjournals.com/about/)
+  - [Login](https://www.trailjournals.com/user/login)
+  - [Join](https://www.trailjournals.com/join)
+  - [Support Trailjournals](https://www.trailjournals.com/about/donate/)
+  - [Contact](https://www.trailjournals.com/about/contact)
+  - [Store](https://www.trailjournals.com/store/)
+
+Backpacking Journals and Photos from Long Distance Hikers
+
+1. [Home](https://www.trailjournals.com/)
+2. [Journals](https://www.trailjournals.com/journals)
+3. [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail)
+4. [2010](https://www.trailjournals.com/journals/appalachian_trail/2010)
+5. [Uncle Frank](https://www.trailjournals.com/journal/10467)
+6. [Entries](https://www.trailjournals.com/journal/entries/10467/uncle%20-frank)
+7. June 15, 2010
+
+Toggle navigation
+
+- [Journal](https://www.trailjournals.com/journal/10467)
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+- [My Journals](https://www.trailjournals.com/myjournals/10467)
+- [View Guest Book](https://www.trailjournals.com/journal/guestbook/10467)
+- [Sign Guest Book](https://www.trailjournals.com/journal/guestbook/sign/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/4a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/2a.gif)
+
+[Journal](https://www.trailjournals.com/journal/10467)
+
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+
+--Choose--01/21/1002/06/1002/07/1002/08/1002/09/1002/10/1002/11/1002/12/1002/13/1002/14/1002/15/1002/16/1002/17/1002/18/1002/19/1002/20/1002/21/1002/22/1002/23/1002/24/1002/25/1002/26/1002/27/1002/28/1003/01/1003/02/1003/03/1003/04/1003/05/1003/06/1003/07/1003/08/1003/09/1003/11/1003/12/1003/13/1003/14/1003/15/1003/16/1003/17/1003/18/1003/19/1003/20/1003/21/1003/24/1003/25/1003/26/1003/27/1003/28/1003/29/1003/30/1003/31/1004/01/1004/02/1004/03/1004/04/1004/05/1004/06/1004/07/1004/08/1004/09/1004/10/1004/11/1004/12/1004/13/1004/14/1004/15/1004/16/1004/17/1004/18/1004/19/1004/20/1004/21/1004/23/1004/24/1004/25/1004/26/1004/27/1004/28/1004/29/1004/30/1005/01/1005/02/1005/03/1005/04/1005/05/1005/06/1005/07/1005/08/1005/09/1005/10/1005/11/1005/12/1005/13/1005/14/1005/15/1005/16/1005/17/1005/18/1005/19/1005/20/1005/21/1005/22/1005/23/1005/24/1005/25/1005/26/1005/27/1005/28/1005/29/1005/30/1005/31/1006/01/1006/02/1006/03/1006/04/1006/05/1006/06/1006/07/1006/08/1006/09/1006/10/1006/11/1006/12/1006/13/1006/14/1006/15/1006/16/1006/17/1006/18/1006/19/1006/20/1006/21/10
+
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+
+Guest Book
+
+- [Sign](https://www.trailjournals.com/journal/guestbook/sign/10467)
+- [View](https://www.trailjournals.com/journal/guestbook/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/4a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/2a.gif)
+
+- [AT Journals](https://www.trailjournals.com/journals/appalachian_trail)
+- [AT Photos](https://www.trailjournals.com/photos/appalachian_trail)
+- [AT Books](https://www.trailjournals.com/books/appalachian_trail)
+- [Appalachian Trail](http://www.appalachiantrail.org/)
+
+[Join](https://www.trailjournals.com/join) [Login](https://www.trailjournals.com/user/login)
+
+[RSS](https://www.trailjournals.com/journal/rss/10467/xml)
+
+# Uncle Frank's 2010  Appalachian Trail Journal
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/316907) [Next](https://www.trailjournals.com/journal/entry/316909) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+Tuesday, June 15, 2010
+
+Destination:Wilson Valley Lean-to
+
+Today's Miles:13.70
+
+Start Location:Shaw's Boarding House
+
+Trip Miles:2075.20
+
+Destination:Wilson Valley Lean-to
+
+Start Location:Shaw's Boarding House
+
+Today's Miles:13.70
+
+Trip Miles:2075.20
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/316907) [Next](https://www.trailjournals.com/journal/entry/316909) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+### Hiker Entries June 15, 2010
+
+|  | Journalist | Destination | Trail |
+| --- | --- | --- | --- |
+|  | [RuhRoh](https://www.trailjournals.com/journal/about/13023) | [Newfound Gap](https://www.trailjournals.com/journal/entry/366125) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Rough Cut](https://www.trailjournals.com/journal/about/11734) | [RPH Shelter](https://www.trailjournals.com/journal/entry/336856) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | ["Dances with Wolfie"](https://www.trailjournals.com/journal/about/7342) | [NY55/Hotel](https://www.trailjournals.com/journal/entry/335993) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/1999beaker_6183TN.jpg) | [beaker](https://www.trailjournals.com/journal/about/6183) | [Boiling Springs](https://www.trailjournals.com/journal/entry/335001) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DidgeridudeandDoodlebug_9852TN.jpg) | [Didgeridude and Doodlebug](https://www.trailjournals.com/journal/about/9852) | [Allenberry Boiling Springs](https://www.trailjournals.com/journal/entry/334684) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [58Starter](https://www.trailjournals.com/journal/about/11488) | [Dicks Creek Gap Rd](https://www.trailjournals.com/journal/entry/334555) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [trackz man and sscblaze](https://www.trailjournals.com/journal/about/11275) | [East side of Black Butte](https://www.trailjournals.com/journal/entry/331528) | [Tahoe Rim Trail](https://www.trailjournals.com/journals/Tahoe%20_Rim%20_Trail) |
+|  | [bone lady](https://www.trailjournals.com/journal/about/11245) | [Dalton, Mass](https://www.trailjournals.com/journal/entry/330817) | [The Long Trail - Vermont](https://www.trailjournals.com/journals/The%20_Long%20_Trail%20_-%20_Vermont) |
+|  | [Red Fox](https://www.trailjournals.com/journal/about/10662) | [Kincora Hiking hostel](https://www.trailjournals.com/journal/entry/329869) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Trooper](https://www.trailjournals.com/journal/about/10644) | [Mile 500](https://www.trailjournals.com/journal/entry/329336) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+| [More...](https://www.trailjournals.com/entries/2010/06/15) [Grouped By Trail...](https://www.trailjournals.com/entries/2010/06/15/trail) |
+
+|     |
+| --- |
+| I was caught in a downpour. Lightning flashed and thunder cracked right after. Raindrops pelted at me sideways. The trail turned into a river as rainwater gushed downhill, soaking my boots. I felt like Dorothy in the twister, trying to keep my umbrella from blowing inside-out, trying not to slip on the smooth, wet rocks, trying to see the white blazes through the rain.... <br>[Red Panda](https://www.trailjournals.com/journal/entry/502313) —<br>[Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail) [2015](https://www.trailjournals.com/journals/appalachian_trail/2015) |
+
+[![Trailjournals](https://www.trailjournals.com/images/logo.png)](https://www.trailjournals.com/)
+
+#### Hiking
+
+- [Trails](https://www.trailjournals.com/trails/list)
+- [Journals](https://www.trailjournals.com/journals)
+- [Photos](https://www.trailjournals.com/photos)
+- [Calendar](https://www.trailjournals.com/calendar)
+- Gear
+- [Links](https://www.trailjournals.com/links)
+
+#### Partners
+
+- [ULA Equipment](https://ula-equipment.sjv.io/drN9K)
+- [REI](http://www.avantlink.com/click.php?tt=ml&ti=45265&pw=68025)
+- [Patagonia](http://www.avantlink.com/click.php?tt=ml&ti=45781&pw=68025)
+
+#### Network
+
+- [Trail Forums](http://www.trailforums.com/)
+- Trail News
+
+#### About Us
+
+- [Contact](https://www.trailjournals.com/about/contact)
+- [Donate](https://www.trailjournals.com/about/donate)
+- [Join](https://www.trailjournals.com/join)
+- [Login](https://www.trailjournals.com/user/login)
+- [Help](https://www.trailjournals.com/help)
+
+#### Follow Us
+
+- [Facebook](https://www.facebook.com/trailjournals)
+- [Instagram](https://instagram.com/trailjournals/)
+- [Twitter](https://twitter.com/trailjournals)
+- [Pinterest](https://www.pinterest.com/trailjournals/)
+- [Linkedin](https://www.linkedin.com/company/trailjournals-llc)
+
+Top Photo © Comer and Jean - Appalachian Trail,
+07/01/2001 by
+[Comer and Jean](https://www.trailjournals.com/journal/129)
+
+Trailjournals LLC © 2026
+All Rights Reserved. [privacy policy](https://www.trailjournals.com/about/privacy)
+
+Newburyport, MA 01950
+
+[Terms under which this service is provided to you.](https://www.trailjournals.com/about/privacy)
+
+Build: 20210226:165913 [Manage Settings](https://www.trailjournals.com/about/settings)
+---
+
+# Wednesday, June 16, 2010 — Chairback Gap Lean-to
+**Start Location:** Wilson Valley Lean-to
+**Miles Today:** 15.60
+**Trip Miles:** 2090.80
+
+Toggle navigation[Trail Journals](https://www.trailjournals.com/)
+
+- [Journals](https://www.trailjournals.com/journal/entry/316909#)  - [Journals](https://www.trailjournals.com/journals)
+  - [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail/2026)
+  - [Pacific Crest Trail](https://www.trailjournals.com/journals/pacific_crest_trail/2026)
+  - [Colorado Trail](https://www.trailjournals.com/journals/colorado_trail/2026)
+  - [Continental Divide Trail](https://www.trailjournals.com/journals/continental_divide_trail/2026)
+  - [Long Trail - Vermont](https://www.trailjournals.com/journals/the_long_trail_-_vermont/2026)
+  - [Florida Trail](https://www.trailjournals.com/journals/the_florida_trail/2026)
+  - [Arizona Trail](https://www.trailjournals.com/journals/arizona_trail/2026)
+  - [John Muir Trail](https://www.trailjournals.com/journals/john_muir_trail/2026)
+  - [Camino de Santiago](https://www.trailjournals.com/journals/camino_de_santiago/2026)
+  - [American Discovery Trail](https://www.trailjournals.com/journals/american_discovery_trail/2026)
+  - [Coast to Coast Walk](https://www.trailjournals.com/journals/coast_to_coast_walk/2026)
+  - [More...](https://www.trailjournals.com/journals/)
+- [Trails](https://www.trailjournals.com/trails/)
+- [Photos](https://www.trailjournals.com/photos/2026)
+- [Gear](https://www.trailjournals.com/journal/entry/316909#)  - [Current Sales](https://www.trailjournals.com/gear/deals/onsale)
+  - [REI](https://www.trailjournals.com/gear/rei)
+  - [ULA](https://www.trailjournals.com/gear/ula)
+  - [Patagonia](https://www.trailjournals.com/gear/patagonia)
+  - [Cabela's](https://www.trailjournals.com/gear/cabela)
+- [Planning](https://www.trailjournals.com/journal/entry/316909#)  - [Plan Your Hike](https://www.trailjournals.com/planning/)
+  - [Gear](https://www.trailjournals.com/gear/)
+  - [Books](https://www.trailjournals.com/books/)
+  - [Links](https://www.trailjournals.com/links/)
+- [Search](https://www.trailjournals.com/search/)
+- [About](https://www.trailjournals.com/journal/entry/316909#)  - [About Trailjournals](https://www.trailjournals.com/about/)
+  - [Login](https://www.trailjournals.com/user/login)
+  - [Join](https://www.trailjournals.com/join)
+  - [Support Trailjournals](https://www.trailjournals.com/about/donate/)
+  - [Contact](https://www.trailjournals.com/about/contact)
+  - [Store](https://www.trailjournals.com/store/)
+
+Backpacking Journals and Photos from Long Distance Hikers
+
+1. [Home](https://www.trailjournals.com/)
+2. [Journals](https://www.trailjournals.com/journals)
+3. [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail)
+4. [2010](https://www.trailjournals.com/journals/appalachian_trail/2010)
+5. [Uncle Frank](https://www.trailjournals.com/journal/10467)
+6. [Entries](https://www.trailjournals.com/journal/entries/10467/uncle%20-frank)
+7. June 16, 2010
+
+Toggle navigation
+
+- [Journal](https://www.trailjournals.com/journal/10467)
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+- [My Journals](https://www.trailjournals.com/myjournals/10467)
+- [View Guest Book](https://www.trailjournals.com/journal/guestbook/10467)
+- [Sign Guest Book](https://www.trailjournals.com/journal/guestbook/sign/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/4a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/5a.gif)
+
+[Journal](https://www.trailjournals.com/journal/10467)
+
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+
+--Choose--01/21/1002/06/1002/07/1002/08/1002/09/1002/10/1002/11/1002/12/1002/13/1002/14/1002/15/1002/16/1002/17/1002/18/1002/19/1002/20/1002/21/1002/22/1002/23/1002/24/1002/25/1002/26/1002/27/1002/28/1003/01/1003/02/1003/03/1003/04/1003/05/1003/06/1003/07/1003/08/1003/09/1003/11/1003/12/1003/13/1003/14/1003/15/1003/16/1003/17/1003/18/1003/19/1003/20/1003/21/1003/24/1003/25/1003/26/1003/27/1003/28/1003/29/1003/30/1003/31/1004/01/1004/02/1004/03/1004/04/1004/05/1004/06/1004/07/1004/08/1004/09/1004/10/1004/11/1004/12/1004/13/1004/14/1004/15/1004/16/1004/17/1004/18/1004/19/1004/20/1004/21/1004/23/1004/24/1004/25/1004/26/1004/27/1004/28/1004/29/1004/30/1005/01/1005/02/1005/03/1005/04/1005/05/1005/06/1005/07/1005/08/1005/09/1005/10/1005/11/1005/12/1005/13/1005/14/1005/15/1005/16/1005/17/1005/18/1005/19/1005/20/1005/21/1005/22/1005/23/1005/24/1005/25/1005/26/1005/27/1005/28/1005/29/1005/30/1005/31/1006/01/1006/02/1006/03/1006/04/1006/05/1006/06/1006/07/1006/08/1006/09/1006/10/1006/11/1006/12/1006/13/1006/14/1006/15/1006/16/1006/17/1006/18/1006/19/1006/20/1006/21/10
+
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+
+Guest Book
+
+- [Sign](https://www.trailjournals.com/journal/guestbook/sign/10467)
+- [View](https://www.trailjournals.com/journal/guestbook/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/4a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/5a.gif)
+
+- [AT Journals](https://www.trailjournals.com/journals/appalachian_trail)
+- [AT Photos](https://www.trailjournals.com/photos/appalachian_trail)
+- [AT Books](https://www.trailjournals.com/books/appalachian_trail)
+- [Appalachian Trail](http://www.appalachiantrail.org/)
+
+[Join](https://www.trailjournals.com/join) [Login](https://www.trailjournals.com/user/login)
+
+[RSS](https://www.trailjournals.com/journal/rss/10467/xml)
+
+# Uncle Frank's 2010  Appalachian Trail Journal
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/316908) [Next](https://www.trailjournals.com/journal/entry/316910) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+Wednesday, June 16, 2010
+
+Destination:Chairback Gap Lean-to
+
+Today's Miles:15.60
+
+Start Location:Wilson Valley Lean-to
+
+Trip Miles:2090.80
+
+Destination:Chairback Gap Lean-to
+
+Start Location:Wilson Valley Lean-to
+
+Today's Miles:15.60
+
+Trip Miles:2090.80
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/316908) [Next](https://www.trailjournals.com/journal/entry/316910) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+### Hiker Entries June 16, 2010
+
+|  | Journalist | Destination | Trail |
+| --- | --- | --- | --- |
+|  | [Deluxe](https://www.trailjournals.com/journal/about/21748) | [\-\- View Entry --](https://www.trailjournals.com/journal/entry/566469) | [Northville-Placid Trail](https://www.trailjournals.com/journals/Northville-Placid%20_Trail) |
+|  | [Deluxe](https://www.trailjournals.com/journal/about/21748) | [\-\- View Entry --](https://www.trailjournals.com/journal/entry/566467) | [Northville-Placid Trail](https://www.trailjournals.com/journals/Northville-Placid%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010seeksit_11881TN.jpg) | [seeksit](https://www.trailjournals.com/journal/about/11881) | [End of Bollinger Mill Road, Liberty Reservoir](https://www.trailjournals.com/journal/entry/338076) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Rough Cut](https://www.trailjournals.com/journal/about/11734) | [Morgan Stewart Shelter](https://www.trailjournals.com/journal/entry/336857) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | ["Dances with Wolfie"](https://www.trailjournals.com/journal/about/7342) | [Hoyt Rd NY/CT Line](https://www.trailjournals.com/journal/entry/335994) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/1999beaker_6183TN.jpg) | [beaker](https://www.trailjournals.com/journal/about/6183) | [Darlington Shelter](https://www.trailjournals.com/journal/entry/335006) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DidgeridudeandDoodlebug_9852TN.jpg) | [Didgeridude and Doodlebug](https://www.trailjournals.com/journal/about/9852) | [Allenberry](https://www.trailjournals.com/journal/entry/334685) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [trackz man and sscblaze](https://www.trailjournals.com/journal/about/11275) | [South ridge above Squaw Creek](https://www.trailjournals.com/journal/entry/331529) | [Tahoe Rim Trail](https://www.trailjournals.com/journals/Tahoe%20_Rim%20_Trail) |
+|  | [bone lady](https://www.trailjournals.com/journal/about/11245) | [Congdon Shelter](https://www.trailjournals.com/journal/entry/330818) | [The Long Trail - Vermont](https://www.trailjournals.com/journals/The%20_Long%20_Trail%20_-%20_Vermont) |
+|  | [Red Fox](https://www.trailjournals.com/journal/about/10662) | [Watuga Lake](https://www.trailjournals.com/journal/entry/329870) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| [More...](https://www.trailjournals.com/entries/2010/06/16) [Grouped By Trail...](https://www.trailjournals.com/entries/2010/06/16/trail) |
+
+|     |
+| --- |
+| The weather relaxed, and to our left the valley opened up in a soft light with soft ethereal edges. It looked like heaven.... <br>[Whirled Peas](https://www.trailjournals.com/journal/entry/434924) —<br>[Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail) [2013](https://www.trailjournals.com/journals/appalachian_trail/2013) |
+
+[![Trailjournals](https://www.trailjournals.com/images/logo.png)](https://www.trailjournals.com/)
+
+#### Hiking
+
+- [Trails](https://www.trailjournals.com/trails/list)
+- [Journals](https://www.trailjournals.com/journals)
+- [Photos](https://www.trailjournals.com/photos)
+- [Calendar](https://www.trailjournals.com/calendar)
+- Gear
+- [Links](https://www.trailjournals.com/links)
+
+#### Partners
+
+- [ULA Equipment](https://ula-equipment.sjv.io/drN9K)
+- [REI](http://www.avantlink.com/click.php?tt=ml&ti=45265&pw=68025)
+- [Patagonia](http://www.avantlink.com/click.php?tt=ml&ti=45781&pw=68025)
+
+#### Network
+
+- [Trail Forums](http://www.trailforums.com/)
+- Trail News
+
+#### About Us
+
+- [Contact](https://www.trailjournals.com/about/contact)
+- [Donate](https://www.trailjournals.com/about/donate)
+- [Join](https://www.trailjournals.com/join)
+- [Login](https://www.trailjournals.com/user/login)
+- [Help](https://www.trailjournals.com/help)
+
+#### Follow Us
+
+- [Facebook](https://www.facebook.com/trailjournals)
+- [Instagram](https://instagram.com/trailjournals/)
+- [Twitter](https://twitter.com/trailjournals)
+- [Pinterest](https://www.pinterest.com/trailjournals/)
+- [Linkedin](https://www.linkedin.com/company/trailjournals-llc)
+
+Top Photo © Comer and Jean - Appalachian Trail,
+07/01/2001 by
+[Comer and Jean](https://www.trailjournals.com/journal/129)
+
+Trailjournals LLC © 2026
+All Rights Reserved. [privacy policy](https://www.trailjournals.com/about/privacy)
+
+Newburyport, MA 01950
+
+[Terms under which this service is provided to you.](https://www.trailjournals.com/about/privacy)
+
+Build: 20210226:165913 [Manage Settings](https://www.trailjournals.com/about/settings)
+---
+
+# Thursday, June 17, 2010 — Cooper Brook Falls Lean-to
+**Start Location:** Chairback Gap Lean-to
+**Miles Today:** 29
+**Trip Miles:** 2119.80
+
+Toggle navigation[Trail Journals](https://www.trailjournals.com/)
+
+- [Journals](https://www.trailjournals.com/journal/entry/316910#)  - [Journals](https://www.trailjournals.com/journals)
+  - [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail/2026)
+  - [Pacific Crest Trail](https://www.trailjournals.com/journals/pacific_crest_trail/2026)
+  - [Colorado Trail](https://www.trailjournals.com/journals/colorado_trail/2026)
+  - [Continental Divide Trail](https://www.trailjournals.com/journals/continental_divide_trail/2026)
+  - [Long Trail - Vermont](https://www.trailjournals.com/journals/the_long_trail_-_vermont/2026)
+  - [Florida Trail](https://www.trailjournals.com/journals/the_florida_trail/2026)
+  - [Arizona Trail](https://www.trailjournals.com/journals/arizona_trail/2026)
+  - [John Muir Trail](https://www.trailjournals.com/journals/john_muir_trail/2026)
+  - [Camino de Santiago](https://www.trailjournals.com/journals/camino_de_santiago/2026)
+  - [American Discovery Trail](https://www.trailjournals.com/journals/american_discovery_trail/2026)
+  - [Coast to Coast Walk](https://www.trailjournals.com/journals/coast_to_coast_walk/2026)
+  - [More...](https://www.trailjournals.com/journals/)
+- [Trails](https://www.trailjournals.com/trails/)
+- [Photos](https://www.trailjournals.com/photos/2026)
+- [Gear](https://www.trailjournals.com/journal/entry/316910#)  - [Current Sales](https://www.trailjournals.com/gear/deals/onsale)
+  - [REI](https://www.trailjournals.com/gear/rei)
+  - [ULA](https://www.trailjournals.com/gear/ula)
+  - [Patagonia](https://www.trailjournals.com/gear/patagonia)
+  - [Cabela's](https://www.trailjournals.com/gear/cabela)
+- [Planning](https://www.trailjournals.com/journal/entry/316910#)  - [Plan Your Hike](https://www.trailjournals.com/planning/)
+  - [Gear](https://www.trailjournals.com/gear/)
+  - [Books](https://www.trailjournals.com/books/)
+  - [Links](https://www.trailjournals.com/links/)
+- [Search](https://www.trailjournals.com/search/)
+- [About](https://www.trailjournals.com/journal/entry/316910#)  - [About Trailjournals](https://www.trailjournals.com/about/)
+  - [Login](https://www.trailjournals.com/user/login)
+  - [Join](https://www.trailjournals.com/join)
+  - [Support Trailjournals](https://www.trailjournals.com/about/donate/)
+  - [Contact](https://www.trailjournals.com/about/contact)
+  - [Store](https://www.trailjournals.com/store/)
+
+Backpacking Journals and Photos from Long Distance Hikers
+
+1. [Home](https://www.trailjournals.com/)
+2. [Journals](https://www.trailjournals.com/journals)
+3. [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail)
+4. [2010](https://www.trailjournals.com/journals/appalachian_trail/2010)
+5. [Uncle Frank](https://www.trailjournals.com/journal/10467)
+6. [Entries](https://www.trailjournals.com/journal/entries/10467/uncle%20-frank)
+7. June 17, 2010
+
+Toggle navigation
+
+- [Journal](https://www.trailjournals.com/journal/10467)
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+- [My Journals](https://www.trailjournals.com/myjournals/10467)
+- [View Guest Book](https://www.trailjournals.com/journal/guestbook/10467)
+- [Sign Guest Book](https://www.trailjournals.com/journal/guestbook/sign/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/4a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/2a.gif)
+
+[Journal](https://www.trailjournals.com/journal/10467)
+
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+
+--Choose--01/21/1002/06/1002/07/1002/08/1002/09/1002/10/1002/11/1002/12/1002/13/1002/14/1002/15/1002/16/1002/17/1002/18/1002/19/1002/20/1002/21/1002/22/1002/23/1002/24/1002/25/1002/26/1002/27/1002/28/1003/01/1003/02/1003/03/1003/04/1003/05/1003/06/1003/07/1003/08/1003/09/1003/11/1003/12/1003/13/1003/14/1003/15/1003/16/1003/17/1003/18/1003/19/1003/20/1003/21/1003/24/1003/25/1003/26/1003/27/1003/28/1003/29/1003/30/1003/31/1004/01/1004/02/1004/03/1004/04/1004/05/1004/06/1004/07/1004/08/1004/09/1004/10/1004/11/1004/12/1004/13/1004/14/1004/15/1004/16/1004/17/1004/18/1004/19/1004/20/1004/21/1004/23/1004/24/1004/25/1004/26/1004/27/1004/28/1004/29/1004/30/1005/01/1005/02/1005/03/1005/04/1005/05/1005/06/1005/07/1005/08/1005/09/1005/10/1005/11/1005/12/1005/13/1005/14/1005/15/1005/16/1005/17/1005/18/1005/19/1005/20/1005/21/1005/22/1005/23/1005/24/1005/25/1005/26/1005/27/1005/28/1005/29/1005/30/1005/31/1006/01/1006/02/1006/03/1006/04/1006/05/1006/06/1006/07/1006/08/1006/09/1006/10/1006/11/1006/12/1006/13/1006/14/1006/15/1006/16/1006/17/1006/18/1006/19/1006/20/1006/21/10
+
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+
+Guest Book
+
+- [Sign](https://www.trailjournals.com/journal/guestbook/sign/10467)
+- [View](https://www.trailjournals.com/journal/guestbook/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/4a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/2a.gif)
+
+- [AT Journals](https://www.trailjournals.com/journals/appalachian_trail)
+- [AT Photos](https://www.trailjournals.com/photos/appalachian_trail)
+- [AT Books](https://www.trailjournals.com/books/appalachian_trail)
+- [Appalachian Trail](http://www.appalachiantrail.org/)
+
+[Join](https://www.trailjournals.com/join) [Login](https://www.trailjournals.com/user/login)
+
+[RSS](https://www.trailjournals.com/journal/rss/10467/xml)
+
+# Uncle Frank's 2010  Appalachian Trail Journal
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/316909) [Next](https://www.trailjournals.com/journal/entry/316911) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+Thursday, June 17, 2010
+
+Destination:Cooper Brook Falls Lean-to
+
+Today's Miles:29
+
+Start Location:Chairback Gap Lean-to
+
+Trip Miles:2119.80
+
+Destination:Cooper Brook Falls Lean-to
+
+Start Location:Chairback Gap Lean-to
+
+Today's Miles:29
+
+Trip Miles:2119.80
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/316909) [Next](https://www.trailjournals.com/journal/entry/316911) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+### Hiker Entries June 17, 2010
+
+|  | Journalist | Destination | Trail |
+| --- | --- | --- | --- |
+|  | [Transient](https://www.trailjournals.com/journal/about/13775) | [Dragon Lake Trail](https://www.trailjournals.com/journal/entry/380603) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010seeksit_11881TN.jpg) | [seeksit](https://www.trailjournals.com/journal/about/11881) | [Cat Rock, Cunningham Falls State Park](https://www.trailjournals.com/journal/entry/338077) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Rough Cut](https://www.trailjournals.com/journal/about/11734) | [Telephone Pioneer Shelter](https://www.trailjournals.com/journal/entry/336858) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/1999beaker_6183TN.jpg) | [beaker](https://www.trailjournals.com/journal/about/6183) | [Doyle Hotel](https://www.trailjournals.com/journal/entry/335007) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DidgeridudeandDoodlebug_9852TN.jpg) | [Didgeridude and Doodlebug](https://www.trailjournals.com/journal/about/9852) | [Darlington Shelter](https://www.trailjournals.com/journal/entry/334686) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DavidandBecky_11425TN.jpg) |  | [Our 2010 CDT Hike: An Intro](https://www.trailjournals.com/journal/entry/333887) | [Continental Divide Trail](https://www.trailjournals.com/journals/Continental%20_Divide%20_Trail) |
+|  | [trackz man and sscblaze](https://www.trailjournals.com/journal/about/11275) | [Myrazek Trail-above Tumalo Falls](https://www.trailjournals.com/journal/entry/331530) | [Tahoe Rim Trail](https://www.trailjournals.com/journals/Tahoe%20_Rim%20_Trail) |
+|  | [bone lady](https://www.trailjournals.com/journal/about/11245) | [Goddard Shelter](https://www.trailjournals.com/journal/entry/330819) | [The Long Trail - Vermont](https://www.trailjournals.com/journals/The%20_Long%20_Trail%20_-%20_Vermont) |
+|  | [Red Fox](https://www.trailjournals.com/journal/about/10662) | [Handicapped AT trail](https://www.trailjournals.com/journal/entry/329871) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Trooper](https://www.trailjournals.com/journal/about/10644) | [Tehachapi-Willow Springs Rd](https://www.trailjournals.com/journal/entry/329339) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+| [More...](https://www.trailjournals.com/entries/2010/06/17) [Grouped By Trail...](https://www.trailjournals.com/entries/2010/06/17/trail) |
+
+|     |
+| --- |
+| What is better than two cokes, four hard boiled eggs, a Klondike Ice Cream Bar, two cookies, and hand picked blueberries? Nothing.... <br>[Three By Five](https://www.trailjournals.com/journal/entry/469659) —<br>[Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail) [2014](https://www.trailjournals.com/journals/appalachian_trail/2014) |
+
+[![Trailjournals](https://www.trailjournals.com/images/logo.png)](https://www.trailjournals.com/)
+
+#### Hiking
+
+- [Trails](https://www.trailjournals.com/trails/list)
+- [Journals](https://www.trailjournals.com/journals)
+- [Photos](https://www.trailjournals.com/photos)
+- [Calendar](https://www.trailjournals.com/calendar)
+- Gear
+- [Links](https://www.trailjournals.com/links)
+
+#### Partners
+
+- [ULA Equipment](https://ula-equipment.sjv.io/drN9K)
+- [REI](http://www.avantlink.com/click.php?tt=ml&ti=45265&pw=68025)
+- [Patagonia](http://www.avantlink.com/click.php?tt=ml&ti=45781&pw=68025)
+
+#### Network
+
+- [Trail Forums](http://www.trailforums.com/)
+- Trail News
+
+#### About Us
+
+- [Contact](https://www.trailjournals.com/about/contact)
+- [Donate](https://www.trailjournals.com/about/donate)
+- [Join](https://www.trailjournals.com/join)
+- [Login](https://www.trailjournals.com/user/login)
+- [Help](https://www.trailjournals.com/help)
+
+#### Follow Us
+
+- [Facebook](https://www.facebook.com/trailjournals)
+- [Instagram](https://instagram.com/trailjournals/)
+- [Twitter](https://twitter.com/trailjournals)
+- [Pinterest](https://www.pinterest.com/trailjournals/)
+- [Linkedin](https://www.linkedin.com/company/trailjournals-llc)
+
+Top Photo © Mathew Olsen - The Colorado Trail,
+06/22/2001 by
+[Leif](https://www.trailjournals.com/journal/97)
+
+Trailjournals LLC © 2026
+All Rights Reserved. [privacy policy](https://www.trailjournals.com/about/privacy)
+
+Newburyport, MA 01950
+
+[Terms under which this service is provided to you.](https://www.trailjournals.com/about/privacy)
+
+Build: 20210226:165913 [Manage Settings](https://www.trailjournals.com/about/settings)
+---
+
+# Friday, June 18, 2010 — Wadleigh Stream Lean-to
+**Start Location:** Cooper Brook Falls Lean-to
+**Miles Today:** 21.50
+**Trip Miles:** 2141.30
+
+Toggle navigation[Trail Journals](https://www.trailjournals.com/)
+
+- [Journals](https://www.trailjournals.com/journal/entry/316911#)  - [Journals](https://www.trailjournals.com/journals)
+  - [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail/2026)
+  - [Pacific Crest Trail](https://www.trailjournals.com/journals/pacific_crest_trail/2026)
+  - [Colorado Trail](https://www.trailjournals.com/journals/colorado_trail/2026)
+  - [Continental Divide Trail](https://www.trailjournals.com/journals/continental_divide_trail/2026)
+  - [Long Trail - Vermont](https://www.trailjournals.com/journals/the_long_trail_-_vermont/2026)
+  - [Florida Trail](https://www.trailjournals.com/journals/the_florida_trail/2026)
+  - [Arizona Trail](https://www.trailjournals.com/journals/arizona_trail/2026)
+  - [John Muir Trail](https://www.trailjournals.com/journals/john_muir_trail/2026)
+  - [Camino de Santiago](https://www.trailjournals.com/journals/camino_de_santiago/2026)
+  - [American Discovery Trail](https://www.trailjournals.com/journals/american_discovery_trail/2026)
+  - [Coast to Coast Walk](https://www.trailjournals.com/journals/coast_to_coast_walk/2026)
+  - [More...](https://www.trailjournals.com/journals/)
+- [Trails](https://www.trailjournals.com/trails/)
+- [Photos](https://www.trailjournals.com/photos/2026)
+- [Gear](https://www.trailjournals.com/journal/entry/316911#)  - [Current Sales](https://www.trailjournals.com/gear/deals/onsale)
+  - [REI](https://www.trailjournals.com/gear/rei)
+  - [ULA](https://www.trailjournals.com/gear/ula)
+  - [Patagonia](https://www.trailjournals.com/gear/patagonia)
+  - [Cabela's](https://www.trailjournals.com/gear/cabela)
+- [Planning](https://www.trailjournals.com/journal/entry/316911#)  - [Plan Your Hike](https://www.trailjournals.com/planning/)
+  - [Gear](https://www.trailjournals.com/gear/)
+  - [Books](https://www.trailjournals.com/books/)
+  - [Links](https://www.trailjournals.com/links/)
+- [Search](https://www.trailjournals.com/search/)
+- [About](https://www.trailjournals.com/journal/entry/316911#)  - [About Trailjournals](https://www.trailjournals.com/about/)
+  - [Login](https://www.trailjournals.com/user/login)
+  - [Join](https://www.trailjournals.com/join)
+  - [Support Trailjournals](https://www.trailjournals.com/about/donate/)
+  - [Contact](https://www.trailjournals.com/about/contact)
+  - [Store](https://www.trailjournals.com/store/)
+
+Backpacking Journals and Photos from Long Distance Hikers
+
+1. [Home](https://www.trailjournals.com/)
+2. [Journals](https://www.trailjournals.com/journals)
+3. [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail)
+4. [2010](https://www.trailjournals.com/journals/appalachian_trail/2010)
+5. [Uncle Frank](https://www.trailjournals.com/journal/10467)
+6. [Entries](https://www.trailjournals.com/journal/entries/10467/uncle%20-frank)
+7. June 18, 2010
+
+Toggle navigation
+
+- [Journal](https://www.trailjournals.com/journal/10467)
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+- [My Journals](https://www.trailjournals.com/myjournals/10467)
+- [View Guest Book](https://www.trailjournals.com/journal/guestbook/10467)
+- [Sign Guest Book](https://www.trailjournals.com/journal/guestbook/sign/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/4a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/8a.gif)
+
+[Journal](https://www.trailjournals.com/journal/10467)
+
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+
+--Choose--01/21/1002/06/1002/07/1002/08/1002/09/1002/10/1002/11/1002/12/1002/13/1002/14/1002/15/1002/16/1002/17/1002/18/1002/19/1002/20/1002/21/1002/22/1002/23/1002/24/1002/25/1002/26/1002/27/1002/28/1003/01/1003/02/1003/03/1003/04/1003/05/1003/06/1003/07/1003/08/1003/09/1003/11/1003/12/1003/13/1003/14/1003/15/1003/16/1003/17/1003/18/1003/19/1003/20/1003/21/1003/24/1003/25/1003/26/1003/27/1003/28/1003/29/1003/30/1003/31/1004/01/1004/02/1004/03/1004/04/1004/05/1004/06/1004/07/1004/08/1004/09/1004/10/1004/11/1004/12/1004/13/1004/14/1004/15/1004/16/1004/17/1004/18/1004/19/1004/20/1004/21/1004/23/1004/24/1004/25/1004/26/1004/27/1004/28/1004/29/1004/30/1005/01/1005/02/1005/03/1005/04/1005/05/1005/06/1005/07/1005/08/1005/09/1005/10/1005/11/1005/12/1005/13/1005/14/1005/15/1005/16/1005/17/1005/18/1005/19/1005/20/1005/21/1005/22/1005/23/1005/24/1005/25/1005/26/1005/27/1005/28/1005/29/1005/30/1005/31/1006/01/1006/02/1006/03/1006/04/1006/05/1006/06/1006/07/1006/08/1006/09/1006/10/1006/11/1006/12/1006/13/1006/14/1006/15/1006/16/1006/17/1006/18/1006/19/1006/20/1006/21/10
+
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+
+Guest Book
+
+- [Sign](https://www.trailjournals.com/journal/guestbook/sign/10467)
+- [View](https://www.trailjournals.com/journal/guestbook/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/4a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/8a.gif)
+
+- [AT Journals](https://www.trailjournals.com/journals/appalachian_trail)
+- [AT Photos](https://www.trailjournals.com/photos/appalachian_trail)
+- [AT Books](https://www.trailjournals.com/books/appalachian_trail)
+- [Appalachian Trail](http://www.appalachiantrail.org/)
+
+[Join](https://www.trailjournals.com/join) [Login](https://www.trailjournals.com/user/login)
+
+[RSS](https://www.trailjournals.com/journal/rss/10467/xml)
+
+# Uncle Frank's 2010  Appalachian Trail Journal
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/316910) [Next](https://www.trailjournals.com/journal/entry/316912) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+Friday, June 18, 2010
+
+Destination:Wadleigh Stream Lean-to
+
+Today's Miles:21.50
+
+Start Location:Cooper Brook Falls Lean-to
+
+Trip Miles:2141.30
+
+Destination:Wadleigh Stream Lean-to
+
+Start Location:Cooper Brook Falls Lean-to
+
+Today's Miles:21.50
+
+Trip Miles:2141.30
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/316910) [Next](https://www.trailjournals.com/journal/entry/316912) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+### Hiker Entries June 18, 2010
+
+|  | Journalist | Destination | Trail |
+| --- | --- | --- | --- |
+|  | [Transient](https://www.trailjournals.com/journal/about/13775) | [Pinchot Pass](https://www.trailjournals.com/journal/entry/380604) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+|  | [RuhRoh](https://www.trailjournals.com/journal/about/13023) | [Siler Bald Shelter](https://www.trailjournals.com/journal/entry/366126) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Troll_3506TN.jpg) | [Troll](https://www.trailjournals.com/journal/about/3506) | [Hightop Hut](https://www.trailjournals.com/journal/entry/355113) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010seeksit_11881TN.jpg) | [seeksit](https://www.trailjournals.com/journal/about/11881) | [Liberty Reservoir](https://www.trailjournals.com/journal/entry/339202) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Rough Cut](https://www.trailjournals.com/journal/about/11734) | [Ten mile river lean too](https://www.trailjournals.com/journal/entry/336859) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DidgeridudeandDoodlebug_9852TN.jpg) | [Didgeridude and Doodlebug](https://www.trailjournals.com/journal/about/9852) | [Duncannon PA](https://www.trailjournals.com/journal/entry/334687) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [trackz man and sscblaze](https://www.trailjournals.com/journal/about/11275) | [Shevlin Park](https://www.trailjournals.com/journal/entry/331531) | [Tahoe Rim Trail](https://www.trailjournals.com/journals/Tahoe%20_Rim%20_Trail) |
+|  | [bone lady](https://www.trailjournals.com/journal/about/11245) | [Story Spring Shelter](https://www.trailjournals.com/journal/entry/330820) | [The Long Trail - Vermont](https://www.trailjournals.com/journals/The%20_Long%20_Trail%20_-%20_Vermont) |
+|  | [Red Fox](https://www.trailjournals.com/journal/about/10662) | [Damascus, VA](https://www.trailjournals.com/journal/entry/329872) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Trooper](https://www.trailjournals.com/journal/about/10644) | [\-\- View Entry --](https://www.trailjournals.com/journal/entry/329341) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+| [More...](https://www.trailjournals.com/entries/2010/06/18) [Grouped By Trail...](https://www.trailjournals.com/entries/2010/06/18/trail) |
+
+|     |
+| --- |
+| I've never seen anything like this place, a large canyon connecting lakes with snow fed streams originating at a snow pack high up on a mountain.... <br>[Fitty Shrimp](https://www.trailjournals.com/journal/entry/519076) —<br>[Pacific Northwest Trail](https://www.trailjournals.com/journals/pacific_northwest_trail) [2015](https://www.trailjournals.com/journals/pacific_northwest_trail/2015) |
+
+[![Trailjournals](https://www.trailjournals.com/images/logo.png)](https://www.trailjournals.com/)
+
+#### Hiking
+
+- [Trails](https://www.trailjournals.com/trails/list)
+- [Journals](https://www.trailjournals.com/journals)
+- [Photos](https://www.trailjournals.com/photos)
+- [Calendar](https://www.trailjournals.com/calendar)
+- Gear
+- [Links](https://www.trailjournals.com/links)
+
+#### Partners
+
+- [ULA Equipment](https://ula-equipment.sjv.io/drN9K)
+- [REI](http://www.avantlink.com/click.php?tt=ml&ti=45265&pw=68025)
+- [Patagonia](http://www.avantlink.com/click.php?tt=ml&ti=45781&pw=68025)
+
+#### Network
+
+- [Trail Forums](http://www.trailforums.com/)
+- Trail News
+
+#### About Us
+
+- [Contact](https://www.trailjournals.com/about/contact)
+- [Donate](https://www.trailjournals.com/about/donate)
+- [Join](https://www.trailjournals.com/join)
+- [Login](https://www.trailjournals.com/user/login)
+- [Help](https://www.trailjournals.com/help)
+
+#### Follow Us
+
+- [Facebook](https://www.facebook.com/trailjournals)
+- [Instagram](https://instagram.com/trailjournals/)
+- [Twitter](https://twitter.com/trailjournals)
+- [Pinterest](https://www.pinterest.com/trailjournals/)
+- [Linkedin](https://www.linkedin.com/company/trailjournals-llc)
+
+Top Photo © Comer and Jean - Appalachian Trail,
+07/01/2001 by
+[Comer and Jean](https://www.trailjournals.com/journal/129)
+
+Trailjournals LLC © 2026
+All Rights Reserved. [privacy policy](https://www.trailjournals.com/about/privacy)
+
+Newburyport, MA 01950
+
+[Terms under which this service is provided to you.](https://www.trailjournals.com/about/privacy)
+
+Build: 20210226:165913 [Manage Settings](https://www.trailjournals.com/about/settings)
+---
+
+# Saturday, June 19, 2010 — The Birches Lean-tos
+**Start Location:** Wadleigh Stream Lean-to
+**Miles Today:** 33
+**Trip Miles:** 2174.30
+
+Toggle navigation[Trail Journals](https://www.trailjournals.com/)
+
+- [Journals](https://www.trailjournals.com/journal/entry/316912#)  - [Journals](https://www.trailjournals.com/journals)
+  - [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail/2026)
+  - [Pacific Crest Trail](https://www.trailjournals.com/journals/pacific_crest_trail/2026)
+  - [Colorado Trail](https://www.trailjournals.com/journals/colorado_trail/2026)
+  - [Continental Divide Trail](https://www.trailjournals.com/journals/continental_divide_trail/2026)
+  - [Long Trail - Vermont](https://www.trailjournals.com/journals/the_long_trail_-_vermont/2026)
+  - [Florida Trail](https://www.trailjournals.com/journals/the_florida_trail/2026)
+  - [Arizona Trail](https://www.trailjournals.com/journals/arizona_trail/2026)
+  - [John Muir Trail](https://www.trailjournals.com/journals/john_muir_trail/2026)
+  - [Camino de Santiago](https://www.trailjournals.com/journals/camino_de_santiago/2026)
+  - [American Discovery Trail](https://www.trailjournals.com/journals/american_discovery_trail/2026)
+  - [Coast to Coast Walk](https://www.trailjournals.com/journals/coast_to_coast_walk/2026)
+  - [More...](https://www.trailjournals.com/journals/)
+- [Trails](https://www.trailjournals.com/trails/)
+- [Photos](https://www.trailjournals.com/photos/2026)
+- [Gear](https://www.trailjournals.com/journal/entry/316912#)  - [Current Sales](https://www.trailjournals.com/gear/deals/onsale)
+  - [REI](https://www.trailjournals.com/gear/rei)
+  - [ULA](https://www.trailjournals.com/gear/ula)
+  - [Patagonia](https://www.trailjournals.com/gear/patagonia)
+  - [Cabela's](https://www.trailjournals.com/gear/cabela)
+- [Planning](https://www.trailjournals.com/journal/entry/316912#)  - [Plan Your Hike](https://www.trailjournals.com/planning/)
+  - [Gear](https://www.trailjournals.com/gear/)
+  - [Books](https://www.trailjournals.com/books/)
+  - [Links](https://www.trailjournals.com/links/)
+- [Search](https://www.trailjournals.com/search/)
+- [About](https://www.trailjournals.com/journal/entry/316912#)  - [About Trailjournals](https://www.trailjournals.com/about/)
+  - [Login](https://www.trailjournals.com/user/login)
+  - [Join](https://www.trailjournals.com/join)
+  - [Support Trailjournals](https://www.trailjournals.com/about/donate/)
+  - [Contact](https://www.trailjournals.com/about/contact)
+  - [Store](https://www.trailjournals.com/store/)
+
+Backpacking Journals and Photos from Long Distance Hikers
+
+1. [Home](https://www.trailjournals.com/)
+2. [Journals](https://www.trailjournals.com/journals)
+3. [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail)
+4. [2010](https://www.trailjournals.com/journals/appalachian_trail/2010)
+5. [Uncle Frank](https://www.trailjournals.com/journal/10467)
+6. [Entries](https://www.trailjournals.com/journal/entries/10467/uncle%20-frank)
+7. June 19, 2010
+
+Toggle navigation
+
+- [Journal](https://www.trailjournals.com/journal/10467)
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+- [My Journals](https://www.trailjournals.com/myjournals/10467)
+- [View Guest Book](https://www.trailjournals.com/journal/guestbook/10467)
+- [Sign Guest Book](https://www.trailjournals.com/journal/guestbook/sign/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/4a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/6a.gif)
+
+[Journal](https://www.trailjournals.com/journal/10467)
+
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+
+--Choose--01/21/1002/06/1002/07/1002/08/1002/09/1002/10/1002/11/1002/12/1002/13/1002/14/1002/15/1002/16/1002/17/1002/18/1002/19/1002/20/1002/21/1002/22/1002/23/1002/24/1002/25/1002/26/1002/27/1002/28/1003/01/1003/02/1003/03/1003/04/1003/05/1003/06/1003/07/1003/08/1003/09/1003/11/1003/12/1003/13/1003/14/1003/15/1003/16/1003/17/1003/18/1003/19/1003/20/1003/21/1003/24/1003/25/1003/26/1003/27/1003/28/1003/29/1003/30/1003/31/1004/01/1004/02/1004/03/1004/04/1004/05/1004/06/1004/07/1004/08/1004/09/1004/10/1004/11/1004/12/1004/13/1004/14/1004/15/1004/16/1004/17/1004/18/1004/19/1004/20/1004/21/1004/23/1004/24/1004/25/1004/26/1004/27/1004/28/1004/29/1004/30/1005/01/1005/02/1005/03/1005/04/1005/05/1005/06/1005/07/1005/08/1005/09/1005/10/1005/11/1005/12/1005/13/1005/14/1005/15/1005/16/1005/17/1005/18/1005/19/1005/20/1005/21/1005/22/1005/23/1005/24/1005/25/1005/26/1005/27/1005/28/1005/29/1005/30/1005/31/1006/01/1006/02/1006/03/1006/04/1006/05/1006/06/1006/07/1006/08/1006/09/1006/10/1006/11/1006/12/1006/13/1006/14/1006/15/1006/16/1006/17/1006/18/1006/19/1006/20/1006/21/10
+
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+
+Guest Book
+
+- [Sign](https://www.trailjournals.com/journal/guestbook/sign/10467)
+- [View](https://www.trailjournals.com/journal/guestbook/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/4a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/6a.gif)
+
+- [AT Journals](https://www.trailjournals.com/journals/appalachian_trail)
+- [AT Photos](https://www.trailjournals.com/photos/appalachian_trail)
+- [AT Books](https://www.trailjournals.com/books/appalachian_trail)
+- [Appalachian Trail](http://www.appalachiantrail.org/)
+
+[Join](https://www.trailjournals.com/join) [Login](https://www.trailjournals.com/user/login)
+
+[RSS](https://www.trailjournals.com/journal/rss/10467/xml)
+
+# Uncle Frank's 2010  Appalachian Trail Journal
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/316911) [Next](https://www.trailjournals.com/journal/entry/316913) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+Saturday, June 19, 2010
+
+Destination:The Birches Lean-tos
+
+Today's Miles:33
+
+Start Location:Wadleigh Stream Lean-to
+
+Trip Miles:2174.30
+
+Destination:The Birches Lean-tos
+
+Start Location:Wadleigh Stream Lean-to
+
+Today's Miles:33
+
+Trip Miles:2174.30
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/316911) [Next](https://www.trailjournals.com/journal/entry/316913) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+### Hiker Entries June 19, 2010
+
+|  | Journalist | Destination | Trail |
+| --- | --- | --- | --- |
+|  | [Transient](https://www.trailjournals.com/journal/about/13775) | [Upper Palisade Lake](https://www.trailjournals.com/journal/entry/380606) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+|  | [RuhRoh](https://www.trailjournals.com/journal/about/13023) | [Tyre Top](https://www.trailjournals.com/journal/entry/366127) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Troll_3506TN.jpg) | [Troll](https://www.trailjournals.com/journal/about/3506) | [Rock Spring Hut](https://www.trailjournals.com/journal/entry/355114) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010seeksit_11881TN.jpg) | [seeksit](https://www.trailjournals.com/journal/about/11881) | [Bollinger Mill Road trailhead](https://www.trailjournals.com/journal/entry/339204) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DidgeridudeandDoodlebug_9852TN.jpg) | [Didgeridude and Doodlebug](https://www.trailjournals.com/journal/about/9852) | [Clarks Ferry Shelter](https://www.trailjournals.com/journal/entry/334688) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [bone lady](https://www.trailjournals.com/journal/about/11245) | [North Shore Tenting Area, Stratton Pond](https://www.trailjournals.com/journal/entry/330821) | [The Long Trail - Vermont](https://www.trailjournals.com/journals/The%20_Long%20_Trail%20_-%20_Vermont) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010lastonthebus_10176TN.jpg) | [lastonthebus "LB"](https://www.trailjournals.com/journal/about/10176) | [\-\- View Entry --](https://www.trailjournals.com/journal/entry/329352) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Trooper](https://www.trailjournals.com/journal/about/10644) | [\-\- View Entry --](https://www.trailjournals.com/journal/entry/329342) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Peru_10969TN.jpg) | [Peru](https://www.trailjournals.com/journal/about/10969) | [Daleville](https://www.trailjournals.com/journal/entry/325475) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010SlowWalker_10376TN.jpg) | [Slow Walker](https://www.trailjournals.com/journal/about/10376) | [Alresford](https://www.trailjournals.com/journal/entry/324725) | [Other Trails](https://www.trailjournals.com/journals/Other%20_Trails) |
+| [More...](https://www.trailjournals.com/entries/2010/06/19) [Grouped By Trail...](https://www.trailjournals.com/entries/2010/06/19/trail) |
+
+|     |
+| --- |
+| Last nights choice of a campsite by a stream turned out great for I was able to lie in my tent and listen to the lullaby of the water over the rocks. ... <br>[Short Stop](https://www.trailjournals.com/journal/entry/473502) —<br>[Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail) [2014](https://www.trailjournals.com/journals/appalachian_trail/2014) |
+
+[![Trailjournals](https://www.trailjournals.com/images/logo.png)](https://www.trailjournals.com/)
+
+#### Hiking
+
+- [Trails](https://www.trailjournals.com/trails/list)
+- [Journals](https://www.trailjournals.com/journals)
+- [Photos](https://www.trailjournals.com/photos)
+- [Calendar](https://www.trailjournals.com/calendar)
+- Gear
+- [Links](https://www.trailjournals.com/links)
+
+#### Partners
+
+- [ULA Equipment](https://ula-equipment.sjv.io/drN9K)
+- [REI](http://www.avantlink.com/click.php?tt=ml&ti=45265&pw=68025)
+- [Patagonia](http://www.avantlink.com/click.php?tt=ml&ti=45781&pw=68025)
+
+#### Network
+
+- [Trail Forums](http://www.trailforums.com/)
+- Trail News
+
+#### About Us
+
+- [Contact](https://www.trailjournals.com/about/contact)
+- [Donate](https://www.trailjournals.com/about/donate)
+- [Join](https://www.trailjournals.com/join)
+- [Login](https://www.trailjournals.com/user/login)
+- [Help](https://www.trailjournals.com/help)
+
+#### Follow Us
+
+- [Facebook](https://www.facebook.com/trailjournals)
+- [Instagram](https://instagram.com/trailjournals/)
+- [Twitter](https://twitter.com/trailjournals)
+- [Pinterest](https://www.pinterest.com/trailjournals/)
+- [Linkedin](https://www.linkedin.com/company/trailjournals-llc)
+
+Top Photo © Comer and Jean - Appalachian Trail,
+07/01/2001 by
+[Comer and Jean](https://www.trailjournals.com/journal/129)
+
+Trailjournals LLC © 2026
+All Rights Reserved. [privacy policy](https://www.trailjournals.com/about/privacy)
+
+Newburyport, MA 01950
+
+[Terms under which this service is provided to you.](https://www.trailjournals.com/about/privacy)
+
+Build: 20210226:165913 [Manage Settings](https://www.trailjournals.com/about/settings)
+---
+
+# Sunday, June 20, 2010 — Baxter Peak, Mount Katahdin
+**Start Location:** The Birches Lean-tos
+**Miles Today:** 5.20
+**Trip Miles:** 2179.50
+
+The night had been a long one, buzzing relentlessly with the sound of mosquitos. I was up all night, thanks to a new sting on my face or neck every five minutes, but by 3:00 the cold and rain arrived and suppressed the mosquitos. So, for an hour, I slept.
+
+At 4 o'clock I was up and packing my things. "This is it," I repeated in my head. "Don't get scared now" (that's a line from Home Alone). I hit the trail by 4:37, moving swiftly up and up and up into the end of this horrible trek. The terrain was as difficult as I expected (Katahdin is widely believed to be THE hardest peak on the entire AT), but to be honest I made quick work of the 5.2 miles to the summit. My stomach cramped with hunger and my legs burned with lactic build-up. I felt like Edmond Hillary ascending up the final cornice, the "Hillary Step," but like Hillary it went quickly. "A push and a shove and Tenezig and I were on the top of the world," Hillary wrote later.
+
+So there I was, standing at that godforsaken sign, wind whipping and white cloud shrouding the peak. I showed little emotion--in fact, I showed none. I just stood there, looking at the sign. I didn't feel like anything important was going on, nor that I'd accomplished any sort of feat. I nodded to myself and walked down the mountain. At the bottom, a day hiker asked me my name. "Uncle Fra-," I began to say. But it was all over--the trail had expired and my trail name with it--so I smiled and said, "Ford. Ford Prior."
+---
+
+# Monday, June 21, 2010 — HOME
+**Start Location:** Baxter Peak, Mount Katahdin
+**Miles Today:** 0
+**Trip Miles:** 2179.50
+
+Hey everyone. It's been over for a couple weeks now and I'm getting comfy back at home. Just letting you know that I'll be continuing to write on my website, www.fordprior.weebly.com, so check it out if you ever get bored. I did kind of a trail recap. Thanks for following.

--- a/examples/uncle-frank/journal_facts.txt
+++ b/examples/uncle-frank/journal_facts.txt
@@ -1,0 +1,7132 @@
+---
+date: '2010-01-21'
+start: Gear List
+destination: Pre-Hike Planning
+miles_today: 0.0
+trip_miles: 0.0
+facts:
+  trail_section: Trail section from Gear List to Pre-Hike Planning.
+  confidence: low
+---
+# Thursday, January 21, 2010 — Pre-Hike Planning
+**Start Location:** Gear List
+**Miles Today:** 0
+**Trip Miles:** 0
+
+I'm loading my pack and thinking of Lewis & Clark. Hell, how do you pack for an 5,000-plus march into the unknown? Start with alot of meat, apparently: the Corps packed "a ton of dried pork." Maybe I should bring a baggy of deer jerky.
+
+Food, fuel, shoes, and H20 aside, here's my gear list so far. Keep in mind, I'm going "ultra-light", which basically means I'm trying really hard to keep my pack as light as possible. Duh, right? That's called "common sense", not "ultra-light". Either way, I've slashed significant poundage, leaving my total weight at a skimpy 13.8 lbs!
+
+Anyways, please, give me feedback! Too much? Too little? Missing something?
+
+I-The Big Stuff
+
+Pack (Gossamer Gear Gorilla): 23.3 oz.
+
+Sleeping bag (0-degree GoLite Women's): 45 oz.
+
+Poncho/shelter (Sea-to-Summit): 12.7 oz.
+
+Thermarest (Thermarest ProLite Rig): 16.2 oz.
+
+II-Non-Clothes
+
+Stove (homemade alcohol): 2.1 oz.
+
+Bowl (silicone, 16 fl. oz.): 2.3 oz.
+
+Spork (LightMyFire): 0.5 oz
+
+Tent stakes (4): 2.8 oz.
+
+Latrine digger (MSR): 0.7 oz.
+
+Knife (Gerber): 7.8 oz.
+
+Headlamp (Petzl): 0.7 oz.
+
+Bible (ESV): 9.2 oz.
+
+Journal:
+
+Toothbrush & Floss: 1.5 oz.
+
+Mini-lighter: 1 oz.
+
+First Aid kit (8 BandAids, needle & thread, clothespin, Anti-biotic ointment, .5" medical tape, 5 ft. duct tape, 8 Advil, Moleskin, Gauze): 3.5 oz.
+
+Water bladder (Platypus): 3.5 oz.
+
+50 ft. parachute cord: 2.8 oz.
+
+Harmonica: 2.1 oz.
+
+Pipe & Tobacco: 6 oz.
+
+ID, cash, etc.: 2 oz.
+
+Bags (garbage, zip-lock):
+
+Compass: 1 oz.
+
+1 liter water bottle (Dasani): 1.5 oz.
+
+III-Clothes
+
+Baclava (Seirus): 2.8 oz.
+
+Long underwear bottoms (SmartWool, Merino): 7.8 oz.
+
+Long underwear top (Icebreaker, Merino): 13.5 oz.
+
+Rain shell pants (Marmot Precip): 12 oz.
+
+Rain shell jacket (North Face Venture): 13.5 oz.
+
+Gloves (REI): 2.1 oz.
+
+Down jacket (MontBell Alpine): 11.3 oz.
+
+Wool socks (REI, 3 pairs): 8.5 oz.
+
+Down booties (North Face): 12 oz.
+
+Beanie (normal): 2.8 oz.
+
+Liner socks (1 pair, Merino wool):
+
+It's a long list, indeed. Yet amazingly, it only comes out to only 13.8 lbs! I've still got a couple pounds to add...but still! Technology these days.
+
+First Previous [Next](https://www.trailjournals.com/journal/entry/301866) [Last](https://www.trailjournals.com/journal/entry/318948)
+---
+---
+date: '2010-02-06'
+start: Amicalola Falls State Park
+destination: Hike Inn
+miles_today: 0.0
+trip_miles: 0.0
+facts:
+  weather: High 39°F, low 34°F. Slight snow.
+  trail_section: Amicalola Falls State Park is the traditional starting gateway for
+    northbound AT thru-hikers. The 8.5-mile Approach Trail from Amicalola Falls gains
+    substantial elevation to reach Springer Mountain. Amicalola Falls at 729 feet
+    is one of the tallest cascading waterfalls in the eastern United States. The Hike
+    Inn is a backcountry eco-lodge accessible only on foot via a 5-mile trail near
+    Amicalola Falls. The Hike Inn sits within sight of the AT approach corridor through
+    classic Blue Ridge hardwood forest. The Georgia AT traverses the southern Blue
+    Ridge Mountains, crossing several 4,000-foot summits in ~76 miles. Georgia's AT
+    features rocky ridgelines alternating with dense hardwood forest typical of the
+    southern Appalachians.
+  confidence: high
+  sources:
+  - AT location database
+  - Open-Meteo archive
+---
+# Saturday, February 06, 2010 — Hike Inn
+**Start Location:** Amicalola Falls State Park
+**Miles Today:** 0
+**Trip Miles:** 0
+
+In the darkness we trudged on without words. After a late start, at 3:45pm, the trail took us up Amicalola Falls and higher into Frosty Mountain as dusk drew near. And Frosty it was, thanks to an ice storm that blew in the previous night, leaving the forest glassy and white. The ices thawed, shattered down from the trees overhead, and buried the trail in 2 inches of shards. Rain had fallen below at Amicalola State Park HQ where we set off, but up here the world was gripped in ice. the foul weather slowed progress - not only did we have to march through ice but detour around splintered branches and trees fallen across the trail. So by nightfall, there I was. Trudging by flashlight along the blue-blazed "approach trail", feeling tired of walking even before the white blazes began.
+
+I expected a damp and dismal shelter that night, but we stumbled across a glowing refuge in the middle of the woods: The Hiker Inn. the situation that night was by no means an emergency, but with my Dad and Morgan it seemed like one for some reason. Morgan was having knee problems and looked on the verge of tears, branches and trees were falling all around us, my hands were numb and it was pitch black for a cloud-covered moon. Emergency or not, we saw a trail sign for The Hiker Inn and decided to pull off. I expected a cold night on the front porch or in an old shed. What I found was a lone innkeeper offering a lamp-lit dwelling warmed by woodstove. All's well that ends well.
+
+Let's go back to where it all begins, to my weeping mother by the car in front of the house. I forget sometimes, how much I mean to people. I forget that I have the power to bring great joy and great sadness, that me going actually matters to someone. So when I put my arms around my mother and she started to cry, I was filled with this incredible sense that I was home, the only place in the world where I really mean something. There I was crucial. I guess it all comes back to love, something I've never really been able to put into words. All I can do is point to my mother and father, my two best friends in the whole world, without whom I would just be a scared little boy. They've brought me here. They've made me a man. and although I didn't think any of this at the time, it was painted so perfectly as I held my weeping mother by the car.
+
+That night we drove to South Carolina and stayed at a hotel. I stayed up late that night reading Thoreau out of my sister's Lit book. He rambles alot, but I liked the marrow part: "When I would recreate myself, I seek the darkest wood and most interminable swamp, and enter it as a sacred place, a sanctum sanctorum. Three is strength, the marrow of nature." I'm about to enter a dark season on an interminable trail, I said to myself, so the suffering is all to shine on that marrow. there is the heart of God. We ate at Cracker Barrel at 6:30 the next morning and then drove to Springer Mountain, "Southern Terminus to the Applachian Trail". I fell asleep in the backseat and awoke to the Amicalola State Park HQ, gateway to the Springer Mountain trail. I registered, weighed my pack, and hit the blue-blazed approach trail to the Springer's summit. 8.8 miles. It was 3:45pm. the trail led into ice, night fell, and we ended up in The Hikers Inn warm log-cabin lobby. We met Stanley, the innkeeper and former A.T. thru-hiker himself, who started up the wood stove and offered me advice for my own hike. I was so fortunate to be there with my father and sister, really enjoying our time together. That was the only thing on my mind that night before I began my 2,000 mile trek to Maine.
+---
+---
+date: '2010-02-07'
+start: Hike Inn
+destination: Hawk Mountain Shelter
+miles_today: 9.0
+trip_miles: 9.0
+facts:
+  weather: High 40°F, low 23°F. Slight snow.
+  trail_section: The Hike Inn is a backcountry eco-lodge accessible only on foot via
+    a 5-mile trail near Amicalola Falls. The Hike Inn sits within sight of the AT
+    approach corridor through classic Blue Ridge hardwood forest. Hawk Mountain Shelter
+    sits at roughly AT mile 8 from Springer Mountain in the Georgia Blue Ridge. The
+    trail between Springer Mountain and Hawk Mountain traverses rocky ridgeline sections
+    through hardwood forest. The Georgia AT traverses the southern Blue Ridge Mountains,
+    crossing several 4,000-foot summits in ~76 miles. Georgia's AT features rocky
+    ridgelines alternating with dense hardwood forest typical of the southern Appalachians.
+  confidence: high
+  sources:
+  - AT location database
+  - Open-Meteo archive
+---
+# Sunday, February 07, 2010 — Hawk Mountain Shelter
+**Start Location:** Hike Inn
+**Miles Today:** 9
+**Trip Miles:** 9
+
+We parted ways at 10:00am. My father and sister walked out the door like I’ve seen them do so many times this past month, but this time I wouldn’t wee them return that evening. This was different. It was hard saying goodbye at what I knew was an exit from their lives for the next six months, before I’d go off and live my life and they’d go off and live theirs. As they walked out the door and out of view, I felt just about as lonely as I’d ever felt. I kind of wanted to chase them but that would be too embarrassing. So I sat there, trying to nap but unable. I think it was because I was alone now and knew it, making me uncomfortable and on edge. From here on out it’ll be like that, more or less, with my guard up full-time. I need to stop writing about this or it’ll get to me.
+
+By 10:30 I was at it, trudging through the aftermath of the ice storm, slipping and sliding in the snow and ice and trying not to yell curse words at the huge limbs blocking the trail. It was slow and painful to the summit of Springer Mountain, by 1:00 I was there, wiping snow off the plaque that read, “Southern Terminus of the Appalachian Trail”. It was too cold and windy to relish the moment, so I marched down to the gap for a break. From there to the shelter, elevation decreased and trail conditions improved. No more ice. No more debris to climb over. Just 2” of snow to stomp down. My spirits immediately brightened as well.
+
+At a shelter, I took a nap and ate. It was only 3:00 by then, so I decided to hoof it to the next shelter, 5.5 miles away. This leg turned out to be in perfect shape. I shot through at a steady 3 mph, descending into an amazing ravine of rhododendron and amazing old growth hemlocks. Some were 300 years old and 5 feet thick, I later learned.
+
+Walking through those holy trees was the highlight of my day. I reached Hawk Mountain shelter before sundown, totaling 9 miles that day. I ran down to the stream to get water, cooked, strung up a bear bag, and wrote for an hour by candlelight. I drifted off and had a strange demon dream where Satan was in my head and barking at me so I couldn’t think, and then I flooded him out by begging God to intervene and jerked awake. After that I was spooked and couldn’t drift off. The mice, in their audacious fashion, ran all over me and all over my stuff, flatly ignoring both my yells and the beams of my flashlight. I slept well that night.
+---
+---
+date: '2010-02-08'
+start: Hawk Mountain Shelter
+destination: Gooch Mountain Shelter
+miles_today: 14.0
+trip_miles: 23.0
+facts:
+  weather: High 44°F, low 27°F. Overcast.
+  trail_section: Hawk Mountain Shelter sits at roughly AT mile 8 from Springer Mountain
+    in the Georgia Blue Ridge. The trail between Springer Mountain and Hawk Mountain
+    traverses rocky ridgeline sections through hardwood forest. Gooch Mountain Shelter
+    near AT mile 16 is a popular first multi-night destination for northbound thru-hikers.
+    The trail from Hawk Mountain to Gooch Mountain crosses Justus Creek and climbs
+    through mixed hardwood forest. The Gooch Mountain area receives heavy hiker traffic
+    in early spring during thru-hiking season. The Georgia AT traverses the southern
+    Blue Ridge Mountains, crossing several 4,000-foot summits in ~76 miles. Georgia's
+    AT features rocky ridgelines alternating with dense hardwood forest typical of
+    the southern Appalachians.
+  confidence: high
+  sources:
+  - AT location database
+  - Open-Meteo archive
+---
+# Monday, February 08, 2010 — Gooch Mountain Shelter
+**Start Location:** Hawk Mountain Shelter
+**Miles Today:** 14
+**Trip Miles:** 23
+
+I woke up at 8:30 and saw a huge red woodpecker which made me smile. By 9:15, I was on the trail strong and fast to my destination 20 miles away. The trail was gradual and I was happy to be on it, hoofing towards Maine. About an hour passed wuntil I realized I was going in the wrong direction. I cursed aloud. I cursed aloud again. And you know how I realized it? “Cool, that guy’s shoe tracks look just like mine. I wonder if he has the same ….oh shit.”
+
+So after logging a total of 6 idiot miles, I was once again back at the shelter. It was 11:15. I took a nap had breakfast, dressed a blister, then set off again towards the next shelter 8 miles away (I gave up on 20 miles after losing so much daylight). And this time I was going North.
+
+Still, the mountain was white out – all white in snow, fog, and sky – and the temperature was still 23F from that morning. But very quickly, the bad weather lifted. The sky cleared, temperatures rose, and somehow the trail was 100% cleared for the nearly all 8 miles. The sun out and surrounding mountains visible, I stopped for a second and though about how they chase the phrase “Appalachian Scenic Trail”: this was no forced march like I’d been treating it that day. It was a scenic route, carved for the likes of Thoreau’s saunterer traveling to the Holy Land. Then I thought of how fortunate I was to be there on that mountain. I could’ve been a lot of other places – like stuck at work or school, in a wheelchair, or in the twisted metal of a car on the side of River Road- like should’ve happened so many times. So here’s to a blessing. “I’m goin’ to Maine!” I said laughing. “I’m goin’ to Maine!”
+
+At dusk, at the shelter, I finished dinner and let the fire die down to dull embers. In his classic hiker’s manual, The Walker’s Handbook, Colin Fletcher let it die from time to time, to let the darkness surround you. There’s nothing as pure and powerful he said, as darkness deep in the woods. So I stood on the porch of the shelter and let everything go black around me. The wind blew in the trees and it was eerily quiet. “Say something” I said to God. I didn’t know whether to expect something good to happen or something bad, because I’ve found that he’s speaking all the time in the strangest ways, and he’s found in both the happy and the hard. I stood there for a long time, dreaming not thinking about all the blackness. It was addicting. It cozied the mind and numbed it over, like the way you cease when you finally arrive home. I was at home, in the wooded blackness. After half an hour, I retired to my sleeping bag and fell asleep.
+---
+---
+date: '2010-02-09'
+start: Gooch Mountain Shelter
+destination: Neel Gap Hostel
+miles_today: 15.5
+trip_miles: 38.5
+facts:
+  weather: High 40°F, low 34°F. Slight rain.
+  trail_section: Gooch Mountain Shelter near AT mile 16 is a popular first multi-night
+    destination for northbound thru-hikers. The trail from Hawk Mountain to Gooch
+    Mountain crosses Justus Creek and climbs through mixed hardwood forest. The Gooch
+    Mountain area receives heavy hiker traffic in early spring during thru-hiking
+    season. The Georgia AT traverses the southern Blue Ridge Mountains, crossing several
+    4,000-foot summits in ~76 miles. Georgia's AT features rocky ridgelines alternating
+    with dense hardwood forest typical of the southern Appalachians.
+  confidence: high
+  sources:
+  - AT location database
+  - Open-Meteo archive
+---
+# Tuesday, February 09, 2010 — Neel Gap Hostel
+**Start Location:** Gooch Mountain Shelter
+**Miles Today:** 15.50
+**Trip Miles:** 38.50
+
+In the morning, I awoke before 8:00 and prepared to leave. It was very cold, but off I went towards Neels Gap. After several hours I passed through Woody Gap, where I met a middle-aged couple on a geo mission. The man took my photo with his iphone and emailed it to my mom and dad. They lady kept looking at me like she wished she had a son of her own. My first run in with Trail Magic!
+
+It was 11:00 and I continued on up to the ominously titled Blood Mountain. Cherokee and Creek warriors met head to head on these slopes, leaving so many dead that the streams ran red with blood. On the way up, I passed homeless and unemployed, two 2001 thru-hikers on a stroll for the day. Two of the nicest hippies I’ve ever met. The man really wanted to give me tips and advice and the woman was beaming at me the whole time. I’m not entirely sure why, but that couple filled me up with so much positive energy.
+
+Down into the next gap, I began to micro-nap. I don’t know how long it lasted, but I continued to twist my ankle and walk off the trail, and even hallucinate (I saw my dad’s face in a poplar tree, even double-taking to make sure) until, at last, I threw down my pack and collapsed trailside for a deep, hour long nap.
+
+Blood Mountain wasn’t too difficult. It climbed up and over several false summits and finally wound up into a rocky, rhododendron covered peak. The wind was steady and snow was still on the ground. I Exploded off the trail and shot down the mountain (small birds for once played in the rhododendron). I found cougar tracks. An ornery, cantankerous skunk was said to occupy the mountaintop shelter, and a bear had reportedly been “hanging out” around the summit. To accentuate the sense of wildness was the narrow trail itself, which tunneled through the rhododendron and crawled over mossy rocks. On the summit’s main rocky outcrop, I saw the entire North Georgia Mountains rolling out and a pink and purple sunset over them. The CCC constructed shelter, a 2 room stone edifice complete with windows and a fireplace. Still, drafts of cold wind kept the shelter far from cozy, so I gambled on finding a free place to stay and moved on down the mountain to Neels Gap.
+
+I reached Neels Gap outfitter by 5 o’clock, closing time, but fortunately the Hiker Hostel was open. There were several men milling about, all with foot-long gray beards and long hair. A long beard means one thing in the mountains - experience- so, naturally, I was excited to spend a night with the experts. The price was only $15, said one bearded man, with the possibility of working it off. I sat down inside and wrote while another bearded man prepared tacos and rambled on about how “everything was going to shit” thanks to an enforcement of state ordinances. Two more bearded men walked in the door and dissappeared out the back. “Can you shoot a cougar?” I asked. “Sure, I don’t see why not. But if they catch you they’ll throw you in jail”, said one of the gnarliest of the bunch. Then he let out a long calm laugh and started talking to the cats. “Come get dinner,” he said after awhile, “or the cats’ll get to it. Actually, they already have.” He laughed at that.
+
+After dinner I boiled some tea and sat by the heater to write in my journal. In ten minutes I was curled up in the chair asleep. It was so nice being warm.
+---
+---
+date: '2010-02-10'
+start: Neel Gap Hostel
+destination: Low Gap Shelter
+miles_today: 11.0
+trip_miles: 49.5
+facts:
+  weather: High 38°F, low 20°F. Light drizzle.
+  trail_section: Trail section from Neel Gap Hostel to Low Gap Shelter.
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+---
+# Wednesday, February 10, 2010 — Low Gap Shelter
+**Start Location:** Neel Gap Hostel
+**Miles Today:** 11
+**Trip Miles:** 49.50
+
+In the morning I got up at 6:15 to get a hot shower before the others did, then sat by the heater and read a book about trees. At 9:00, I packed up, and walked up to the outfitters. I asked to do some work to pay off my stay, but the owner wasn’t there so I settled up to save time. I hit the trail just before 10, just as the rains came.
+
+That day was divided sharply between great and God-awful. The first half, the great part, flew past as I hoofed without stopping through the wind and rain. 6 miles over to Tesnatee Gap. I went hard and strong and felt like a champ. But after a short stop at Tesnatee, things fell apart. During the stop, I’d quickly lost all doby and hand heart and became a numb-fingered, shivering - and , not to mention, dripping wet – mess. My hands lost the benign feeling of numbness and began to hurt like someone was bending them back. Groaning aloud and cursing, I began to march. I won’t go into details because the next 4 hours was a drama of the most boring kind. I’ll just say it really sucked and skip to the moment with God, which occurred near the end of the ordeal. I was mouthing off at him again (aloud, mind you), not really making a case but just pissed at the day’s suffering. I had to yell at someone. I told h im to make it okay, or at least give me the big picture so I could at least calm down. All of the sudden, I said it aloud, “This is all part of it”. This is part of the Good, the adventure, the chase after an elusive Spirit. This very moment of numb hands, wet clothes and stabbing blisters was the very reason I set off. Because this is Thoreau’s “marrow of life”, and in it I will find my God.
+
+I went to sleep that night with no idea what to do about my blisters for the next day. The wind picked up and a fog rolled in and the night was all dense blackness and I thought to myself about the old proverb “When I saw I stumbled.”
+---
+---
+date: '2010-02-11'
+start: Low Gap Shelter
+destination: EconoLodge Motel (Helen, GA)
+miles_today: 13.5
+trip_miles: 63.0
+facts:
+  weather: High 42°F, low 24°F. Overcast.
+  trail_section: Trail section from Low Gap Shelter to EconoLodge Motel (Helen, GA).
+  town_events: Franklin named first Appalachian Trail Community in 2010 - Facebook
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+  - https://www.facebook.com/groups/159729421133853/posts/877502402689881/
+---
+# Thursday, February 11, 2010 — EconoLodge Motel (Helen, GA)
+**Start Location:** Low Gap Shelter
+**Miles Today:** 13.50
+**Trip Miles:** 63
+
+That was a rough night. The temperature plummeted, freezing to rock everything in the shelter I thought was safe – my water bottles, my boots, my clothes. Snow flurries blew in while I slept and covered my down sleeping bag, soaking into the goosedown inside and forming a shell of ice on the surface. As a result, my feet went numb. I awoke cold and discouraged. I fumbled with numb hands to gather my gear and apply my moleskin. My boots were too frozen to put on so I screamed at God in the ravine “What the hell am I supposed to do??” I put on my down booties and started walking.
+
+To my surprise, the down booties did an excellent job. By the time I reached the Blue Mountain Shelter, I had marched through 8 miles of snow and ice and my feet felt great. Close to the summit the wind blasted through the trees. It filled the ears like deafening static. “C’mon! C’mon!” I yelled exhilarated by the struggle against the elements. At the summit shelter, I found an old-timer with his dog and Kevin, a young thru-hiker. “Fire!”, I said, seeing the wind ripping smoke out of the fire pit. “How’d you pull that off?” Kevin was knelt by the fire. He grinned like it was no big deal. “Sticks and fire”. Then he laughed. “Respect”, I said, I asked for more details. The old-timer had a long beard and a weathered face. He was smoking a Backwoods cigar. As it were, the two were holed up in the shelter because the next peak on the trail, Tray Mountain, was demolished by a terrible ice storm. The trail was impassable, said the old-timer; he had tried. The company was nice, especially by two with more knowledge of mountain survival than I. “So where’d you learn to make a fire in the snow?”, I asked. Kevin had been a hunting guide in British Columbia for half of the year, for the past six years, and had “pulled out bodies” from the snow many times. I told him of the previous night’s problems and asked for advice, “The learning curve in the cold is steep, bro” he said grinning. He was really impressed by my light pack. “Hats off to you, mate. Especially in cold weather.”
+
+I gave Kevin some cheese, warmed my hands up by the fire, and marched on down to Unicoi Gap to hitch into town. Dry gear and a warm motel were in high demand. After a minute of thumbing a black car pulled over. Alex, a gay artist on his way to see his boyfriend, was glad to drive me around town to check various motel prices. He was “paying back a favor, or paying it forward, whichever one” He said in his hometown, Hayesville, NC, alcohol had just become legal last month. He had been a vocal advocate. His father, a Baptist minister, had led the opposition. I laughed. Alex said goodbye at the EconoLodge, and I fell asleep on my $30/night bed. I woke up, took a shower, called home, and ate some shrimp ramen with tuna and olive oil. Everyone seemed fine at home, like they’d moved on without me as I’m accustomed to them doing. When you’re away, all you can really say is “I love you” or “I miss you” but those words don’t mean much. It still kinda sucks. I thought about that while I ate my ramen. That night I watched a cheesy movie about aliens. I just didn’t feel like writing.
+---
+---
+date: '2010-02-12'
+start: EconoLodge Motel (Helen, GA)
+destination: Mull's Motel (Hiawasee, GA)
+miles_today: 15.0
+trip_miles: 78.0
+facts:
+  trail_section: Trail section from EconoLodge Motel (Helen, GA) to Mull's Motel (Hiawasee,
+    GA).
+  town_events: Hiawassee/Towns County, GA
+  confidence: low
+  sources:
+  - https://appalachiantrail.org/protect/conservation/at-community-program/hiawassee-towns-county-ga/
+---
+# Friday, February 12, 2010 — Mull's Motel (Hiawasee, GA)
+**Start Location:** EconoLodge Motel (Helen, GA)
+**Miles Today:** 15
+**Trip Miles:** 78
+
+At 6:15 the next morning, I was packing my gear up. It was all so warm and dry. I wrote until 7 o’clock then went to breakfast. Ron, the on-duty manager, was fiddling around with setting up breakfast. He rambled on about how dismal Richmond was for various reasons, including one story about two hookers begging him for crack money. Another story involved drug-running and leaving town after a 6’5” friend fooled around with some other guy’s girlfriend. “I gotta ask you something”, he said. “Are you carrying a gun?”
+
+After breakfast, I dressed my blisters. I bought moleskin at Randy’s pharmacy and the lady let me sit inside to apply it. Randy gave me free blister tape: Trail Magic! “Stay as long as you want, I’d let you lay out and take a nap if we still had those mattresses!”
+
+I walked out to the road and stuck out my thumb. Believe it or not, Ron pulled over. He rambled about me burning ukp all his gas money, running a homeless shelter, how “he don’t pay me shit” at his job and the yars he spent with black ops in Vietnam. “I help people like you out because of what I done to all them”, he said looking skyward. “You wouldn’t believe the sniper rifles they got these days,” he said next. Ron was a good man, a wreck but worth every penny. I’m glad I met him. “I can’t afford to burn all this gas,” he said. “But I need to get up into these mountains. It’s beautiful”. I got out and slammed the door at the trailhead. He rolled down his window and yelled for me. “Hey, hey…I’ve gotta ask you a question.” “Do you ever see things up there that you’d never see down here?” I said “Yes, you do.”
+
+That day on the trail was great. I passed one hiker after another, meeting and greeting and exchanging trail info. I first passed Ryan, another thru-hiker. He’d been laid off, but luckily gotten into law school, and, with his wife’s permission, took off on the A.T. during the layover. He had a nice North Carolina draw. “I’m one of those slow, deliberate people”, he said as I passed. “Yeah,” I laughed. “You’ll probably pass me napping in the next shelter”. Next, I passed three sturdy men moving in the opposite direction. They were older, yet were “tougher than your average weekenders” as they assured, and seemed it. They were impressed by my ultralight pack. On my way up Tray Mountain, I passed an older fellow coming down. Dave Herring was in his 60’s and still climbing Georgia’s mountains, meeting up with thru-hikers and helping them along the way. A full-time Trail Angel, you might say. Today, he escorted two thru-hikers up and over Tray Mountain (remember, the trail was all but wiped out by the storm). For two separate nights, Dave had brought the hikers homecooked dinner, a warm bed, and a place to watch the Super Bowl. For three days, he had brought in two thru-hikers for hot meals, beds, and a Super Bowl party while icy conditions on Tray Mountain improved. Today, he escorted them up and over the mountain. He used to be a big runner, he said, but had lost cartilage in his knee. Now, he was down to just day-hiking for he and his wife. I was overwhelmed with gratitude for this man and his wife, for people who give themselves so fully to the strangers passing through. I’m talking about the A.T.’s host of Angels, and they’re watching over our road north.
+
+After a long nap at the top of Tray, I passed two thru-hikers, Fauma and Second Stage, on the way down the mountain (when I say “down the mountain”, I’m referring t the many ups and downs between a summit and a gap. Rarely is there black-and-white ascent and descent on the AT). All day, I’d been tracking their prints through the snow and around the debris. Catching up to them was the climax of the day. “You hear about these hikers ahead of you and you read all their entries in the shelter journals. You start to paint a mental picture of them,” I told Fauma when I caught him. “It’s kinda like online dating.” He laughed, “Wow, guy”.
+
+My eyes were set on Dicks Creek Gap, still 5.5 miles away by dusk. I flicked on my headlamp, chugged some orange juice and kept trucking. My legs were tired and my feet sore from walking in my booties for 8 miles already. I made it by 7:30 and hitched a ride into Hiawasee by 8pm. I got a motel room for $50 despite efforts at bargaining. I walked across the street to Hardee’s for dinner. I wrote, took a hot shower, and fell asleep by 11:00 with the lights on.
+---
+---
+date: '2010-02-13'
+start: Mull's Motel (Hiawasee, GA)
+destination: Mull's Motel (Hiawasee, GA)
+miles_today: 0.0
+trip_miles: 78.0
+facts:
+  trail_section: Trail section from Mull's Motel (Hiawasee, GA) to Mull's Motel (Hiawasee,
+    GA).
+  town_events: 2013 Appalachian Trail Events
+  confidence: low
+  sources:
+  - https://appalachiantrail.com/2013-appalachian-trail-events/
+---
+# Saturday, February 13, 2010 — Mull's Motel (Hiawasee, GA)
+**Start Location:** Mull's Motel (Hiawasee, GA)
+**Miles Today:** 0
+**Trip Miles:** 78
+
+I woke up and caught the motel on fire. My alcohol stove liaks, you see, so when I placed it right outside the door of my second-story room it soaked the green carpet with alcohol. When I lit it, it exploded in a flame. I tried to blow it out to no avail. I knocked it over and flaming alcohol spilled out over more carpet. Flames were at least a foot high. I beat at it and finally got it under control, but the damage was done. The carpet was black and smoking. “Shit.” I said calmly. I quickly packed up my gear and got the hell out of there ASAP, tip-toeing over the office, down the steps, and one building down to a café.
+
+As I sipped my coffee and wrote, I kept waiting for the motel owner to come looking for me. Afterall, in a small town one can’t run far. The café door would squeak open and I’d brace for confrontation, over and over again. “The cops are here for you”, I suddenly heard the barista tell a regular. I tensed. Maybe cops were turning into the motel parking lot, which the café shared, to hunt the fleeing vandal. And sure enough, three cops entered and stood by the door looking at me. “Can I help you officers?”, said the barista, and the officers sat down for a doughnut. I breathed out.
+
+Looking over my shoulder, I crossed the street to the grocery store. I spent $33 for almost a week’s worth of food. Then I got a ride to the Blueberry Patch Hostel where the owner, Gary Potteat, turned me down at the driveway. “We’re just not finished yet. Maybe tomorrow.” He said kinda sorely. He’s a good Christian man who’s taken in thousands of hikers for no gain but ministry, so if he was sore I think it was because he had to turn down a hiker in need.
+
+I had only 60 some dollars left, so another night at the motel was out of the question, even if I hadn’t fled the burned carpet that morning. I had no where to go.
+
+The kind folks who gave me a ride (out of their way) to Blueberry Patch Hostel dropped me off at a church at the junction where they returned to their route to Atlanta to see their sick mother. I’ve always wanted to test out the church as a place of unconditional refuge, so I walked up to the office and knocked on the door. No answer. Just before walking back out to the road to thumb to another church, I noticed a small house on the corner of the church property. A pick-up was out front. I walked up and knocked, and to my surprise a younger man opened the door. He was hip-looking, sharp, kinda like a Young Life leader. “Let me see what I can do. Come on in.” I knelt down to pet the lab. “You know, I’m a thru-hiker back in 1996”. I couldn’t believe it. But the magic didn’t stop there. He said, “Follow me” and we walked over to the church. He flicked on the light in a room, “Wait in there and I’m gonna try to pull some strings,” he said, then disappeared. I read a bible for about five minutes, when a gleaming middle-aged woman walked in. “I’m Lynn”, she said. “I’m Gary’s wife, at the Blueberry Patch. We’re gonna get you a room in town.” I couldn’t believe it. Lynn, the gleaming secretary at the church, at which I fortuitously knocked, was the wife of the woner of the hostel where I’d just stopped, wife of a man who’s Christian kindness spread his name all the way to Richmond. And this connection was dropped in my lap by a sympathetic thru-hiking pastor. “We’re going to get you a room at Mull’s Motel”, she said. My stomach dropped. The burned carpet. That’s where I left the burned carpet. “Let me drive you to Mull’s” said the young pastor. We pulled in and I prepared for impact upon entering the cramped motel office. Fortunately, the 86 year old lady was still there in her nightgown, just like I’d seen her the evening before. And, (thanks to her age, perhaps) she didn’t remember me. I couldn’t believe it. I was redeemed. “I really don’t know how to thank you, man,” I said. “It just works out, doesn’t it”, he said. I think from time to time God has fun and wires things. Redemption of unbelievable cause-and-effect complexity. Even miracles. No, it’s not in his nature. It’s not all like that. Jesus spent but a sliver of his hours dropping jaws with these unbelievable occurances. Most of his days were spent walking around in the dust, telling people that, yeah..reality can be really boring but it’s okay. The miracles almost never happen around town but it doesn’t matter because the real miracle is deep within. The real wonder is the heart and soul of man. So, I won’t walk to Maine looking for him to wink at me again. I’ll keep looking within.
+
+Snow fell that night in Hiawasee, about 2 inches. I ate my trail mix and wrote oa letter to the Potteats from the warmth of my motel room. After two nights of comfort, I was ready to hit the trail again.
+---
+---
+date: '2010-02-14'
+start: Mull's Motel (Hiawasee, GA)
+destination: Blueberry Patch Hostel
+miles_today: 0.0
+trip_miles: 78.0
+facts:
+  trail_section: Trail section from Mull's Motel (Hiawasee, GA) to Blueberry Patch
+    Hostel.
+  town_events: Hiawassee/Towns County, GA - Appalachian Trail Conservancy
+  confidence: low
+  sources:
+  - https://appalachiantrail.org/protect/conservation/at-community-program/hiawassee-towns-county-ga/
+---
+# Sunday, February 14, 2010 — Blueberry Patch Hostel
+**Start Location:** Mull's Motel (Hiawasee, GA)
+**Miles Today:** 0
+**Trip Miles:** 78
+
+After a "zero day" off the trail, I awoke again in Mull's Motel and gathered my things. A lady saw me and asked if I needed any fuel of supplies. Yes, I said. I needed denatured alcohol for my stove. She pointed towards an outfitter down the street and told me to meet her there. "We got some for ya." She drove her truck around the corner, parked out front and opened the door and led me in. "It's free," she said, pointed towards some steel cans of alcohol. "Just leave a little something in the Kitty." I dropped a couple quarters in a cat-shaped container, thanked her, and hitched to the Blueberry Patch Hostel. The owner Gary Poteat still hadn't opened for the season, but I needed to pick up a package my parents had shipped there. Gary's house is off a 45 mph highway, miles from the city. It's easy to get a ride there from the city, but hitching away is difficult. A nice guy in a pick-up dropped me off there and drove away. Nobody was home so I waited, but I quickly realized it was too cold to hang around. Back to the trail was my only option. I left a note and walked out to the road. I stuck out my thumb and tried to look cold and miserable.The more cold and miserable you look, the more likely a car is to stop. I think.
+
+After almost 30 minutes, around the bend came a pickup. It was slowing and it's turn signal was on. It was Gary and his wife, Lynna, returning from town. They pulled in. "I know yall aren't open yet. I just need a package before I go," I quickly said as they got out. I wanted to make it clear that I just needed a package, not more charity. He said he had it and added, "You're welcome to stay the night." I pretended not to hear. If he really meant it, he'd repeat the offer. Sure enough, he did. "Yeah, I'd love to." This meant another day's delay, a second "zero", but I didn't care. This was an experience I wanted to have. Back in Richmond, I'd heard of Gary, his hostel, and even his hiker-famous blueberry pancakes. It was worth a day lost.
+
+We chatted as he lit the wood stove in the bunkhouse. Gary was a talker, and told me some of his story in his cool, Georgia-accented voice. He thru-hiked in the 90's and felt the Lord's voice. "Open a hostel of your own," he heard. "Minister to hikers." He married, moved back to Georgia and bought a parcel off the AT. Ever since, he's taken in ragamuffin hikers like myself. I was the first of his 18th year.
+
+The telephone rang and he walked over an answered it. Another hiker was on his way. Soon, a familiar face appeared at the door. Keven, the Canadian I'd met on Blue Mountain, walked in the door. He was thrilled to see me. I was glad to see him.
+
+That night we went into Hiawasee. We bought food for the next stretch to Fontana Dam, a tedious process of diving out calories on price. Keven convinced me to share food together over the next two weeks--breakfast, lunch, and dinner. Sounded like a good idea. I mean, why not? We also got some steaks and asparagus to take back to cook. I bought a crispy Fuji apple. Back at the hostel, we ate heartily and stayed up until 1:00 dividing ten days of food weight.
+---
+---
+date: '2010-02-15'
+start: Blueberry Patch Hostel
+destination: Muskrat Creek Shelter
+miles_today: 15.0
+trip_miles: 93.0
+facts:
+  weather: High 27°F, low 19°F. Heavy snow.
+  trail_section: Trail section from Blueberry Patch Hostel to Muskrat Creek Shelter.
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+---
+# Monday, February 15, 2010 — Muskrat Creek Shelter
+**Start Location:** Blueberry Patch Hostel
+**Miles Today:** 15
+**Trip Miles:** 93
+
+We skipped church the next morning. The pastor of the Poteat's church, the Macedonian Baptist, had given me a ride into town and paid for a $50 motel room, and Gary Poteat had broken tradition and opened the hostel a day early just for me. I owed it to them to go to church and I knew it. But to make it 11 miles to the Muskrat Shelter by Sunday night, we needed to leave early. Kevin agreed. I still feel like I missed something by skipping church. I think He was waiting for me there, but I was too hasty to stop. We broke the news to Gary that night.
+
+At 7:30 Sunday morning, I packed my pack and prepared to leave. Gary called us inside for a stellar breakfast of sausage, biscuts, eggs and pancakes with home-picked & home-made blueberry syrup. We held hands and prayed over the food, just like home. Gary prayed for us and I knew he (and Lynna) meant every word. It all warmed me up. Lynna gave us a hug before leaving, told us he'd be watching out. I've never meant a person that glowed so genuinely for Christ. You can't glow for God, I thought to myself, cus he's kinda mean. He's like the snow and ice. But you can glow for Christ. He's like the sunshine.
+
+By 10:15 we were on the Trail, marching towards Maine. Just before the Muskrat Creek Shelter we crossed the North Carolina border. We celebrated and cursed Georgia. "Screw Georgia! We're in North Carolina!". Remember, all was buried in 1.5 feet of snow. Some drifts were even up to our thighs. After passing the gnarled oak in the clearing at Bly Gap, North Carolina greeted us with a grueling climb in 2-foot snow drifts. Very difficult. At Muskrat Creek, we found some food left by the previous night's campers. We played cards while we ate it for dinner. That night 4 inches of snow fell. Snowflakes drifted in and soaked into our down sleeping bags. I slept well.
+---
+---
+date: '2010-02-16'
+start: Muskrat Creek Shelter
+destination: Standing Indian Shelter
+miles_today: 5.3
+trip_miles: 98.3
+facts:
+  weather: High 24°F, low 12°F. Overcast.
+  trail_section: Standing Indian Mountain at 5,498 feet is the highest peak south
+    of the Great Smokies on the AT. The Standing Indian area is known for its high
+    balds and sweeping views of the southern Appalachians. The North Carolina AT includes
+    some of the highest peaks east of the Mississippi outside the Rockies.
+  confidence: high
+  sources:
+  - AT location database
+  - Open-Meteo archive
+---
+# Tuesday, February 16, 2010 — Standing Indian Shelter
+**Start Location:** Muskrat Creek Shelter
+**Miles Today:** 5.30
+**Trip Miles:** 98.30
+
+The snowfall paralyzed the next day's movement. We packed up and ran down to Raven Rock, a side trail to a rocky outcropping over miles of open ridge & valley. The view was spectacular. Kevin pointed out a bear. I wasn't convinced.
+
+A word on Kevin. He's good kid, 22 years-old and mild-mannered like myself. And like myself, his giggles and lightheartedness are clear stamps of loving parents and a comfortable, financially-stable home. Still, being with him is a challenge. It's Kevin in the morning and Kevin in the evening. We share shelter, food and water. We share the gratification of a long day's hike. We even share the silence of nightfall, which he prefers filling with dialogue. In a word, I'm sharing my great spiritual journey and it's irritating. I didn't hit the trail for company, to substitute "I" for "us" in my journaling. But the Spirit put him in here for a reason. To show me something or another.
+
+The short 5.3-mile hike taxed our mind and body. We crawled along at about 1mph through the snow, inspiring each other with singing and joking. For hours we carried on, and arrived at the Standing Indian Shelter by dusk. We threw down our packs and searched for firewood. In 20 minutes a fire was blazing. It's amazing what a fire can do for spirits! "I'm not afraid of the night anymore," I said. "I'm not afraid of the cold." The fire smoked-out the shelter, sending us coughing out into the snow. It died down as we cooked tortillas with cheese over the flames. Beef stew for dinner. For some reason, Kevin got sick and I kinda had to take care of him in the cold. Up to that point, I'd kind of honored him as a senior, like a guide. But I realized then that I was better off alone. I was strong and independent.
+---
+---
+date: '2010-02-17'
+start: Standing Indian Shelter
+destination: Carter Gap Shelter
+miles_today: 7.6
+trip_miles: 105.9
+facts:
+  weather: High 28°F, low 8°F. Overcast.
+  trail_section: Standing Indian Mountain at 5,498 feet is the highest peak south
+    of the Great Smokies on the AT. The Standing Indian area is known for its high
+    balds and sweeping views of the southern Appalachians. The North Carolina AT includes
+    some of the highest peaks east of the Mississippi outside the Rockies.
+  confidence: high
+  sources:
+  - AT location database
+  - Open-Meteo archive
+---
+# Wednesday, February 17, 2010 — Carter Gap Shelter
+**Start Location:** Standing Indian Shelter
+**Miles Today:** 7.60
+**Trip Miles:** 105.90
+
+The next morning was 10 F in the shadow of Standing Indian Mountain. According to Cherokee legend, "a great winged monster once inhabited the mountain, and, during the monster's reign, warriors were posted on the mountain as lookouts." One day, a huge bold of lightening exploded on the mountain, killing the monster and striking the unfortunate warrior on-duty at the time. He was a lousy look-out, apparently. That's why he was struck and turned to stone. He's still there, a "Standing Indian" stone, but I didn't see it.
+
+The sun was out and it was freezing. It had snowed another inch. Again, I had to wait for Kevin and ended up just leaving. We were both miserably cold. My feet were numb and patience low, but I brightened up the moment I started walking. That day flew by. We rolled into the shelter by 3:30 after nearly 8 miles of snow trudging. Fahma from Massachusetts was there. He'd taken the day off "I've been eatin' and drinkin' all day," he said. Running into Fahma was the highlight of the day. The night fell easier with him there to break the monotony of Kevin's voice. No offense to Kevin's voice. I'm just tired of it.
+
+I asked Fahma about his family. He said he once had a son who thru-hike with him two years ago. "He had so much energy," he said. "He really got me through it". His son died last April of a brain tumor, and this hike was for him. According to Kevin, he paid for the Gooch Mountain Shelter I'd stayed in several nights before, in honor of his son. I recalled seeing a memorial photo on the wall. "This is for you, Tim", Fahma writes on every shelter journal. Lord, the baggage we carry so silently.
+---
+---
+date: '2010-02-18'
+start: Carter Gap Shelter
+destination: Sapphire Inn (Franklin, NC)
+miles_today: 15.9
+trip_miles: 121.8
+facts:
+  weather: High 38°F, low 27°F. Slight snow.
+  trail_section: Trail section from Carter Gap Shelter to Sapphire Inn (Franklin,
+    NC).
+  town_events: Franklin named first Appalachian Trail Community in 2010 - Facebook
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+  - https://www.facebook.com/groups/159729421133853/posts/877502402689881/
+---
+# Thursday, February 18, 2010 — Sapphire Inn (Franklin, NC)
+**Start Location:** Carter Gap Shelter
+**Miles Today:** 15.90
+**Trip Miles:** 121.80
+
+I left Kevin again that morning. That's how it'll probably always be: me leaving early and him catching up at the shelter at the end of the day. Because I'm with him morning and night, I cherish the days where it's just me and the trail. It's funny I use the words "me and the trail" when I sort of mean "me and God". Because that's kinda what he's like. Like a trail.
+
+The first several hours were painful. My feet burned and ached from numbness, and I groaned aloud. "My toes," I kept saying. "My toes hurt." Frostbite was a possibility, I thought, but I felt no tingling. Just numbness. I debated stopping and firing up my stove to thaw them out, but it was just too cold to stop. "And if I do get frostbite," I thought, "it's okay because I'm young." Still I was worried. I kept walking.
+
+I took a side trail around Mount Albert, the official "emergency weather route". The moment I spotted an observation tower on it's summit I veered back onto the trail. An observation tower would be worth the difficulty. As expected, the rocky ascent was extremely precarious in the 2-foot snow drifts (I quickly learned that they offer "emergency weather" routes for a good reason). The tower was old and tired-looking and surrounded by dense rhododendron thicket. The wind blew. I climbed up to look out over the valley, spreading out for perhaps 50 miles. On the horizon hunched the Smokies, blue and ominous. A snowstorm obscured its peaks. I felt like Frodo, staring out to the black peaks of Mordor where my road would inevitably lead. Except this Mordor was blue and icy.
+
+At about 2:00 I felt my toes for the first time that day, thanks to a gradual downhill that allowed me to pick up speed and get blood down to my feet. I gulped from a stream. I walked on. Time blurred and suddenly it was 4:00. I waited at the shelter for Kevin.
+
+Soon Kevin arrived, and we decided to move on to Franklin, 3.7 miles down the trail. After 5 days and 4 nights in the cold, we needed a night off. My feet were sore and stressed and I suspected some hairline fractures, but I kept on 'til we reached the highway. After 20 minutes of thumbing, a white pick-up pulled over. He was a skinny, tatooed young guy with a NC accent and Marlboro Red in his mouth.
+
+He, his brother, his father, and even his grandfather--yeah, his grandfather!--all enlisted in the Marines within the last decade. He's been shot twice and blasted by an IED. The IED was a ticket home, where he got a job managing three Hardee's in the area. The "interview" for the job was a West Virginia football game, where he got hammered and had flashbacks from the fireworks. "I freaked out," he said. After a pause, "And I got the job the next day." For a while, he took post-tramautic stress disorder ("PSTD", he called it), but it killed his personality. "I'll take the flashbacks," he said. He also said he'd die before his son grew up as poor as he did, eating PB&J for dinner. That made me happy to hear.
+
+He dropped us at the Sapphire Inn where we got a 10% discount for being A.T. thru-hikers. We had fajitas at a Mexican place across the street and lounged in the room until around midnight. I took off my boots for a shower before dinner and found a browned and swelled pinky toe. It burned under water. Frostbite! I laughed and decided not to tell my parents when I called. I journaled later that night. Kevin watched TV. I wished I had the room to myself.
+---
+---
+date: '2010-02-19'
+start: Sapphire Inn (Franklin, NC)
+destination: Siler Bald Shelter
+miles_today: 6.0
+trip_miles: 127.8
+facts:
+  weather: High 39°F, low 29°F. Overcast.
+  trail_section: Trail section from Sapphire Inn (Franklin, NC) to Siler Bald Shelter.
+  town_events: Franklin named first Appalachian Trail Community in 2010
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+  - https://www.facebook.com/groups/159729421133853/posts/877502402689881/
+---
+# Friday, February 19, 2010 — Siler Bald Shelter
+**Start Location:** Sapphire Inn (Franklin, NC)
+**Miles Today:** 6
+**Trip Miles:** 127.80
+
+We left late the next morning. I drank 4-5 cups of coffee and updated my blog on the hotel’s computer. Kevin packed up and watched TV in the room. At 11:00 we walked over to Hardee’s. Kevin ordered 4 burgers and I brought in some tortillas, PB and honey. We got a hitch to the tail from another young local. “S\*\*\*, man. Just came from a funeral. I had to get the F\*\*\* outa there.” A buddy of 21 years had gotten drunk and dropped a cigarette in the couch. The house caught fire and “they found him right next to the F\*\*\* door”, he said. “I guess the smoke just got to him”. He got quiet. “We all knew him pretty well.” He pulled over and ran into a convenience store. He came out with a brown bag and drove off. He steered with his knees and rolled a cigarette. “I’d offer you some weed but my girlfriend has it all.” He complained about unemployment and not being able to provide for his kids. He seemed so worn out by it all. He dropped us at the trailhead and drove off.
+
+The hike in was only 6 miles, a steady climb on a good trail. At the shelter we ate two burgers that Kevin had mistakenly received at the Hardee's, and we went to bed early after a game of cards. Playing cards in the cold takes a lot of effort.
+---
+---
+date: '2010-02-20'
+start: Siler Bald Shelter
+destination: Cold Spring Shelter
+miles_today: 12.6
+trip_miles: 140.4
+facts:
+  weather: High 45°F, low 23°F. Mainly clear.
+  trail_section: Trail section from Siler Bald Shelter to Cold Spring Shelter.
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+---
+# Saturday, February 20, 2010 — Cold Spring Shelter
+**Start Location:** Siler Bald Shelter
+**Miles Today:** 12.60
+**Trip Miles:** 140.40
+
+We started late the next day, the day that would be the physically hardest yet of my journey. After a morning of lounging in the sun and eating, I was on the trail at noon. My destination: Cold Spring shelter, 12 miles away. The snow was deep over Siler’s Bald, where the imaginary Joseph Siler grazed stock nearly 200 years ago, and I followed Kevin’s prints. I caught up with him at Wayah Gap after 2 miles of trudging. I was enjoying myself, yelling “Wayah” over and over again in a high pitched voice.
+
+The ascent after Wayah was difficult. I blazed through knee-deep snow for nearly 2 miles, stopping every 20 steps to catch my breath. That wore me out. The trail wound around the mountain and up to an old stone observation tower built by the CCC in 1933. We stopped to take photos and eat dinner (it was 5:00). We hit the trail again in an hour under a setting sun.. The snow looked orange. We didn’t want to go but knew we had to in order to make it to NOC in time to meet Kevin’s friend, so that night we hiked until 10:00 pm to Cold Spring Shelter, totaling 12 miles that day.
+---
+---
+date: '2010-02-21'
+start: Cold Spring Shelter
+destination: A cabin (NOC)
+miles_today: 12.0
+trip_miles: 152.4
+facts:
+  weather: High 44°F, low 23°F. Overcast.
+  trail_section: Trail section from Cold Spring Shelter to A cabin (NOC).
+  town_events: Events
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+  - https://appalachiantrail.org/events/
+---
+# Sunday, February 21, 2010 — A cabin (NOC)
+**Start Location:** Cold Spring Shelter
+**Miles Today:** 12
+**Trip Miles:** 152.40
+
+There were 12 miles to go before the NOC, so we got up early (7:45) and hit the trail. The conditions on the hike were good – better than the day before – and we made excellent time. 12 miles in 5 hours, thanks in part to a 6 mile downhill. The last bit of the trail was paradise. The sun hit down in to the pines and to the understory, and the world was green and brown. I savored the smell of the pines. “This is how the South should smell,” I thought. That snowless section, though short, redeemed all days before it. Or at least gave them a happy ending.
+
+Kevin’s friend treated us well that night, feeding us homebaked cookies, cheetos, and whiskey and then taking us out for $15 steaks. The house was warm and, honestly, that was the biggest treat of all. They’re good friends and got drunk. I sat inside and wrote. It felt like a perfect day off, as do any long days with a warm-bed ending.
+
+At this point on the trail, I don’t know how I feel. Since joining up with Kevin, I feel like the emotional growth has stopped. It’s just been a social experience since and doesn’t excite me like the first leg of the journey did. I’m kind of bored with it, in fact, because it’s no longer mine. It’s shared with Kevin. My happy memories all lie in the first week, before Kevin. Since, it’s been dull and lifeless. God hasn’t been there. He hasn’t said a thing. It makes me hate Kevin for robbing it all from me, this once-in-a-lifetime season with God. I need to get away. I’ve decided that. I don’t know how. Will god put an opportunity in my lap to sneak away? Or should I just break away. For now, everyday is a lost one with Kevin. Every day is just like the rest.
+
+I wrote all that just several hours before, as a timely answer to my prayers, Kevin decided to take a “zero day” and let me hike on. We’d catch up in Fontana, three days away. It was just so perfect the way it worked out, you know? Maybe a wink from Him, saying “don’t you worry. Just seek me and you’ll find me.”
+---
+---
+date: '2010-02-22'
+start: A cabin (NOC)
+destination: Sassafras Gap Shelter
+miles_today: 7.5
+trip_miles: 159.9
+facts:
+  weather: High 53°F, low 38°F. Slight rain.
+  trail_section: Trail section from A cabin (NOC) to Sassafras Gap Shelter.
+  town_events: Franklin named first Appalachian Trail Community in 2010 - Facebook
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+  - https://www.facebook.com/groups/159729421133853/posts/877502402689881/
+---
+# Monday, February 22, 2010 — Sassafras Gap Shelter
+**Start Location:** A cabin (NOC)
+**Miles Today:** 7.50
+**Trip Miles:** 159.90
+
+So we ate a huge brunch and at 12:30 Kevin and his friend drove me to the trailhead. I was so happy to be off again, alone on my quest. The sun was out, snow melted and there was smell of pine everywhere. Just like summer! I took my shirt off and yipped aloud.
+
+I thought about my family and how much I miss them. They’ve done so much for me already, loved me so fully that I teared-up thinking about it. I saw god in all the beauty there. Our family is such a sold rock.
+
+By and by the trial became snowy and deep, and splintered rhododendron thickets, limbs and full trees blocked the trail every 50-some feet. Anger came at all the slipping and sliding. My frostbite blisters ached. So did my heel blisters. The deep snow and debris persisted. My anger grew. By the time I reached the shelter, that anger had burned me out. I didn’t really feel anything, and so the day ended on kind of a sour note. That night the wind made strange noises that kept me on edge. The drips of the shelter sounded just like feet crunching through show, and several times I got out of my sleeping bag and sent out to see nothing.
+---
+---
+date: '2010-02-23'
+start: Sassafras Gap Shelter
+destination: Brown Fork Gap Shelter
+miles_today: 9.1
+trip_miles: 169.0
+facts:
+  weather: High 41°F, low 31°F. Light drizzle.
+  trail_section: Trail section from Sassafras Gap Shelter to Brown Fork Gap Shelter.
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+---
+# Tuesday, February 23, 2010 — Brown Fork Gap Shelter
+**Start Location:** Sassafras Gap Shelter
+**Miles Today:** 9.10
+**Trip Miles:** 169
+
+I awoke late that morning. Being alone is good, but it’s just so lonely. Kevin is irritating me but I think it all may be more pleasant with him around. Not better for me, just more pleasant.
+
+At noon I left. A very late start to my destination 10 miles away. I’d eaten all of my cliff bars, smoked pipe, and played my harmonica. All was well. I was cursing again up the mountain to Cheoah Bald, furious at the debris blocking the trail and snow slipping under my feet. I hated everything around me, I hated god, and I hated myself. Fog was everywhere.
+
+The trail disappeared at Cheoah and it took a while to find. My anger was still around just quieted down. Another hour passed and the fog lifted. Suddenly, the sun broke through and illuminated the trail.. Bugs began to fly. Birds called. My heart was lifted and cleared out, and I laughed outloud. I thought about my family and how much love is there and started to cry in joy. I’m so emotionally unstable. Maybe I’m just mimicking a trail that itself is so irregular. Then I thought deeply about anger. Because I felt like people walking in the woods should think deeply about things. Anger comes up from below, I figured, only when a happy ending is no where in sight. It’s when you feel like your stranded in a bad situation with no ladder around to climb out. When I know the shelter is right around the corner, I don’t care how many limbs are on the trail. The end is near. But for some reason it angers me when I don’t know how long the struggle will ensue. Trudging through snow is okay if I know the shelter is near, but I go to rage when the end is nowhere in sight.
+
+In the sunshine I thought also about my friends at JMU. Leaving them behind and hiking with a stranger, I realize how deep and true they all are. I’m not talking about my dear old friends, Sean and Wesley, whose role in my life day to day is marginal nowadays. I’m talking about the Treehouse boys (my roommates), who I see now are so much more than I realized. Something about them – maybe their humor, maybe their devotion to each other, maybe the way they gave themselves so truly to me – strikes a chord deep in my heart. I didn’t see it before, but looking back alone in the woods I see it now: Rawlz, Chocolate, Seth, Barefoot, Cameron, Will and Fedesh were a gift. They were God showing me how it should be. I almost cried thinking about the gift.
+
+As you can see, reader, I’m entirely emotionally unstable as I hike towards Maine. I fly high in the morning, curse God at noon, whimper in the evening, and quietly surrender myself to His will before I go to bed. It’s an incredible high relief experience, now that I think about it, that few are fortunate enough to have. The portrait of god out here, captured through the lens of my twisted hart, is so shocking. So outrageous. So explosive. I’m seeing colors flashing and booming in my heart that I never knew existed.
+
+That night I slept at the Brown fork Shelter with Bill, a skinny old guy with a beard. He was good company. He liked to talk wild about anything that was worth talking about with a loud and enthusiastic voice. Trail conditions, hiking at night, his dog, good gear, philosophical matters. Like I said, he’s good energy generating company.
+---
+---
+date: '2010-02-24'
+start: Brown Fork Gap Shelter
+destination: Fontana Lodge (Fontana Village)
+miles_today: 12.0
+trip_miles: 181.0
+facts:
+  weather: High 32°F, low 24°F. Slight snow.
+  trail_section: Trail section from Brown Fork Gap Shelter to Fontana Lodge (Fontana
+    Village).
+  town_events: Appalachian Trail thru-hikers enjoy trail magic at Fontana Village
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+  - https://www.facebook.com/groups/1070154271134761/posts/1533014594848724/
+---
+# Wednesday, February 24, 2010 — Fontana Lodge (Fontana Village)
+**Start Location:** Brown Fork Gap Shelter
+**Miles Today:** 12
+**Trip Miles:** 181
+
+We all got up in the morning to make it 12 miles to Fontana Dam. I really didn’t feel like hiking and I cursed on the way out. My mom says I’m angry and need to deal with it. She says that maybe I have anger buried deep and that this walk will help release it. All I know is that I have a lot of anger and it boils out on the trail. The demons spill out, yeah, but I still don’t know how to extinguish them before they manifest in all my rage. I haven’t accomplished anything until I’ve accomplished that.
+
+By 2:00 I was thumbing for a ride into Fontana Village – a older guy in a pick-up stopped. He was on his way to work on some village lodges and said in a North Carolina accent that he’d love to say “F\* society” and go into the woods. I think every man has it somewhere in him, that drive away from the world and into the woods.
+
+At the post office I picked up my new showshoes and strapped them to my back. The other package –my food maildrop- hadn’t yet arrived so I walked over to the lodge to call home. On the way, I stopped by the convenience store and the clerk gave me a free sausage dog. I loaded it up with relish, cheese, and chili and bought a chocolate milk and candy bar to wash it down. At the lodge I dialed home and , as it turned out, they had my package right behind the counter. “You’re Ford?”, she said. “Ford Prior?” I was warm and cozy in the lobby and so got a room for $60 – I’d get $30 off for a broken heater. I washed up back at the room. I read the letters in the care package and thought about home before falling sleep. The chef called to invite me to dinner and I feel asleep again.
+---
+---
+date: '2010-02-25'
+start: Fontana Lodge (Fontana Village)
+destination: Fontana Dam Shelter
+miles_today: 1.0
+trip_miles: 182.0
+facts:
+  weather: High 34°F, low 24°F. Moderate snow.
+  trail_section: Fontana Dam at 480 feet is the tallest dam east of the Mississippi
+    River; the AT crosses it entering GSMNP. Fontana Dam Shelter is nicknamed the
+    'Fontana Hilton' for its spacious shower and laundry facilities. The North Carolina
+    AT includes some of the highest peaks east of the Mississippi outside the Rockies.
+  confidence: high
+  sources:
+  - AT location database
+  - Open-Meteo archive
+---
+# Thursday, February 25, 2010 — Fontana Dam Shelter
+**Start Location:** Fontana Lodge (Fontana Village)
+**Miles Today:** 1
+**Trip Miles:** 182
+
+In the morning I went to the front desk at 6:45 and asked for some money back. The heater had kept me awake and restless during my one night of what should have been sweet dreams. I got half of my money back and typed on the guest computer for an hour or two. I went back to sleep, got up and returned to the lobby. Kevin and Bill soon showed up. We lounged there for several hours then hitched to the Fontana Dam Shelter just up the road. Bill, Kevin and I went into town to resupply. At the shelter we ate almost uncontrollably into our food stash and had to force ourselves to stop.
+---
+---
+date: '2010-02-26'
+start: Fontana Dam Shelter
+destination: Mollie's Ridge Shelter
+miles_today: 11.3
+trip_miles: 193.3
+facts:
+  weather: High 39°F, low 21°F. Mainly clear.
+  trail_section: Fontana Dam at 480 feet is the tallest dam east of the Mississippi
+    River; the AT crosses it entering GSMNP. Fontana Dam Shelter is nicknamed the
+    'Fontana Hilton' for its spacious shower and laundry facilities. The North Carolina
+    AT includes some of the highest peaks east of the Mississippi outside the Rockies.
+  confidence: high
+  sources:
+  - AT location database
+  - Open-Meteo archive
+---
+# Friday, February 26, 2010 — Mollie's Ridge Shelter
+**Start Location:** Fontana Dam Shelter
+**Miles Today:** 11.30
+**Trip Miles:** 193.30
+
+Since before leaving home, I’d gloomily anticipated entering the Great Smoky Mountains. It lay like a snowy wall before us, visible now and again from on ly the highest peaks but always on the back of our minds. Today we entered it, crossing over Fontana Dam and into the woods. Huge snowflakes fell. The grade was steep, as we recovered elevation, and with higher altitudes came old snow. That day 12 miles weren’t difficult, well, they were like any miles, reader; they had their curses and laughs and felt linger than they actually were. Mollies Ridge shelter was nice, and we built a fire that wouldn’t stay lit. It snowed all night.
+---
+---
+date: '2010-02-27'
+start: Mollie's Ridge Shelter
+destination: Derrick Knob Shelter
+miles_today: 12.0
+trip_miles: 205.3
+facts:
+  weather: High 30°F, low 11°F. Overcast.
+  trail_section: Trail section from Mollie's Ridge Shelter to Derrick Knob Shelter.
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+---
+# Saturday, February 27, 2010 — Derrick Knob Shelter
+**Start Location:** Mollie's Ridge Shelter
+**Miles Today:** 12
+**Trip Miles:** 205.30
+
+That night was very cold. Bill, the 51 year old 4-time Ironman athlete, said “back home, nobody is ever going to understand. They’ll ask, “was it cold?” All you’ll be able to say is “yes, it was cold.” He also spoke of toughness. “You’re going to forget a lot of this, like how tough you had to be. You’re going to have to remind yourself, time and again for the rest of your life, how tough you really are.” I thought about that.
+
+The previous morning we woke and set off to Derrick Knob , another 12 miles up and over Thunderhead Mountain. I blazed and it broke me, and that day I cried like a baby. I screamed, too. And cursed. It was just so hard I didn’t know what to do. If there had of been someone with me, I would’ve tempered myself. But there were no pressures to keep my cool and I exploded. Friends and family may wonder, “happy ole Ford has anger problems?” I say not really, but you’d be a different man or woman, too, if you were in my position. You’d lose yourself like you never thought you would.
+---
+---
+date: '2010-02-28'
+start: Derrick Knob Shelter
+destination: On the side of the road (U.S. 442)
+miles_today: 15.0
+trip_miles: 220.3
+facts:
+  weather: High 57°F, low 35°F. Partly cloudy.
+  trail_section: Trail section from Derrick Knob Shelter to On the side of the road
+    (U.S. 442).
+  town_events: Franklin named first Appalachian Trail Community in 2010
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+  - https://www.facebook.com/groups/159729421133853/posts/877502402689881/
+---
+# Sunday, February 28, 2010 — On the side of the road (U.S. 442)
+**Start Location:** Derrick Knob Shelter
+**Miles Today:** 15
+**Trip Miles:** 220.30
+
+What a day! It’s funny how you can wake up in the morning and all sorts of things happen and that night you wind up falling asleep in some bizarre place you’d never of guessed. It’s wild. That night I fell asleep spooning with Kevin and cramped up against two large propane tanks. Tight around us was a high wall fence for the tanks, which plugged into the back of a locked weather building next to Route 441 at Newfound Gap. We had hiked 18 miles in the worst of conditions. We hoped to hitch into town at Route 441, but it was desolate, closed, we guessed. The march from Derrick Knob took us to the top of Clingman’s Dome, the AT’s highest point, and down to the gap in 15 hours. Hiking for 15 hours (that includes your four 15 minute breaks) in 2 feet of snow (sometimes 3 foot drifts) will take the fight out of you, until 1:00am we walked, slowly aching and soring all in places we never thought we’d ache and sore. Like my collarbone, which I broke in 9th grade. It was hard, and I pushed my mind and body just a little farther towards wherever we should be pushing our mind and body.
+
+\*Looking back, I realize how intense that night was.
+---
+---
+date: '2010-03-01'
+start: On the side of the road (U.S. 442)
+destination: A cabin (Gatlinburg, TN)
+miles_today: 0.0
+trip_miles: 220.3
+facts:
+  weather: High 51°F, low 40°F. Moderate drizzle.
+  trail_section: Trail section from On the side of the road (U.S. 442) to A cabin
+    (Gatlinburg, TN).
+  town_events: The Appalachian Trail | Great Smoky Mountains National Park
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+  - https://www.gatlinburg.com/great-smoky-mountains/hiking-trails/appalachian-trail/
+---
+# Monday, March 01, 2010 — A cabin (Gatlinburg, TN)
+**Start Location:** On the side of the road (U.S. 442)
+**Miles Today:** 0
+**Trip Miles:** 220.30
+
+Redemption Days, I call them, are when you go into town, you take a hot shower like you’ve never had one before. You eat a meal and close your eyes and wish it would never end. And you sleep in a warm bed in dry clothes and you feel just like a little kid again.
+
+Today, we awoke to the sound of snowplow trucks in reverse. I climbed out of the propane area and ran out to the road in my long underwear. I flagged down the truck. The driver looked at me funny. I didn’t know what to say. “Can you help us out?” He said he couldn’t give us a ride to town but a park ranger would be up in about an hour. He showed up in an hour in his big white suburban and was glad to give us a lift. He talked in the car about how very few thru-hikers are dope-smoking hippies like he once believed. They’re a strong, healthy bunch, he said.
+
+He dropped us at the Visitors Center and I flipped through some summer photography books from the Smokies. The warm, colorful photos made me laugh and tear up. The coming of Spring and Summer arouses such strong emotions for a nomad in the cold.
+
+Kevin’s friend, a grad student working on his thesis, picked us up and took us back to his uncle’s mountain house. We got pizza and beer and lounged by the television. I took a nap and a hot shower and then another nap. Sleep came early that night on a full belly and central heat.
+---
+---
+date: '2010-03-02'
+start: A cabin (Gatlinburg, TN)
+destination: Icewater Spring Shelter
+miles_today: 3.0
+trip_miles: 223.3
+facts:
+  weather: High 40°F, low 33°F. Moderate snow.
+  trail_section: Trail section from A cabin (Gatlinburg, TN) to Icewater Spring Shelter.
+  town_events: Franklin named first Appalachian Trail Community in 2010
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+  - https://www.facebook.com/groups/159729421133853/posts/877502402689881/
+---
+# Tuesday, March 02, 2010 — Icewater Spring Shelter
+**Start Location:** A cabin (Gatlinburg, TN)
+**Miles Today:** 3
+**Trip Miles:** 223.30
+
+Some say getting back on the trail after a day off is difficult, but hitting the trail after our day off at Gatlinburg wasn’t too bad. Our pockets were stuffed with fruit and sausage biscuits as we walked three miles to Icewater Shelter The view was great over Cherokee and the sun was strong, so we stopped, gathered firewood, and relaxed for the afternoon. We slept sweet that night.
+---
+---
+date: '2010-03-03'
+start: Icewater Spring Shelter
+destination: Pecks Corner Shelter
+miles_today: 8.0
+trip_miles: 231.3
+facts:
+  weather: High 22°F, low 16°F. Moderate snow.
+  trail_section: Trail section from Icewater Spring Shelter to Pecks Corner Shelter.
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+---
+# Wednesday, March 03, 2010 — Pecks Corner Shelter
+**Start Location:** Icewater Spring Shelter
+**Miles Today:** 8
+**Trip Miles:** 231.30
+
+The next day was an 8 mile hump to Deck shelter in terrible conditions. It snowed all day and the sun buried in gray clouds. The trail disappeared and we had to blaze through 2 and 3 foot drifts that were often sloped so steeply as to collapse into mini-avalanches that would overcome a mouse. Kevin slid down the mountain some 30 feet, and I had to throw him a linie to drag his pck out. It was 45 minute ordeal. That night we arrived at almost 10pm. It was another long day in the Smokies. That night I punctured my blow-up thermarest, spilled my dinner all over the ground and broke Kevin’s spoon. I was angry.
+---
+---
+date: '2010-03-04'
+start: Pecks Corner Shelter
+destination: Cosby Knob Shelter
+miles_today: 14.0
+trip_miles: 245.3
+facts:
+  weather: High 29°F, low 18°F. Slight snow.
+  trail_section: Trail section from Pecks Corner Shelter to Cosby Knob Shelter.
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+---
+# Thursday, March 04, 2010 — Cosby Knob Shelter
+**Start Location:** Pecks Corner Shelter
+**Miles Today:** 14
+**Trip Miles:** 245.30
+
+The next day we covered 14 miles to the Crosby Knob shelter, a 10 hour hike. Another difficult day. I could get used to this cold, wet snow hiking, but it would be a miserable existence. Like a caveman. Today we blazed trail again, showshoeing through virgin drifts. At Crosby Knob, I found a cigar and smoked it after dinner and drank hot chocolate. Not a bad night. Actually, quite a pleasant one. I’ll never forget the simple pleasure of hot chocolate on a cold night and the glow of the cigar in the pitch black.
+---
+---
+date: '2010-03-05'
+start: Cosby Knob Shelter
+destination: Standing Bear Farm Hostel
+miles_today: 10.0
+trip_miles: 255.3
+facts:
+  weather: High 30°F, low 18°F. Clear sky.
+  trail_section: Trail section from Cosby Knob Shelter to Standing Bear Farm Hostel.
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+---
+# Friday, March 05, 2010 — Standing Bear Farm Hostel
+**Start Location:** Cosby Knob Shelter
+**Miles Today:** 10
+**Trip Miles:** 255.30
+
+|     |
+| --- |
+| [![](https://www.trailjournals.com/images/photos/journals/10467/tj10467_032710_190106_517655.jpg)](https://www.trailjournals.com/journal/photos/10467/517655/301896) |
+
+Getting out of that sleeping bag in the cold is the hardest part of the day. Every morning I lie in my “womb” for as long as I can, trying to convince myself that I’ll make it to my next destination on time, even if I lie just a little longer. That morning was one of those mornings. The sun was high and schedule tight by the time I was out of the bag and on my feet.
+
+The day’s destination was the Standing Bear Farm Hostel, several miles out of the Smokies. The last push wasn’t bad, moving slowly but with momentum, up and over the last mountain. I blazed with snowshoes and Kevin followed. We ran into four Spring Break hikers from Roanoke College – Casey-Lynn, Erin, Cary and Alex Ali (from Godwin!) – coming in the opposite direction. I burst out in excitement, “Oye!” and asiled them with questions and marvels of the trail. A friendly bunch they were, and matched my enthusiasm. They were astounded to run into a veritable thru-hiker, as I’ve been so many times before, and I felt for a moment that my undertaking was indeed greater than myself, that in the eyes of the world, this was a real-life epic, and it was all steered by little ol’ me. And I won’t feign humility here; it sure does feel like it sometimes. They gave us carrots, Kashi bars, and one delicious apple (thanks guys! You’re Angels!) to quiet our grumbling stomachs and hugs to sate a month dry of human contact.
+
+The snow cleared up and we stripped off our snowshoes. Down the hill we ran, yipping and hollering. At last, our feet were free from snow and shoe for the first time in three burdened days-and the liberty was exhilarating. The sun broke through the clouds and illuminated the snow. The sky was blue. I laughed to myself and almost cried: How can it be that the sky opens so easily? How can things be okay again so quickly? One thing I’ve learned in the past month is to expect that of life. When it goes way down it’s okay because it’ll surface again. It gets so bad out here-the snow, the ice, wind, the debris- but I’ve slowly come to know that it’s okay. “Just hang on,” I tell myself. “It’ll be better soon.” When I get home I’ll remember that, because some years ago my mother looked at me hard and said “things are great now, but they won’t be forever”. So when things do go bad I’ll remember the Smokies and all that snow. It’s gets better at the bottom of the hill.
+
+I lay in the sun and took a nap. Lou, from Kentucky, woke me up. He was passing on to the next shelter to “get away and read a little bit.” He had turned back from the trailhead near Gatlinburg, through which I was proud to say we’d fought, successfully. We shook hands and moved on. I arrived at Standing Bear in the afternoon and met Curtis, the owner. Curtis is rough-looking hippie with tough hands and a ponytail. “F\* off, we’re full!” he said with a cigarette in his mouth when I rounded the corner. I laughed and sat on the porch. That night we sat by the wood stove, ate Mom’s banana bread and drank a 24 oz. Heiniken. No hot showers. Oh well.
+---
+---
+date: '2010-03-06'
+start: Standing Bear Farm Hostel
+destination: Groundhog Creek Shelter
+miles_today: 8.0
+trip_miles: 263.3
+facts:
+  trail_section: Trail section from Standing Bear Farm Hostel to Groundhog Creek Shelter.
+  confidence: low
+---
+# Saturday, March 06, 2010 — Groundhog Creek Shelter
+**Start Location:** Standing Bear Farm Hostel
+**Miles Today:** 8
+**Trip Miles:** 263.30
+
+|     |
+| --- |
+| [![](https://www.trailjournals.com/images/photos/journals/10467/tj10467_032710_190106_517656.jpg)](https://www.trailjournals.com/journal/photos/10467/517656/301897) |
+
+When you really don't want to hit the trail, it seems time slips by quicker. This morning we woke late (at least for us) and lay silent in our sleeping bags until nearly 9:30. It had been a late night in the hostel bunkhouse as Kevin, myself, and Hawk the caretaker built homemade alcohol stoves until past 1am to the sound of hard rock radio and in the heat of the bunkhouse's wood stove. With Hawk's recycled metal, I built two new experimental stoves. In case you didn't know, reader, alcohol stoves are made with beer cans and cheap scrap metals. Using the alcohol in your medicine cabinet as fuel, you can boil a pot of water in five minutes. A cool, lightweight and easy-to-make outdoor gear. I bought a 24 oz. Heineken can, drank the contents and built a replacement piece for my old stove. By the time I hit the sack, I was exhausted.
+
+I ate like a lion today, almost uncontrollably. The trail mix, granola, and whole grain couscous was all so good. I was just so hungry. It made me feel full, sleepy and comfortable like I hadn't felt since relaxing at home a month ago.
+
+Curtis, the owner, gave us a tour of the old tobacco farm. I saw a foot-thick American Chestnut tree, which excited me. Curtis was a nice guy, a burned-out yet shrewd hippie with a ponytail and more than an ounce of simmering ambition. He ranted about his farm's potential in a niche organic tobacco market; "Right now, all I farm is hikers. And rocks. That's a figue speech, you know." Whenever he made a joke he paused to clarify with that same phrase: "It's a figure of speech," even when it wasn't a figure of speech. He showed me a sheet of fresna lense, which, used like a magnifying glass on ants, could "melt a penny in a minute". Indeed, in a couple seconds it burned my hand. Curtis laughed.
+
+I sent off some journal entries and at 3:45 we were on the road again towards Maine. The hike wore me out. I was blazing again. We caught a magnificent sunset ontop of the Snowbird Mountain bald. Layered in red and velvet, the Smokies stood solemnly like a blue and white fortress wall. It was the most beautiful I've ever seen. I was pissed about the tough climb. Had Kevin not been there to hold me up and remind me of the beauty, I'd of moped right on down the mountain, counting my curses. I didn't really think about God then, as some of you readers would have hoped. I just thought about how everything fits nicely in the end, and how this sunset was some kind of redemption from the painful two weeks in the Smokies we'd just left behind.
+
+The last stretch of the hike was mild. Kevin led with his headlamp, which I call the "Eye of God" for its brightness. We chatted to pass the time. That night Kevin extinguished an all-too-audacious mouse with the sharp end of his trekking pole and we ate chocolate bars.
+---
+---
+date: '2010-03-07'
+start: Groundhog Creek Shelter
+destination: Roaring Fork Shelter
+miles_today: 11.5
+trip_miles: 274.8
+facts:
+  weather: High 44°F, low 23°F. Overcast.
+  trail_section: Trail section from Groundhog Creek Shelter to Roaring Fork Shelter.
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+---
+# Sunday, March 07, 2010 — Roaring Fork Shelter
+**Start Location:** Groundhog Creek Shelter
+**Miles Today:** 11.50
+**Trip Miles:** 274.80
+
+"Dude, I just don't care anymore," I told Kevin several hours into the next day. He sort of laughed. "Neither do I, man. I've thought more about quitting today than I ever did in the Smokies." It was true. We'd covered over 250 miles and broke past our most formidable challenge, the Great Smoky Mountains, a climax in itself. But the trail felt empty post-climactic void. There was nothing really to look forward to now. No dramatic punctuations. Just dull and difficult miles, and 2,000 miles of them.
+
+That morning had been another late start. We just couldn't move on with any intention or speed. I was angry at Kevin for something stupid and left before him. On the mountain my toes went numb and dangerously close to frostbite. I groaned and groaned at the pain. I finally pulled over, took off my shoes and socks, and heated up my feet over the stove until my feet stopped hurting. The feeling was vaguely there, but the frostbite pain (which is like someone bending your toes backwards) was gone. Kevin walked up and sat down. We cooked a hot meal in the middle of the trail and moved along. (I learned later that I'd sustained more frostbite on my big toe, but the skin was protected by thick toe-pad callus. Writing 2 days later, it's still totally numb on both toes).
+
+At Max Patch, an amazing bald so large that airplanes used to land on it, we found some dayhikers and talked to them as the sun set. Then it was on to Roaring Fork Shelter, where we found two more overnighters to share the lean-to. “People! Kevin, people! Are you excited? I’m excited.” He was. This was the first night with company. After almost a month of occupying shelters with just Kevin, seeing a light through the woods beyond the “SHELTER” sign brought me to a yip and a yell. In fact, all the human contact that day filled me up; the shelter company was just icing on the cake.
+
+Yeah, we were weary coming out of the Smokies, but we’d moved on that day hoping for a little inspiration. Mr. Boyer said I’d empty out for a long time before the Lord would fill me back up. So maybe that’s what’s happening now. I do not fear it. It’s no fun, but I do not fear it.
+---
+---
+date: '2010-03-08'
+start: Roaring Fork Shelter
+destination: Deer Park Shelter
+miles_today: 15.0
+trip_miles: 289.8
+facts:
+  weather: High 48°F, low 25°F. Overcast.
+  trail_section: Trail section from Roaring Fork Shelter to Deer Park Shelter.
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+---
+# Monday, March 08, 2010 — Deer Park Shelter
+**Start Location:** Roaring Fork Shelter
+**Miles Today:** 15
+**Trip Miles:** 289.80
+
+A great day.
+---
+---
+date: '2010-03-09'
+start: Deer Park Shelter
+destination: A cabin (Hot Springs, NC)
+miles_today: 3.2
+trip_miles: 293.0
+facts:
+  weather: High 67°F, low 34°F. Overcast.
+  trail_section: Trail section from Deer Park Shelter to A cabin (Hot Springs, NC).
+  town_events: Hot Springs Town & Trail Festival
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+  - https://appalachiantrail.org/event/hot-springs-town-trail-2026/
+---
+# Tuesday, March 09, 2010 — A cabin (Hot Springs, NC)
+**Start Location:** Deer Park Shelter
+**Miles Today:** 3.20
+**Trip Miles:** 293
+
+Many nights, I open my eyes in confusion. I awake from deep dreams of home, so it sickens the stomach when one realizes he's far from it. Sadly, that hard floor below and black shelter ceiling above mean one thing: I'm on the A.T. The disappoinment is alawys deep. Early this morning I awoke in Hot Springs, lying under soft bed covers in a heated cabin, and it hit me. Opening my eyes was deeply disappointing. The dream wasn't of home (actually, it was of NASCAR races in the Outer Banks, NC), but it was so warm and fuzzy. It wasn't along the A.T. where, deep down, I don't want to be. That's right: I don't want to be here
+
+That "Live in the present" B.S. only works for 10-second bursts available 3 to 5 times a day. The rest of the day sucks, and one can either spend time not thinking (i.e. approaching mental fluidity and Zen) or thinking (i.e. consciously cursing each bump on the trail). I move back and forth between both.
+
+So even though I was riding the gravy train in Hot Springs, I still didn't want to be there. I wanted to be home. As for the day's schedule, there's not much to say. Eating heartily between each event, we relaxed, showered, hot tubbed, and slept. The best part of the day? Plunging into the icy Frech Broad River from the cozy hot springs.
+
+So to all you faithful readers who say to yourselves, "DOESN'T WANT TO BE THERE?! IS HE CRAZY? HE'S LIVING THE DREAM!", remember that, no matter how uncomfortable I am, I'm following Truth and that's all I need. "Following truth" sounds cheesy and over-inflated, but honestly that's the only reason I'm here. That is what's binding me to The Trail.
+
+P.S. Sorry about the sporadic entries. My faithful mother is serving as secretary and transcribing the journal pages I'm mailing from trail towns. Using a computer like I am now is an exception.
+---
+---
+date: '2010-03-11'
+start: A cabin (Hot Springs, NC)
+destination: Spring Mountain Shelter
+miles_today: 11.0
+trip_miles: 304.0
+facts:
+  weather: High 55°F, low 42°F. Dense drizzle.
+  trail_section: Trail section from A cabin (Hot Springs, NC) to Spring Mountain Shelter.
+  town_events: Hot Springs Town & Trail Festival - Appalachian Trail Conservancy
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+  - https://appalachiantrail.org/event/hot-springs-town-trail-2026/
+---
+# Thursday, March 11, 2010 — Spring Mountain Shelter
+**Start Location:** A cabin (Hot Springs, NC)
+**Miles Today:** 11
+**Trip Miles:** 304
+
+March 11
+
+The vortex. That’s what the lady at the outfitter called it. I’m not familiar with the vortex but I’ve felt its presence especially as Kevin and I debated on whether or not to move on today. When your feet stop moving the pull of the vortex begins, they say. First it’s an extra day of rest, then it’s a week, then you’ve given up. But it wasn’t like that for us. We just needed another day of rest, and, writing a day later, I’m glad we kicked up our feet another day. No regrets. I’m all alone now, sitting in a diner at 6:45am. It’s warm outside and rain is coming. I’m as happy as I could be to be one country breakfast away from hitting the trail again.
+
+A man behind with suspenders and a white beard rambled on to every local who comes in the door. “Johnny, d’you remember when the bank got robbed?” he says to Johnny, who pays for a to-go cup of coffee. The old bearded man tells the story just as he did to the last passerby. Johnny tries to go. “Darn it, Johnny, sit down here and let’s talk,” gripes the old man. After 20-some minutes the conversation goes to corporal punishment, “You know that’s what’s a matter with kids these days. Hell, I’ll come over there and whip ‘em myself!” Then stories are exchanged.
+
+The day's hike was not a bad one, but climbing back into the mountains from Hot Springs made me question why I was moving on in the first place. The old-timer's rambling 9-5 routine was so appealing. Rain broke, and I reached the shelter feeling miserable and cursing under my breath. But, as always, I got in my sleeping bag and everything was alright.
+---
+---
+date: '2010-03-12'
+start: Spring Mountain Shelter
+destination: Jerry Cabin Shelter
+miles_today: 15.4
+trip_miles: 319.4
+facts:
+  weather: High 60°F, low 43°F. Slight rain.
+  trail_section: Trail section from Spring Mountain Shelter to Jerry Cabin Shelter.
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+---
+# Friday, March 12, 2010 — Jerry Cabin Shelter
+**Start Location:** Spring Mountain Shelter
+**Miles Today:** 15.40
+**Trip Miles:** 319.40
+
+Today ended with seven hikers, lined like sardines in a shelter with the rain pattering on the roof. I wished I was alone, but oh well. The day had been a good one – almost 16 miles – and clear enough to keep me in bright spirits. It rained on and off and I was always wet, but the air was balmy and wind low and I stayed lkay the whole day. I won’t go into the boring details because to everyone except me they’re just that: boring.
+
+So at the shelter we met some kids from Appalachian State, including two pretty girls. It was nice being around some pretty girls. They gave us a full loaf of home-risen bread. In the morning, I hiked alone in the sunshine and had a revelation about the “remember how tough you are” bit of advice. Nobody’s ever a coward or a wimp, they just don’t remember how tough they are. And when you’re a Christian, it’s not remembering how tough He is.
+
+I got up in the dark of the night. The rain was really coming down in heaves and everyone was asleep. Someone snored nightly. I looked out in the gloomy woods, just a mess of dark gray and black. It was all so beautiful, and I wondered if this was God romancing me, you know? I lit a pipe and watched the embers glow and die and glow and die, not knowing what the silence of the night meant, but knowing it meant something.
+---
+---
+date: '2010-03-13'
+start: Jerry Cabin Shelter
+destination: Hogback Ridge Shelter
+miles_today: 14.7
+trip_miles: 334.1
+facts:
+  weather: High 47°F, low 36°F. Moderate rain.
+  trail_section: Trail section from Jerry Cabin Shelter to Hogback Ridge Shelter.
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+---
+# Saturday, March 13, 2010 — Hogback Ridge Shelter
+**Start Location:** Jerry Cabin Shelter
+**Miles Today:** 14.70
+**Trip Miles:** 334.10
+
+Another beautiful day, and hopes were high as I crossed mile 300. I was leading the pack, the second northbound thru-hiker of the worse-weathered season in recent memory, and I felt strong and confident. Three hundred miles of ups and downs and here I am: on the bright side. We made it to our shelter before nightfall, and found 2 beers, 7 sodas floating in the icy cold pool by the spring. Our first encounter with premeditated trail magic! I used ear plugs that night for Rooster’s snoring. I’m starting to write strange things in the trail registers. Yesterday, I wrote that monkeys stole all our food. Tonight I wrote that watch-selling gypsies showed up at 3am.
+---
+---
+date: '2010-03-14'
+start: Hogback Ridge Shelter
+destination: No Business Knob Shelter
+miles_today: 20.7
+trip_miles: 354.8
+facts:
+  weather: High 43°F, low 32°F. Moderate drizzle.
+  trail_section: Trail section from Hogback Ridge Shelter to No Business Knob Shelter.
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+---
+# Sunday, March 14, 2010 — No Business Knob Shelter
+**Start Location:** Hogback Ridge Shelter
+**Miles Today:** 20.70
+**Trip Miles:** 354.80
+
+And I thought we were in the clear. The morning opened with an inch of still-falling snow on the ground, and we were off with moderate spirits, and I was feeling alright, in the zone. But approaching the top of Big Bald, the trail simply disappeared. The snow was knee-deep by now. Two experienced college kids had given up searching the day before and set up an emergency shelter. A 20-something couple had done the same. Both groups headed back down the mountain, but we didn't have the luxury of turning back. We took a photo of a contour map and kept trudging on. The trail – or lack there of – was hell, and we wandered the woods, completely lost. Finally, we found some cross country ski tracks and followed them to the shelter. I don’t feel like recounting those last 10 miles, but I got lost a couple more times for 30 minutes, broke my trekking pole against a tree in anger, and arrived to camp in the pitch black of night. Deep snow, bad downfalls, a numb-toed nap in a hollowed-out tree. Twenty-one miles and a long, long day. But we made it, and all’s well that ends well.
+---
+---
+date: '2010-03-15'
+start: No Business Knob Shelter
+destination: Curley Maple Gap Shelter
+miles_today: 10.5
+trip_miles: 365.3
+facts:
+  weather: High 44°F, low 37°F. Moderate drizzle.
+  trail_section: Trail section from No Business Knob Shelter to Curley Maple Gap Shelter.
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+---
+# Monday, March 15, 2010 — Curley Maple Gap Shelter
+**Start Location:** No Business Knob Shelter
+**Miles Today:** 10.50
+**Trip Miles:** 365.30
+
+All-You-Can-Eat pizza took the place of breakfast, lunch, and dinner today. We sat in Erwin’s Pizza Plus for several hours, eating pizza after pizza and drinking Mountain Dew. It was incredible. It made my day. We’d trotted 6 miles into town that morning to resupply and left to the next shelter late that afternoon. I bought fuel, 7 snickers bars, 7 oatmenal packets, lemondade mix, 2 ramens, and mixed two varieties of trail mix – nuts, raisins and baking chocolates & pinapple, mangoes, cranberries and nuts. Enough for 3 days of strenuous hiking. We also did a load of detergentless laundry at the coin laundry. Rooster, the kindhearted Arizonan we’d picked up in the Springs, decided to quit. “It wasn’t what I thought it’d be, man. Not like last year.” I’ll miss him and the way he calmed the room. Oh well. We got to the shelter that night in the dark. I smoked my pipe, drank hot tea, and whished I was alone. The other guys just wouldn’t stop talking loudly. An interesting thought: Toe Man said that when he’s hiking alone he knows exactly where he is , but when he’s with company he doesn’t really know what’s going on. He relies on others to lead him. Life is like that , he said. I agree. Things are so clear alone.
+---
+---
+date: '2010-03-16'
+start: Curley Maple Gap Shelter
+destination: Clyde Smith Shelter
+miles_today: 22.0
+trip_miles: 387.3
+facts:
+  weather: High 42°F, low 30°F. Light drizzle.
+  trail_section: Trail section from Curley Maple Gap Shelter to Clyde Smith Shelter.
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+---
+# Tuesday, March 16, 2010 — Clyde Smith Shelter
+**Start Location:** Curley Maple Gap Shelter
+**Miles Today:** 22
+**Trip Miles:** 387.30
+
+Robin said that (even though we are out of the Smokies) challenges lay ahead. Yesterday I army-crawled over Unaka Mountain, and I realized how right she was. Unaka was buried with 3 feet of snow, and on the way up we ran into a Citadel grad, 3 months shy of deployment to Iraq. He said he’d been on the mountain for three days, trying unsuccessfully to push through the snow and downfall with his GPS. He’d lost the trail. "Want us to lead you over?," Toe Man asked. "We're not turning back." In a couple hours, we broke through the mess. “What does that say about the U.S. Military?” Toe Man joked.   Every soul we’ve encountered has been in escape of the mountain, retreating with head hung low. That days hike carried over into night. Even with my headlamp, all was murky as thick fog rolled in. I was ahead, and when I got to the shelter I sat out in the dark to smoke my pipe. No headlamp; just my pipe, the dark and I.
+---
+---
+date: '2010-03-17'
+start: Clyde Smith Shelter
+destination: A cabin (near Overmountain Shelter?)
+miles_today: 13.1
+trip_miles: 400.4
+facts:
+  weather: High 49°F, low 37°F. Light drizzle.
+  trail_section: Trail section from Clyde Smith Shelter to A cabin (near Overmountain
+    Shelter?).
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+---
+# Wednesday, March 17, 2010 — A cabin (near Overmountain Shelter?)
+**Start Location:** Clyde Smith Shelter
+**Miles Today:** 13.10
+**Trip Miles:** 400.40
+
+|     |
+| --- |
+| [![](https://www.trailjournals.com/images/photos/journals/10467/tj10467_032710_190106_517666.jpg)](https://www.trailjournals.com/journal/photos/10467/517666/302273) |
+
+You never really know who to trust when asking about the trail ahead. Everyone has his or her standards of assessment, so when Joe at the trailhead looks wearily at me and says, “Turn back man. It’s impossible.” The trail may in fact be quite the opposite. It may be an easy day. So whenever someone tells me it’s impossible, I size ‘em up. What are they wearing? Do they sound frantic? How long were they at it? And did they use the work “impossible”? Because if they did, they are not to be trusted. Down in Erwin, the outfitter told us (in crude language) that Roan Mountain would be extremely difficult, that we should wait for better weather. Well, we made it over Roan today defying the outfitter’s forecast of failure and surprising the critics once again. It was hard, but not as hard as he said. Off the mountain I was soaked with snow, sweat, and ice-melt. I met aaron, a warmhearted man on his way down from a day-hike. He was full of love. Or maybe it was joy. Aaron: if you read this, thanks for brightening my life. You radiate, man. I caught a “God Bless” when we parted ways and I think it may have something to do with it.
+
+Next we climbed several balds, open grassy expanses that took me back to scenes from Braveheart. Lone Scots running along highland ridges with bagpipes in the background. The bagpipes played on as we walked with 360 degree panoramic views.
+
+Off the balds we lost the trail. We ended up following a old logging road to the bottom of the vally. In the dark, we spotted a dimly lit mansion and approached. Upon knocking we met Jim Morton, who gave us directions back to the trail but offered us a night in one of his five cabins on the property. We couldn’t believe our good fortune, and I fell asleep that night on a soft bed. Trail magic, once again.
+---
+---
+date: '2010-03-18'
+start: A cabin (near Overmountain Shelter?)
+destination: Mountain Harbour Hostel (Elk Park, TN)
+miles_today: 9.0
+trip_miles: 409.4
+facts:
+  weather: High 60°F, low 40°F. Overcast.
+  trail_section: Trail section from A cabin (near Overmountain Shelter?) to Mountain
+    Harbour Hostel (Elk Park, TN).
+  town_events: 'Appalachian Trail Conservancy: Home'
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+  - https://appalachiantrail.org/
+---
+# Thursday, March 18, 2010 — Mountain Harbour Hostel (Elk Park, TN)
+**Start Location:** A cabin (near Overmountain Shelter?)
+**Miles Today:** 9
+**Trip Miles:** 409.40
+
+I was all out of food, so the next day’s journey was a hungry one. We crossed two 5,500 foot balks and descended down to Elk Park, TN over the course of 9 miles. I got ahead of Toe Man and Kevin and, at the road, hitchhiked in to town to pick up my maildrop. I was ecstatic to be away from the fellas. They were really starting to get on my nerves, and I felt the rush of freedom as I sat at the hostel and slit open the maildrop box with my knife. Or maybe that was just the rush of seeing a zip-lock bag of homemade cookies! I took a shower, stoked the wood stove, ate cookies, and walked around the living room if the hostel, not really sure what to do with myself. Free time? For all the vagrant conceptions of thru-hikers, we’re actually a busy bunch. Free time is a treat.
+---
+---
+date: '2010-03-19'
+start: Mountain Harbour Hostel (Elk Park, TN)
+destination: Moreland Gap Shelter
+miles_today: 16.7
+trip_miles: 426.1
+facts:
+  weather: High 57°F, low 34°F. Mainly clear.
+  trail_section: Trail section from Mountain Harbour Hostel (Elk Park, TN) to Moreland
+    Gap Shelter.
+  town_events: 'Erwin, TN to US 19 E. at Elk Park, NC : r/AppalachianTrail - Reddit'
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+  - https://www.reddit.com/r/AppalachianTrail/comments/1plxo5/the_appalachian_trail_in_30_days_530_erwin_tn_to/
+---
+# Friday, March 19, 2010 — Moreland Gap Shelter
+**Start Location:** Mountain Harbour Hostel (Elk Park, TN)
+**Miles Today:** 16.70
+**Trip Miles:** 426.10
+
+I passed a “mile 400” sign today in a ravine, and I kept on walking, wondering how I made it this far. I thought back to the second day, when I felt like things couldn’t get any worse, and I wonder what bizarre force pushed me on. Was it will? Stubborness? Faith? Or something other than that?
+
+Tonight is the most quiet night of the walk so far. It’s like a glassy lake fogged with darkness. I’m alone tonight again and glad for it. “Make it stop”. I kept saying aloud on the way here. It wad dark and my feet were at their limit, pounding with a pain I just couldn’t numb my mind to. My feet were not happy, and every step was a reminder of 400 miles of walking, these were the most painful of all. I did something I’ve never done before, right then: I asked God for strength. I didn’t really know what else to do. I wasn’t angry or emotional like before – I shed neither rage nor tears – but just tired of my feet hurting. And my prayer worked like a good medicine. In a couple of minutes, a second wind picked me up and carried me to the shelter.
+
+Like I said, that night was quiet like a cathedral. You could feel it all around you, that still and open space that afforded the lonely hiker with a sense of safety in the night.
+---
+---
+date: '2010-03-20'
+start: Holiday Inn Express (Abingdon, VA)
+destination: Kincora (Dennis Cove, TN)
+miles_today: 6.0
+trip_miles: 432.1
+facts:
+  trail_section: Trail section from Holiday Inn Express (Abingdon, VA) to Kincora
+    (Dennis Cove, TN).
+  town_events: Hiking Laurel Falls from Hampton trailhead - Facebook
+  confidence: low
+  sources:
+  - https://www.facebook.com/groups/tennesseehiking/posts/783378817687401/
+---
+# Saturday, March 20, 2010 — Kincora (Dennis Cove, TN)
+**Start Location:** Holiday Inn Express (Abingdon, VA)
+**Miles Today:** 6
+**Trip Miles:** 432.10
+
+I think if Jesus was around, he’d sit down and talk wit you about your favorite thing, no matter how boring it was. He’d pretend to be interested while the NASCAR fan talked his ear off about why Dale Jarret should be in the Hall of Fame. He’d ask questions, too, and pretend to be excited with you. “Wait, he won the Daytona how many times?!?!” There aren’t enough people like Jesus around to encourage us to spout off our passions, so we begin to believe that those passions aren’t worth being passionate about. I try to jump in like Jesus would, but I forget most days. I mean, it’s exhausting.
+
+Today I went to church with Bob Peoples, owner of the Kincora Hostel, and after the service he invited me to a dinner. It was all old folks, but I sat with a girl my age who wants to open a quilt shop. She was a really nice girl. After the dinner, I sat around and chatted while Bob helped clean up with the other men. “They wanna do their part so I understand,” said the woman who prepared the dinner, “but it’d be quicker if they just let me do it. They don’t know where anything goes.” Her husband came out to catch his breath ,and started talking to me about his German Shepard. Nobody was really listening to him as he went on, so I stepped up and played Jesus. “It’s only two years and weighs 105 lbs.!?!? Does she eat a lot?” And doing that for him, really validating his passion, filled me up.
+
+The woman was overweight and had short-hair and was the kind I would have passed on the street with a judgemental eye. But she sprang to life as I talked to her about her work with the church and state as a counselor psychologist. She was full of love, like we all should be. She mentioned her five kids. “It sounds like you’re a mother to more than five,” I said.
+
+Back at the hostel I talked with five students from Grinnell College, and it hit me how sociable JMU kids are by comparison. JMU kids know the art of communication and pride themselves in being exceptionally agreeable citizens. Kids from smaller, private liberal arts schools tend to communicate awkwardly and choose not to shake hands and smile. So it seems, at least.
+---
+---
+date: '2010-03-21'
+start: Kincora (Dennis Cove, TN)
+destination: Kincora (Dennis Cove, TN)
+miles_today: 0.0
+trip_miles: 432.1
+facts:
+  trail_section: Trail section from Kincora (Dennis Cove, TN) to Kincora (Dennis Cove,
+    TN).
+  town_events: 10.1 mile Appalachian Trail hike from Dennis Cove to ...
+  confidence: low
+  sources:
+  - https://www.facebook.com/groups/theweekendadventurer/posts/1389047798518663/
+---
+# Sunday, March 21, 2010 — Kincora (Dennis Cove, TN)
+**Start Location:** Kincora (Dennis Cove, TN)
+**Miles Today:** 0
+**Trip Miles:** 432.10
+
+I took a “zero” day today to rest my feet. I don’t really have blister problems; it’s my bone structure and foot pads that hurt so badly. In a word, my feet just feel bruised. The whole situation doesn’t irritate me too much, but I am disappointed to be wasting away this beautiful weather. I wish I just felt good. I could really start complaining here but I’ll save my time. Can’t wait to be back on the trail tomorrow but fearing my feet.
+---
+---
+date: '2010-03-24'
+start: Double Spring Shelter
+destination: The Place (Damascus, VA)
+miles_today: 18.0
+trip_miles: 450.1
+facts:
+  weather: High 65°F, low 36°F. Overcast.
+  trail_section: Trail section from Double Spring Shelter to The Place (Damascus,
+    VA).
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+---
+# Wednesday, March 24, 2010 — The Place (Damascus, VA)
+**Start Location:** Double Spring Shelter
+**Miles Today:** 18
+**Trip Miles:** 450.10
+
+|     |
+| --- |
+| [![](https://www.trailjournals.com/images/photos/journals/10467/tj10467_032710_190106_517674.jpg)](https://www.trailjournals.com/journal/photos/10467/517674/301902) |
+
+Yesterday was another day split by dull pain and bright moments of joy. I ate some cold oatmeal (it's better cold, I beleive) and left Double Spring Shelter at 9:36. According to Tony, it was "surely" no more than 8 miles to Damascus, a section he claimed was "the easiest section on the Trail." Not true. I cursed him under my breath the whole way for being so sure about something he obviously knew nothing about. Before long I was at the gap and soon after that Abingdon Shelter. There, I cooked (and ate) too much couscous and fell asleep with my feet propped up to reduce swelling. I woke nearly an hour later from deep sleep. My head felt fresh but my feet hurt badly. The march down to Damascus was a difficult one, but I was there by 5:00. At The Place, an unattended $5-donation hostel run by the Methodist Church, I ate too many candy bars (a bag of them, left as Trail Magic in the hostel). I left to grab a bacon cheesburger, Mountain Dew, and an ice cream bar. Then, an old-timer invited me back to his house for teriyaki chicken. I obliged. His name was Larry, and he's got a wild story. He escaped the law and hid in the woods for 3 years, until he had a spiritual revelation and turned himself in. He did time and came out somewhat reformed. Since, Damascus has taken him in and he's taken to helping hikers. Now, Larry lives with his dog and cat. He stands in front of a warehouse and sells yard-sale things. That night, I ate more candy bars and fell asleep.
+---
+---
+date: '2010-03-25'
+start: The Place (Damascus, VA)
+destination: The Place (Damascus, VA)
+miles_today: 0.0
+trip_miles: 450.1
+facts:
+  weather: High 62°F, low 42°F. Moderate drizzle.
+  trail_section: Trail section from The Place (Damascus, VA) to The Place (Damascus,
+    VA).
+  town_events: Appalachian Trail Days Festival - Visit Damascus
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+  - https://visitdamascus.org/traildays/
+---
+# Thursday, March 25, 2010 — The Place (Damascus, VA)
+**Start Location:** The Place (Damascus, VA)
+**Miles Today:** 0
+**Trip Miles:** 450.10
+
+My zero day in Damascus has little to say. I was supposed to walk over to Larry's to buy some eggs and turn his garden, but instead I ate dougnuts and walked over to Mount Rogers Outfitters to try on some insoles. My feet were killing me. Jeff, the large, kindhearted foot expert there, fitted me for some Superfeet insoles and said it would solve my problems. It took him a half hour to explain the foot-mechanics behind my pain, and I appreciated every minute of it. It's not often you run across someone who really knows what they're talking about. I met up with Lucky, a SOBO, and another section hiker. We power-walked a mile or so to a Pizza Plus (all-you-can-eat pizza), then waddled like penquins back to the hostel. I took a nap then walked over to Joe's Gym, and I paid him $5 for a MMA lesson. We practiced kickboxing kicks, boxing drills, ju-jitsu holds, and muy thai clinches. Afterwards I lifted weights. Shaking up the routine like that it sometimes all a hiker needs. Hanging out with Joe freshened my spirits. That night we went to Quincy's Bar & Grill and I had a Star Hill IPA and a grilled cheese. It was live music night, and we listened to some suprisingly-talented locals sing, strum the guitar, and play the harmonica. "In Color" was my favorite cover they performed. Everyone at the bar was singing along. The other hikers watched the March Madness game and I watched the locals interact. The Place was cold and had only dirty towels (yea, I may have used one or two) and hardwood beds, so it was just a step up from the shelter. Still, I slept alright.
+---
+---
+date: '2010-03-26'
+start: The Place (Damascus, VA)
+destination: Augusta's Appalachian Inn (Damascus, VA)
+miles_today: 18.0
+trip_miles: 468.1
+facts:
+  weather: High 52°F, low 42°F. Dense drizzle.
+  trail_section: Trail section from The Place (Damascus, VA) to Augusta's Appalachian
+    Inn (Damascus, VA).
+  town_events: Appalachian Trail Days Festival
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+  - https://visitdamascus.org/traildays/
+---
+# Friday, March 26, 2010 — Augusta's Appalachian Inn (Damascus, VA)
+**Start Location:** The Place (Damascus, VA)
+**Miles Today:** 18
+**Trip Miles:** 468.10
+
+|     |
+| --- |
+| [![](https://www.trailjournals.com/images/photos/journals/10467/tj10467_032710_190106_517675.jpg)](https://www.trailjournals.com/journal/photos/10467/517675/302260) |
+
+Today my dad came! I woke up early and walked across the street to Augusta's Appalachian Inn. I'd met Terry and Sissy on their front porch of their B&B the day I entered town, so I recommended the place to my dad. down the street/AT for a diner for a breakfast of pancakes, bacon and egg. From there I hit the trail for an 18-mile day hike (I'd hitch back to Damascus that afternoon to meet my dad). I was anxious to get some more miles under my belt.
+
+A mile down the trail, I realized that I forgot the pay for my breakfast. But I disappeared into the woods and told myself I'd pay when I got back to town. It was raining and I was soaked shortly, which was uncomfortable. I wore only Terry's daypack, so I was able to trail run off and on. My feet hurt.
+
+For you history buffs, the trail was a cool one. It ran along the Virginia Creeper Trail, an old railroad used to export valuable timber from the region. Thanks to the Creeper, named for the "creeping" slow speeds of the trains, acres of old-growth poplar and hemlock forests were leveled and Damascus experienced a economic boom. The lumber boom died, the rail went to public transportation, and by the 1980's the state stripped the ties and closed the line. In it's place, they layed out the Virginia Creeper Scenic Trail. It is open for pedestrian, equestrian, and bicycle traffic. Between the trail and the rail flowed the Laurel River, a fairly-wide river popular for trout angling. The whole day, I could hear the dull roar of the river rapids.
+
+By 2:30 I was at U.S. Highway 58 (1.5 mi N of Lost Mountain Shelter), where I was to meet my Dad in the parking lot at 5:00 PM. Too cold to wait, I thumbed a ride. The pick-up took my several miles down the road, but I found myself again on the side of the road, sticking out my thumb in the rain-turned-snow. It was cold.
+
+After over 2 hours of thumbing unsuccessfully (I hated Mankind at this point), I saw Terry coming down the road in his new 4-door pick-up. It had been a cold and shivering wait, and I was too exhausted to be excited about this stroke up good fortune (\*you see, my Dad had called in bad traffic and asked for Terry to come pick me up). I got back to the B&B, drank hot coffee, and took a shower before my Dad arrived. I got out of the showever and stopped: was that my Dad's voice downstairs? It was, and something ticked and I suddenly felt so safe. Yea, Pops was downstairs, and it was good.
+
+That night we went out for burgers at Quincy's and met "Full Moon," our waiter and three-time 1,000-miler that worked also at the bike shop next store. We asked about biking the Virginia Creeper Trail tomorrow, and he gave us the low-down. We asked about the Tavern, a fancy restaurant in Abingdon, and he gave us the low-down. The chef came out and talked to us about the menu; the the scznitzel, he said, the scznitzel.
+We drank some beers and walked back to Augusta's and sorted out my food. All I can say is that reunited with my Dad was one of the most amazing things I've yet experienced on the Trail. We went to bed around midnight.
+---
+---
+date: '2010-03-27'
+start: Augusta's Appalachian Inn (Damascus, VA)
+destination: Holiday Inn Express (Abingdon, VA)
+miles_today: 0.0
+trip_miles: 468.1
+facts:
+  weather: High 58°F, low 31°F. Partly cloudy.
+  trail_section: Trail section from Augusta's Appalachian Inn (Damascus, VA) to Holiday
+    Inn Express (Abingdon, VA).
+  town_events: Abingdon, VA - Appalachian Trail Conservancy
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+  - https://appalachiantrail.org/protect/conservation/at-community-program/abingdon-va/
+---
+# Saturday, March 27, 2010 — Holiday Inn Express (Abingdon, VA)
+**Start Location:** Augusta's Appalachian Inn (Damascus, VA)
+**Miles Today:** 0
+**Trip Miles:** 468.10
+
+What a weekend with Ford. I guess you can call me a "Guest" writer for Ford (Uncle Frank). After a great day in Damascus conquering the grueling downhill Creeper trail on bikes, we headed over to Abingdon to see the town and get a steak dinner before Ford hits the trail again. Abingdon is a very cool town that is home to The Tavern where Ford and I got the VERY best steak that I have had in memory. I don’t know if it was the self imposed fast that Ford and I were on in preparation for our dinner or the company but we both agreed that steak dinners like that don’t come frequently enough. After we gorged ourselves we lay back in our chairs, starred at each other and reminisced of great steak dinners of our time. We agreed that we must do better about keep track of great steak dinners and that more were surly to come. I also reminded Ford that a great lobster, not yet in the boat awaited him in Maine. Ford is a big topic with Ford nowadays and I don’t mind doing my part to make sure he gets his share of gastronomical events while in Virginia.
+I put him back on the trail today. Rested I hope. The rain began to fall as Ford got his gear together put it on his back and slipped into his poncho. I was amazed at how fast he got his gear together and reminisced at the time when he was a scout when it took hours to leave the car for an overnight and he was ready and on the trail in 5 minutes for a week. After a hug and some encouraging words before he disappeared into the wet leaves of the Rhododendrons of the Appalachian Trail.
+As I made my way back to Richmond, I thought about how much I wished I could be on the trail with Ford and what an amazing journey he is on. To be with him this weekend gave me some insight into his journey. It’s complicated but very simple. It seems like by being on the trail alone most of time, when you get to a small town like Damascus or Abingdon, connecting with people becomes a big part of the experience. No one does this with more enthusiasm than Ford. I am so proud to say I am Ford’s Dad.
+---
+---
+date: '2010-03-28'
+start: U.S. 58
+destination: Wise Shelter
+miles_today: 20.0
+trip_miles: 488.1
+facts:
+  weather: High 52°F, low 36°F. Slight rain.
+  trail_section: Trail section from U.S. 58 to Wise Shelter.
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+---
+# Sunday, March 28, 2010 — Wise Shelter
+**Start Location:** U.S. 58
+**Miles Today:** 20
+**Trip Miles:** 488.10
+
+Hey Everybodies! I'm losing steam documenting every detail of every day, so I'm just going to do a High-and-Low format to cut down on the tedium and simplify things a bit. Here it goes...
+
+Highs: My first high was meeting up and picking the brain of Eric, a 7-time PCT (and 2-time AT) ultra-light thru-hiker with a 6 lbs. pack. Eric is 39 and works at a brewery out West to save money for his next thru-hike, and I asked him question after question about how he accomplishes a thru-hike. What do you eat? How often do you drink? Do you take ibuprofen? Why the umbrella?
+
+My second high was hiking on Whitetop Mountain in 100 mph winds (100 according to Eric). Crossing the bald, that mighty wind blew OFF his poncho and knocked me down twice. I just screamed with excitement, "Wooooooooo-hoo-hoo-hoo!". It was a blast. Eric said he'd never seen winds that high. "And it cost zero dollars and zero cents!", I said. Eric liked to trail run and I struggled to keep up.
+
+Lows: Saying "Bye Dad" sucked. He dropped me at the trailhead and we both went our separate ways and I told myself, "Just keep walking. It'll all be fine. Just keep walking." I tried to be jolly but I felt so alone.
+---
+---
+date: '2010-03-29'
+start: Wise Shelter
+destination: Trimpi Shelter
+miles_today: 20.0
+trip_miles: 508.1
+facts:
+  weather: High 48°F, low 37°F. Slight rain.
+  trail_section: Trail section from Wise Shelter to Trimpi Shelter.
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+---
+# Monday, March 29, 2010 — Trimpi Shelter
+**Start Location:** Wise Shelter
+**Miles Today:** 20
+**Trip Miles:** 508.10
+
+Highs: Seeing a young owl flap curiously around me. His flap was loud and awkward, and needed practice. That was at dusk, after I'd spent almost an hour trail running down to Trimpi Shelter. When I got to the shelter, two old fellas awaited me with a hot fire, and I dried my socks and boots.
+
+Lows: It rained alot that morning/afternoon, and for a couple hours I sat in the shelter not wanting to move on into the rain. Getting started sucked. Another low was wandering with numb barefeet around Trimpi Shelter looking for firewood.
+---
+---
+date: '2010-03-30'
+start: Trimpi Shelter
+destination: north of Atkins
+miles_today: 27.0
+trip_miles: 535.1
+facts:
+  trail_section: Trail section from Trimpi Shelter to north of Atkins.
+  confidence: low
+---
+# Tuesday, March 30, 2010 — north of Atkins
+**Start Location:** Trimpi Shelter
+**Miles Today:** 27
+**Trip Miles:** 535.10
+
+Highs: Eating at a shelter after a morning of hunger, napping in the sun, smelling the pines. Also, I met Joe, a 2-time record-breaker for speed-hiking the PCT. He was also ultra-light. Joe was stocky with tattooed arms (not your typical long-distance hiker build). I hiked with him until near Atkins and picked his brain. "You'll be a different person when you get back," he promised me. "Something will change." At such a young age, he said I'd probably end up hiking the PCT next year. "Twenty-one? It's good you're getting into this stuff \[long-distance hiking\] so early," he said. He was in his 40's.
+
+Another high was leaving Joe to trail-run to Atkins, down the mountains and into the pastureland. At the bog, the grass was lush and green, and I saw purplish-green jar plants. At Atkins, I ate veggies and picked up a maildrop at the Barnyard Restaurant and set off at sunset for some night hiking. I hiked until nearly 10:30 under a full moon. At the top of the mountain, I pulled off and layed out my sleeping bag under the moon. I toothed open a bottle of Dead Guy Ale and drank it, staring dazed at the moon. Everything was gray silver or hidden in moon-shadow. A full moon is an amazing thing.
+
+Lows: None! Maybe a little foot pain in the beginning, but nothing qualifying as a low.
+---
+---
+date: '2010-03-31'
+start: north of Atkins
+destination: Jenkins Shelter
+miles_today: 30.0
+trip_miles: 565.1
+facts:
+  weather: High 66°F, low 37°F. Overcast.
+  trail_section: Trail section from north of Atkins to Jenkins Shelter.
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+---
+# Wednesday, March 31, 2010 — Jenkins Shelter
+**Start Location:** north of Atkins
+**Miles Today:** 30
+**Trip Miles:** 565.10
+
+Highs: Joe caught up with me mid-day, and covering ground with him was probably my high of the day. I asked him questions and let him talk. Also, getting up at sunrise on the mountaintop was a gratifying experience. Lastly, a tough 4-mile climb with Joe culminated at Chestnut Nob, a beautiful 270-degree view of the surrounding mountains. You could really see the hand of geology from the ridge, the pushed the mountains together into wrinkles and smoothed them over.
+
+Lows: Eating too much cous-cous at lunch always sucks. I was burping it up all the way up Chestnut Nob. Good energy, I guess. The last bit of night-hiking sucked. I was just impatient and ready to call it a day, but I pushed on.
+---
+---
+date: '2010-04-01'
+start: Jenkins Shelter
+destination: Jenny's Knob Shelter
+miles_today: 23.8
+trip_miles: 588.9
+facts:
+  weather: High 78°F, low 42°F. Overcast.
+  trail_section: Trail section from Jenkins Shelter to Jenny's Knob Shelter.
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+---
+# Thursday, April 01, 2010 — Jenny's Knob Shelter
+**Start Location:** Jenkins Shelter
+**Miles Today:** 23.80
+**Trip Miles:** 588.90
+
+Highs: My highest point of the day, I think, was deciding to make 9 miles in 3 hours and DOING IT, despite uphill terrain and sore feet. I just pushed and pushed, invigorated by cool night air and a big bag of walnuts, almonds, and cranberries (my power food, I think). I also enjoyed lounging by the river for what seemed like all afternoon. Lastly, finding Storm Crow in the shelter that night was a pleasant surprise. He gave me some trail mix because I was hungry from hiking and all out of food. I got to hear Storm Crow talk about his hobby: medieval battle. Since his 20's he's been dressing as a "3rd to 4th Century Germanic warrior" and battling against other characters with dull weapons. It's called Live Action Warfare (LAW) or something like that, and well-dressed Americans trade their collared shirts and slacks for a full medieval suit of armor and a weapon to match. All fighting styles gather in field and forest for an eclectic battle of epic proportions, and afterwards they brew up a massive pot of stew and drink punch. Storm Crow was knocked unconscious once, he said, by a blow dealt by the catan of a Japanese Samurai, and brought him into his tent afterwards for a drink \[That's right, he owns a authentic medievel tent\]. In the heat of battle, if you're hit in the arm you can't use it anymore. Hit in the leg? You've got to hop. The chest or neck? You're dead. It all sounded pretty awesome. Wesley, Sean and I have dealt full blows before with wooden shafts in our lacrosse pads, but doing it with practice and precision sounds awesome. Not to mention charging into enemy lines with 500 fellow warriors.
+
+Lows: Eating all my food, though relaxing, makes me feel like crap. I do it anyway out of an incontrollable hunger instinct, and it does give me fuel for afternoon hiking. But that was my low of the day. Also, the first 5 miles was painful on my feet.
+---
+---
+date: '2010-04-02'
+start: Jenny's Knob Shelter
+destination: Woods Hole Hostel
+miles_today: 21.0
+trip_miles: 609.9
+facts:
+  trail_section: Trail section from Jenny's Knob Shelter to Woods Hole Hostel.
+  confidence: low
+---
+# Friday, April 02, 2010 — Woods Hole Hostel
+**Start Location:** Jenny's Knob Shelter
+**Miles Today:** 21
+**Trip Miles:** 609.90
+
+The highs included eating and lounging outside a convenience store after a morning of aching hunger. I had 2 slices of pizza, 2 gatorades, a candybar, and a bag of nuts. A stray puppy kept wandering out of an old barn and barking at me. I'd ignore him and he'd tip-toe back into the barn. Local lumbermill workers on lunch-break sat quietly at a picnic table nearby. I layed over and fell asleep. Storm Crow walked up shortly after with a 6-pack of Yuengling. He called for a shuttle to the Woods Hole Hostel, and he drank and talked about 4 "pretty recent" hiker murders in the area.
+I set off from there into the Dismal Creek lowlands, a labrytnh of creeks and rhododenron where the murders took place. The murderer had known the area well, and had taken back passages to sneak around the hikers and ambush them and escape afterwards. I was paranoid, and kept hearing sounds of ATVs or pickups through the woods. Or maybe it was just the creek. I was sweating heavily and took a bath in the stream, feeling like someone was watching me.
+Several miles later, I realized I'd left my map at the creek where I bathed. The map had all my scheduled stops starred, so I imagined the killer following my tracks and pciking up the map with a sick grin. Up the trail I stopped at Watipi Shelter, where some guy shot cans with a pellet gun and showed off his knife and machete. The other fellow there was named "Know-Nothing", because he didn't want to know anything new on the trail. I ate and moved on to Woods Hole Shelter.
+The sun set and my headlight flicked on. I was paranoid still as I approached Sugar Run Road, where the killer had crashed his car in escape. My light was dim and rocks difficult to hike on. I extinguished my light near the road and approached under the cover of darkness. Keep in mind, this road was a totally isolated forest road. At the clearing, my map lay on the ground. That's right: my lost map 10 miles ahead, right on the trail. The killer! He'd found my map, and taken a back road ahead of me! My heart stopped. he must be watching me. It was a half-mile down the road to Woods Hole Hostel, so I snatched the map and took of running. Immediatly, I saw a car parked facing towards me, lights off. This was it. He was waiting in the car for me. Instinctually, I darted to the left and charged the car with my hiking poles out to stab. But the car was empty. Still on edge, I took off running again down the road. Headlights beamed around the bend, so flicked off my light and crashed down into a ravine. The car drove by. I remounted the road and took off running again. Soon I saw lights and ran up to the hostel. A bonfire was burning and hikers gathered around it. I was sweating and out of breath. My feet pounded. Someone brought me a beer and sat down. In a minute, the car came back down and pulled into the driveway. The owner got out. She'd come up to fetch me from the trailhead, and I apologized. "I'd of dived off the road too!," he said. BY the way, that beer was a high of the day.
+---
+---
+date: '2010-04-03'
+start: Woods Hole Hostel
+destination: A cabin (Pearisburg, VA)
+miles_today: 10.0
+trip_miles: 619.9
+facts:
+  weather: High 77°F, low 57°F. Overcast.
+  trail_section: Trail section from Woods Hole Hostel to A cabin (Pearisburg, VA).
+  town_events: Pearisburg, VA - Appalachian Trail Conservancy
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+  - https://appalachiantrail.org/protect/conservation/at-community-program/pearisburg-va/
+---
+# Saturday, April 03, 2010 — A cabin (Pearisburg, VA)
+**Start Location:** Woods Hole Hostel
+**Miles Today:** 10
+**Trip Miles:** 619.90
+
+Highs: Seeing my FAMILY! They met me on the trail down from Angel's Rest, the lookout above Pearisburg. From up the trail, I heard their voices down below. That was the high of my day. I ran down full tilt, crashing with a sweaty hug into my little sister. We laughed and yipped. Then I ran down to my mother and tried not to cry with joy. I didn't understand why I wanted to cry, but then again I don't really understand alot about myself. I hugged my Dad, and we all sat down for lunch on the trail. I was ontop of the world.
+
+Later that night we played memory with Dawson, Corey and Morgan, had an awesome conversation about grandparents over my Mom's spaghetti dinner, and watched everyone go to bed. I stayed up to sort out food and pack. The soft bed that night was awesome.
+
+Lows: Everything up to meeting my family on the trail sucked. My feet pounded with pain and I groaned aloud. I tried to be happy becuase my family was waiting ahead, but I just couldn't muster up a smile. I imagined seeing them and saying, "Hold on guys, I just need to keep hiking and get this over with," then hiking on to the bottom. It was very painful. Also, having to divy up my next week's provisions that night sucked, because it was a stressful task that ate of precious time with my family.
+---
+---
+date: '2010-04-04'
+start: A cabin (Pearisburg, VA)
+destination: Rendezevous Motel (Pearisburg, VA)
+miles_today: 0.0
+trip_miles: 619.9
+facts:
+  weather: High 73°F, low 49°F. Overcast.
+  trail_section: Trail section from A cabin (Pearisburg, VA) to Rendezevous Motel
+    (Pearisburg, VA).
+  town_events: Pearisburg, VA - Appalachian Trail Conservancy
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+  - https://appalachiantrail.org/protect/conservation/at-community-program/pearisburg-va/
+---
+# Sunday, April 04, 2010 — Rendezevous Motel (Pearisburg, VA)
+**Start Location:** A cabin (Pearisburg, VA)
+**Miles Today:** 0
+**Trip Miles:** 619.90
+
+Highs: My mother and I woke up early and we hung out together in the cabin kitchen. I love that time with my Mom. She made a huge breakfast of pancakes, eggs and bacon. We packed up and left the cabin and drove into Pearisburg to do some shopping. My Dad and I did a small section of hiking and my Mom and sister staked out a cool spot for lunch. We all went to the New River boat landing and lunched by the river under the bridge. It was cool there in the shade with a light breeze. It was like heaven. Everything I wanted in life was there, it seemed, sitting by the river. We threw skipped rocks and talked about nothing at all. I wish I was back there right now.
+
+Lows: Saying goodbye at the motel sucked. It ached my heart like leaving Springer all over again, and there was nothing I could do about it. That's a funny feeling, waving off the car and closing the motel door on something you desire with all your heart. It ached like love lost. I turned on the TV to take my mind off it all, and flicked to a murder scene in a horror flick. That unsettled me even more. That night sucked.
+---
+---
+date: '2010-04-05'
+start: Rendezevous Motel (Pearisburg, VA)
+destination: Bailey Gap Shelter
+miles_today: 23.2
+trip_miles: 643.1
+facts:
+  weather: High 77°F, low 50°F. Light drizzle.
+  trail_section: Trail section from Rendezevous Motel (Pearisburg, VA) to Bailey Gap
+    Shelter.
+  town_events: Pearisburg, VA
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+  - https://appalachiantrail.org/protect/conservation/at-community-program/pearisburg-va/
+---
+# Monday, April 05, 2010 — Bailey Gap Shelter
+**Start Location:** Rendezevous Motel (Pearisburg, VA)
+**Miles Today:** 23.20
+**Trip Miles:** 643.10
+
+Highs: My high was hiking in a crazy thunderstorm that night. The lightening exploded over my head in the darkness, thunder matching flash. The air smelled rich and metallic, which exhilerated me. After coving 20-some miles, it was a invigorating ending to a painful day. I got lost and heard voices as the storm cleared, so I called out, "HELLO!". I saw flashlights ahead. The shelter! "Is that Uncle Frank?," said a voice. It was TwoCan, the guy who had given me the beer at Woods Hole. Another high was sleeping at the shelter on the sunny bald and dreaming of home.
+
+Lows: I left the motel and called my Mother, which made me feel like crap. I missed home so much and didn't know what to do. The first half of the day was painful inside and out.
+---
+---
+date: '2010-04-06'
+start: Bailey Gap Shelter
+destination: Niday Shelter
+miles_today: 26.2
+trip_miles: 669.3
+facts:
+  weather: High 83°F, low 55°F. Overcast.
+  trail_section: Trail section from Bailey Gap Shelter to Niday Shelter.
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+---
+# Tuesday, April 06, 2010 — Niday Shelter
+**Start Location:** Bailey Gap Shelter
+**Miles Today:** 26.20
+**Trip Miles:** 669.30
+
+Toggle navigation[Trail Journals](https://www.trailjournals.com/)
+
+- [Journals](https://www.trailjournals.com/journal/entry/304005#)  - [Journals](https://www.trailjournals.com/journals)
+  - [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail/2026)
+  - [Pacific Crest Trail](https://www.trailjournals.com/journals/pacific_crest_trail/2026)
+  - [Colorado Trail](https://www.trailjournals.com/journals/colorado_trail/2026)
+  - [Continental Divide Trail](https://www.trailjournals.com/journals/continental_divide_trail/2026)
+  - [Long Trail - Vermont](https://www.trailjournals.com/journals/the_long_trail_-_vermont/2026)
+  - [Florida Trail](https://www.trailjournals.com/journals/the_florida_trail/2026)
+  - [Arizona Trail](https://www.trailjournals.com/journals/arizona_trail/2026)
+  - [John Muir Trail](https://www.trailjournals.com/journals/john_muir_trail/2026)
+  - [Camino de Santiago](https://www.trailjournals.com/journals/camino_de_santiago/2026)
+  - [American Discovery Trail](https://www.trailjournals.com/journals/american_discovery_trail/2026)
+  - [Coast to Coast Walk](https://www.trailjournals.com/journals/coast_to_coast_walk/2026)
+  - [More...](https://www.trailjournals.com/journals/)
+- [Trails](https://www.trailjournals.com/trails/)
+- [Photos](https://www.trailjournals.com/photos/2026)
+- [Gear](https://www.trailjournals.com/journal/entry/304005#)  - [Current Sales](https://www.trailjournals.com/gear/deals/onsale)
+  - [REI](https://www.trailjournals.com/gear/rei)
+  - [ULA](https://www.trailjournals.com/gear/ula)
+  - [Patagonia](https://www.trailjournals.com/gear/patagonia)
+  - [Cabela's](https://www.trailjournals.com/gear/cabela)
+- [Planning](https://www.trailjournals.com/journal/entry/304005#)  - [Plan Your Hike](https://www.trailjournals.com/planning/)
+  - [Gear](https://www.trailjournals.com/gear/)
+  - [Books](https://www.trailjournals.com/books/)
+  - [Links](https://www.trailjournals.com/links/)
+- [Search](https://www.trailjournals.com/search/)
+- [About](https://www.trailjournals.com/journal/entry/304005#)  - [About Trailjournals](https://www.trailjournals.com/about/)
+  - [Login](https://www.trailjournals.com/user/login)
+  - [Join](https://www.trailjournals.com/join)
+  - [Support Trailjournals](https://www.trailjournals.com/about/donate/)
+  - [Contact](https://www.trailjournals.com/about/contact)
+  - [Store](https://www.trailjournals.com/store/)
+
+Backpacking Journals and Photos from Long Distance Hikers
+
+1. [Home](https://www.trailjournals.com/)
+2. [Journals](https://www.trailjournals.com/journals)
+3. [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail)
+4. [2010](https://www.trailjournals.com/journals/appalachian_trail/2010)
+5. [Uncle Frank](https://www.trailjournals.com/journal/10467)
+6. [Entries](https://www.trailjournals.com/journal/entries/10467/uncle%20-frank)
+7. April 06, 2010
+
+Toggle navigation
+
+- [Journal](https://www.trailjournals.com/journal/10467)
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+- [My Journals](https://www.trailjournals.com/myjournals/10467)
+- [View Guest Book](https://www.trailjournals.com/journal/guestbook/10467)
+- [Sign Guest Book](https://www.trailjournals.com/journal/guestbook/sign/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/5a.gif)![](https://www.trailjournals.com/images/9a.gif)
+
+[Journal](https://www.trailjournals.com/journal/10467)
+
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+
+--Choose--01/21/1002/06/1002/07/1002/08/1002/09/1002/10/1002/11/1002/12/1002/13/1002/14/1002/15/1002/16/1002/17/1002/18/1002/19/1002/20/1002/21/1002/22/1002/23/1002/24/1002/25/1002/26/1002/27/1002/28/1003/01/1003/02/1003/03/1003/04/1003/05/1003/06/1003/07/1003/08/1003/09/1003/11/1003/12/1003/13/1003/14/1003/15/1003/16/1003/17/1003/18/1003/19/1003/20/1003/21/1003/24/1003/25/1003/26/1003/27/1003/28/1003/29/1003/30/1003/31/1004/01/1004/02/1004/03/1004/04/1004/05/1004/06/1004/07/1004/08/1004/09/1004/10/1004/11/1004/12/1004/13/1004/14/1004/15/1004/16/1004/17/1004/18/1004/19/1004/20/1004/21/1004/23/1004/24/1004/25/1004/26/1004/27/1004/28/1004/29/1004/30/1005/01/1005/02/1005/03/1005/04/1005/05/1005/06/1005/07/1005/08/1005/09/1005/10/1005/11/1005/12/1005/13/1005/14/1005/15/1005/16/1005/17/1005/18/1005/19/1005/20/1005/21/1005/22/1005/23/1005/24/1005/25/1005/26/1005/27/1005/28/1005/29/1005/30/1005/31/1006/01/1006/02/1006/03/1006/04/1006/05/1006/06/1006/07/1006/08/1006/09/1006/10/1006/11/1006/12/1006/13/1006/14/1006/15/1006/16/1006/17/1006/18/1006/19/1006/20/1006/21/10
+
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+
+Guest Book
+
+- [Sign](https://www.trailjournals.com/journal/guestbook/sign/10467)
+- [View](https://www.trailjournals.com/journal/guestbook/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/5a.gif)![](https://www.trailjournals.com/images/9a.gif)
+
+- [AT Journals](https://www.trailjournals.com/journals/appalachian_trail)
+- [AT Photos](https://www.trailjournals.com/photos/appalachian_trail)
+- [AT Books](https://www.trailjournals.com/books/appalachian_trail)
+- [Appalachian Trail](http://www.appalachiantrail.org/)
+
+[Join](https://www.trailjournals.com/join) [Login](https://www.trailjournals.com/user/login)
+
+[RSS](https://www.trailjournals.com/journal/rss/10467/xml)
+
+# Uncle Frank's 2010  Appalachian Trail Journal
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/304004) [Next](https://www.trailjournals.com/journal/entry/304006) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+Tuesday, April 06, 2010
+
+Destination:Niday Shelter
+
+Today's Miles:26.20
+
+Start Location:Bailey Gap Shelter
+
+Trip Miles:669.30
+
+Destination:Niday Shelter
+
+Start Location:Bailey Gap Shelter
+
+Today's Miles:26.20
+
+Trip Miles:669.30
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/304004) [Next](https://www.trailjournals.com/journal/entry/304006) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+### Hiker Entries April 06, 2010
+
+|  | Journalist | Destination | Trail |
+| --- | --- | --- | --- |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Roche_13900TN.jpg) | [Roche](https://www.trailjournals.com/journal/about/13900) | [Beard Cane Campsite (#11)](https://www.trailjournals.com/journal/entry/385929) | [Other Trails](https://www.trailjournals.com/journals/Other%20_Trails) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2005Blucher_8775TN.jpg) | [Bob](https://www.trailjournals.com/journal/about/8775) | [Jenkins Shelter](https://www.trailjournals.com/journal/entry/367417) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [magic man](https://www.trailjournals.com/journal/about/12513) | [hawk mountain shelter](https://www.trailjournals.com/journal/entry/355996) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DidgeridudeandDoodlebug_9852TN.jpg) | [Didgeridude and Doodlebug](https://www.trailjournals.com/journal/about/9852) | [TriCorner Knob](https://www.trailjournals.com/journal/entry/334619) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2014Sundance_6768TN.jpg) | [Sundance](https://www.trailjournals.com/journal/about/6768) | [NOC](https://www.trailjournals.com/journal/entry/333397) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Dilly Dally & Cubbie](https://www.trailjournals.com/journal/about/10450) | [Tray Mtn. Shelter](https://www.trailjournals.com/journal/entry/324819) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Peru_10969TN.jpg) | [Peru](https://www.trailjournals.com/journal/about/10969) | [Hawk Mountain Shelter](https://www.trailjournals.com/journal/entry/317974) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Opus](https://www.trailjournals.com/journal/about/10015) | [Deep Gap shelter](https://www.trailjournals.com/journal/entry/314912) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Wilderness Bob](https://www.trailjournals.com/journal/about/10881) | [\-\- View Entry --](https://www.trailjournals.com/journal/entry/314749) | [Tahoe Rim Trail](https://www.trailjournals.com/journals/Tahoe%20_Rim%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2008Stickbuilt_7055TN.jpg) | [Stickbuilt](https://www.trailjournals.com/journal/about/7055) | [Maine](https://www.trailjournals.com/journal/entry/314276) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| [More...](https://www.trailjournals.com/entries/2010/04/06) [Grouped By Trail...](https://www.trailjournals.com/entries/2010/04/06/trail) |
+
+|     |
+| --- |
+| The last mile proved particularly arduous. The steepness of the descent was ridiculous. Picture one of those Hobbit movies with stairs at an angle that makes you wince just to look at them. Well, the director of those movies got his inspiration from this section of the AT.... <br>[Blazer](https://www.trailjournals.com/journal/entry/543948) —<br>[Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail) [2016](https://www.trailjournals.com/journals/appalachian_trail/2016) |
+
+[![Trailjournals](https://www.trailjournals.com/images/logo.png)](https://www.trailjournals.com/)
+
+#### Hiking
+
+- [Trails](https://www.trailjournals.com/trails/list)
+- [Journals](https://www.trailjournals.com/journals)
+- [Photos](https://www.trailjournals.com/photos)
+- [Calendar](https://www.trailjournals.com/calendar)
+- Gear
+- [Links](https://www.trailjournals.com/links)
+
+#### Partners
+
+- [ULA Equipment](https://ula-equipment.sjv.io/drN9K)
+- [REI](http://www.avantlink.com/click.php?tt=ml&ti=45265&pw=68025)
+- [Patagonia](http://www.avantlink.com/click.php?tt=ml&ti=45781&pw=68025)
+
+#### Network
+
+- [Trail Forums](http://www.trailforums.com/)
+- Trail News
+
+#### About Us
+
+- [Contact](https://www.trailjournals.com/about/contact)
+- [Donate](https://www.trailjournals.com/about/donate)
+- [Join](https://www.trailjournals.com/join)
+- [Login](https://www.trailjournals.com/user/login)
+- [Help](https://www.trailjournals.com/help)
+
+#### Follow Us
+
+- [Facebook](https://www.facebook.com/trailjournals)
+- [Instagram](https://instagram.com/trailjournals/)
+- [Twitter](https://twitter.com/trailjournals)
+- [Pinterest](https://www.pinterest.com/trailjournals/)
+- [Linkedin](https://www.linkedin.com/company/trailjournals-llc)
+
+Top Photo © Renee Patrick - Pacific Crest Trail,
+05/21/2006 by
+[She-ra](https://www.trailjournals.com/journal/2942)
+
+Trailjournals LLC © 2026
+All Rights Reserved. [privacy policy](https://www.trailjournals.com/about/privacy)
+
+Newburyport, MA 01950
+
+[Terms under which this service is provided to you.](https://www.trailjournals.com/about/privacy)
+
+Build: 20210226:165913 [Manage Settings](https://www.trailjournals.com/about/settings)
+---
+---
+date: '2010-04-07'
+start: Niday Shelter
+destination: Campbell Shelter
+miles_today: 27.1
+trip_miles: 696.4
+facts:
+  weather: High 82°F, low 54°F. Overcast.
+  trail_section: Trail section from Niday Shelter to Campbell Shelter.
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+---
+# Wednesday, April 07, 2010 — Campbell Shelter
+**Start Location:** Niday Shelter
+**Miles Today:** 27.10
+**Trip Miles:** 696.40
+
+High: Today's high was probably seeing a pretty girl on her way up to Dragon's Tooth, south of Catawba. She was with another VT student, a lean guy who would probably be good at ultimate frisbee. She, herself, was fit and strong, also probably good at frisbee. Both were really nice and kind of glowed, balanced in that they didn't give off any more light than they were willing to take in. I chatted with them for 5 maybe 10 minutes then moved on, but their fresh spirit stayed wit me. I had been feeling pretty low. As I descended I could see them on top of the Tooth. "Thank You." I wanted to yell. I moved along quietly. At the gap I walked down to the store to buy a can of Mountain Dew and a 25 cent pack of gum. Near dusk I moved on. I passed a girl in her late twenties by the creek. She'd stopped for the last night of her first camping trip ever, a five day trek. I admired her courage. Being out in the woods in scary, even for a seasoned hiker like myself. She said she wanted to hike the AT one day. I told her firmly that she could.
+Darkness wore on from there, by the creek, across the pasture and into the woods. I felt alright, alright enough to keep up a steady 3 mph pace. The next shelter was 8 miles away. I got to the road at 9:30. It was a usy road, loud and mean in the night. This area was a popular local hang-out, so already I was on edge. the random shootings along the Blue Ridge Parkway - I'd seen on the newspaper at the store - were fresh on my mind, adding to the tension. Just before crossing, I heard a sound in the woods by the road. It was louder than a deer and quicker than a bear, and immediately I decided it was a human. And not just a human: a crazed killer waited to murder night-hikers. I flicked off my flashlight and waited. The sound stopped. I took off running, across the road and back in to the woods. He's following me, I said to myself. He's gonna follow me to the next shelter. I hoofed quickly to the shelter a mile in , hoping to find it packed with hikers. It was empty. Dead quiet. I quickly moved on the next shelter, another mile in. I heard a single gunshot on the way: the killer had arrived at the first shelter to murder me and shot the wall in frustration when he found it empty. The next shelter was empty, too. On to the next shelter, 2.5 miles away. On the way, I heard another gunshot meaning the killer had arrived at the second shelter.
+At McAfee Knob, just before the third shelter, I could see Roanoke glowing, the valley like gold glittering on the ocean floor. An incredible view. I awaited an ambush from the killer, who'd taken the fire road and beat me to the top. At the third shelter, I found two kids sleeping in a tent and felt like I'd beat the killer. I was out of range. I ate some cold oatmeal and went to sleep. It was 12:15am.
+---
+---
+date: '2010-04-08'
+start: Campbell Shelter
+destination: Travelodge Motel (Daleville, VA)
+miles_today: 17.0
+trip_miles: 713.4
+facts:
+  weather: High 73°F, low 57°F. Slight rain.
+  trail_section: Trail section from Campbell Shelter to Travelodge Motel (Daleville,
+    VA).
+  town_events: 'Day 48: Arriving in Daleville, Redux'
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+  - https://thetrek.co/appalachian-trail/daleville-va/
+---
+# Thursday, April 08, 2010 — Travelodge Motel (Daleville, VA)
+**Start Location:** Campbell Shelter
+**Miles Today:** 17
+**Trip Miles:** 713.40
+
+Gnats buzzed in my hair when I awoke. It was only 6:45am, but with the sunrise came heat and bugs so I couldn't sleep. I talked with the kids in the tent as I packed up, and I was on the trail by 7:30. It was a hot, hot day, and my feet were in alot of pain. By the time I got to Lambert's Meadow Shelter, I was ready for a long break. I drank from the stream and washed my body, then took a long nap in the shelter shade. I soaked my shirt and bandana and drapped them over my chest and head, put on my long pants, and went to sleep bug-proofed. I woke up to a dad and his kids arriving from the north. They were two smart kids with a good strong dad who was trying to make them as strong as he. And he was doing a fine job. I told them I was out of food and he accused me of yogi-ing. I retorted, "If I was yogi-ing, I'd be alot smoother than that." What I meant to say was that if I'm yogi-ing I'd ask you straight up for food.
+Clouds covered the sun and I moved on at noon for Daleville, 9 miles away. the hike flew by and the hunger wasn't as bad as the foot pain. By the last mile, I was in so much pain. My four blisters were on fire and my foot pads bruised. I hobbled off the trail to a convenience store to buy a gatorade, then hobbled to the Outfitter to use the computer, then hobbled to the the Three Little Pigs BBQ for dinner. The meal was amazing - fried onion strips and buffalo chips with a big mound of both the tomato and vinegar BBQ and a 1/2 pint of Magic Hat Lager. The BEST meal since the steak with Dad, and the best BBQ ever. I hung at the Outfitter for almost four hours after, reading and writing and chatting with the manager, while rain pounded outside. My mom called their phone and we coordinated Dawson, Caleb and Michael's visit. It was still pouring rain at closing time, so I bribed a ride to the motel from the employee wit ha 6-pack of Miller Lite.
+That night I wrote and showered and ate three apples.
+---
+---
+date: '2010-04-09'
+start: Travelodge Motel (Daleville, VA)
+destination: Fullhardt Knob Shelter
+miles_today: 4.9
+trip_miles: 718.3
+facts:
+  weather: High 58°F, low 43°F. Moderate rain.
+  trail_section: Trail section from Travelodge Motel (Daleville, VA) to Fullhardt
+    Knob Shelter.
+  town_events: 'Day 48: Arriving in Daleville, Redux - The Trek'
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+  - https://thetrek.co/appalachian-trail/daleville-va/
+---
+# Friday, April 09, 2010 — Fullhardt Knob Shelter
+**Start Location:** Travelodge Motel (Daleville, VA)
+**Miles Today:** 4.90
+**Trip Miles:** 718.30
+
+High: An all-you-can-eat breakfast at Shoney's was up on the list, but I must say the high was seeing Caleb, Dawson, and Michael pull to a stop in front of the outfitter after waiting for them all day in Troutville. We all hugged and walked over for an expensive (yet totally worth-it) BBQ dinner at Three Little Pigs. We joked with the waitress and laughed at nothing in particular. It was a grand ol' time, and the adventure hadn't even really begun. It was 9:15 PM when we walked back out to the car and sorted out the gear for the hike under the lamplight. By 10:00 PM we were on the trail, a line of dim headlamps inching towards Fullhardt Knob Shelter.
+Caleb, Dawson and Michael were all sturdy hikers--sturdier than I expected, in fact--and we arrived in good time that night (by "good time" I mean 12:15 am). I bore Caleb's backpack, my rusty old Kelty external-frame from my Boy Scout days. It was loaded with 50+ lbs. of stuff, an entirely foreign level of stress to my feet. Bone structure clearly disturbed, I could feel them groaning in my tennis-shoes like an old ship in a storm. Just outside of Troutville, we cut off the headlamps and crossed a hilly pasture, big and black under a dim blue spread of starlit sky above.
+That night was Caleb and Dawson's first night in an A.T. shelter, which really excited me. It was late and I was tired. I was the first asleep.
+---
+---
+date: '2010-04-10'
+start: Fullhardt Knob Shelter
+destination: Cove Mountain Shelter
+miles_today: 20.0
+trip_miles: 738.3
+facts:
+  weather: High 66°F, low 38°F. Clear sky.
+  trail_section: Trail section from Fullhardt Knob Shelter to Cove Mountain Shelter.
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+---
+# Saturday, April 10, 2010 — Cove Mountain Shelter
+**Start Location:** Fullhardt Knob Shelter
+**Miles Today:** 20
+**Trip Miles:** 738.30
+
+We rose late the next morning, I repeating my eat-and-return-to-sleep cycle several times before actually rising. The others had no real schedule or "hiking routine", so we all just kind of took our time. We left the shelter by 11:15, passing Drip-Dry and Reveille who had hiked the 5 miles from town early that morning. We stopped at a waterfall and stream several miles down the trail. There, we all layed down for a long and sleepy break in the sun. I ate, Caleb and Dawson smoked a cigar, and Michael puffed on his pipe; we all slept. I was in bliss. I will never forget that long, warm hour by the stream.
+
+On we hiked, passing the Blue Ridge Parkway for the first time. Again, we stopped to eat and sleep in the sun. It was heaven. I was drifting off when I heard a voice: "Are yall thru-hikers?." I opened my eyes and looked back. A car was pulled up and a thin, scruffy kid hung out the passenger window. "I am," I said, "I'm Uncle Frank." As it turns out, it was Knee-Deep, another thru-hiker I'd heard a great deal about on the trail. He'd been a day or so behind me for months, he said, and was about to catch up. Today, however, he was spending on the parkway with his girlfriend. He said he'd plan to catch me in a couple of days, and I said I'd be looking forward to it. Off he drove. Off I went back to sleep.
+
+Near dusk we pulled off at a shelter for dinner, SWEET POTATOES! We made a roaring kindling fire and dumped the foil-wrapped 'taters in the coals. Fifty minutes later, we each had a piping hot meal in our hands. We ate and night grew. By 8:00, we were on the trail again. The climb was grueling, but by 10:30 we were at the next shelter. Again, I fell asleep quickly. Later that night, I awoke to the sound of Caleb throwing up. I got out of my bag, grabbed some trail mix, ate it, then went back to sleep. Caleb was still vomiting, yet I was surprisingly indifferent. To me, upchucking is a good thing.
+---
+---
+date: '2010-04-11'
+start: Cove Mountain Shelter
+destination: Thunder Hill Shelter
+miles_today: 17.2
+trip_miles: 755.5
+facts:
+  weather: High 71°F, low 38°F. Clear sky.
+  trail_section: Trail section from Cove Mountain Shelter to Thunder Hill Shelter.
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+---
+# Sunday, April 11, 2010 — Thunder Hill Shelter
+**Start Location:** Cove Mountain Shelter
+**Miles Today:** 17.20
+**Trip Miles:** 755.50
+
+I'll just do highs and lows today. The high was hiking with the boys down to the river. I really did love the company and I dreaded losing it, but there was nothing I could do as Caleb, Dawson and Michael drove off. That was the low. In fact, the rest of the day was low. I hiked slowly and indifferently, covering only 17-some miles and intermittently napping because it took my mind off my depression. It was just a hard day. Several highs, however: I saw a pretty wildflower bed along the trail, and I arrived at the shelter before dark. I thought about calling Haywood and telling him, "I know what you mean: M.A.I.D."
+---
+---
+date: '2010-04-12'
+start: Thunder Hill Shelter
+destination: Punchbowl Shelter
+miles_today: 25.1
+trip_miles: 780.6
+facts:
+  trail_section: Trail section from Thunder Hill Shelter to Punchbowl Shelter.
+  confidence: low
+---
+# Monday, April 12, 2010 — Punchbowl Shelter
+**Start Location:** Thunder Hill Shelter
+**Miles Today:** 25.10
+**Trip Miles:** 780.60
+
+I'd run out of food the day before and had 15 miles to cover to access my mail-drop in Glasgow, VA. My hunger wasn't too bad, neither hurting nor slowing me down noticeably. The trail was smooth and hot, and it reminded me of the trails out in New Mexico. I felt good. High up on the ridge, I spotted the James River, flowing mightily in the valley. I hollered in joy. Not only was it a symbol of home, it was the location of the road to Glasgow and thus a symbol of food. I called my Dad and we set up a mail-drop and talked about meeting up in Harper's Ferry. I missed him. Down into the valley the trees bloomed and leafed, making a tunnel of neon-green light. It was magnificent. The red-buds were blooming in their explosive purples and the maple leaves were glowing verdantly. I took photos of wildflowers and cool leaves. At the river, I was bubbly. I ran across the footbridge just as a freight train ran across on a nearby trestle. The sun poured down on the river. It was all so glorious. I yipped and hollered uncontrollably like a little kid.
+
+At the road I stuck out my thumb and an under-cover cop pulled over. "Hitchhiking is illegal anywhere in Virginia," he said. He background checked by ID and gave me a ride into town in the back of his souped-up Dodge Charger. I sat in the back where they put the criminals, fidgeting on hard plastic seats meant to tell them: You're screwed, and these seats are just the beginning. The cop was nice, and asked me question after question. At the store, I bought some chocolate milk and picked up my mail-drop, and the cop gave me a ride back to the trailhead.
+
+I hauled up the food 1.7 miles to a shelter, where I sat down for a gorge to remember. I chugged chocolate milk and consumed an entire loaf of homemade banana bread, then passed out for an hour. I awoke feeling great.
+
+I lounged at the shelter for at least an hour, until Knee-Deep came strolling down the trail. "Theerrreee he is," he said. "Now I can finally stop." He'd been hiking for 28 miles already that day in order to catch me, and after exchanging trail news and whatnot we both moved on 7 miles to the next shelter. The shelter is located near the site of an unexplained murder of 4 year-old Ottie Bundren in the 1890's, and it's apprently haunted. We left some chocolate by the gravestone where they found her body to pacify the ghost. I slept well that night.
+---
+---
+date: '2010-04-13'
+start: Punchbowl Shelter
+destination: Seely-Woodworth Shelter
+miles_today: 25.3
+trip_miles: 805.9
+facts:
+  trail_section: Trail section from Punchbowl Shelter to Seely-Woodworth Shelter.
+  confidence: low
+---
+# Tuesday, April 13, 2010 — Seely-Woodworth Shelter
+**Start Location:** Punchbowl Shelter
+**Miles Today:** 25.30
+**Trip Miles:** 805.90
+
+We left camp at sunrise, before 6:45 am. The first several hours of hiking were difficult. My feet hurt and morale was low, but being with Knee-Deep helped a lot. We talked most of the time, exchanging stories and sharing experiences. Then we'd go silent before resuming talk. Trail talk is a funny mode of communication. It's entirely aimless and self-centered, bouncing mindlessly from one subject to the next. For example:
+
+Knee-Deep: "I love dogs."
+
+Me: "Yea, I want to get a pit bull one day."
+
+Knee-Deep: "My Uncle has a pit bull. He has like ten Siamese cats, too"
+
+Me: "Oooo, my neighbors had some Siamese cats. They were awesome."
+
+And so on...
+
+Knee-Deep needed to resupply, so I waited on a picnic table in the sun while he hitched into town. I gave him $10 and asked him to get me "something meaty" at the Subway. He came back in 2 hours, I ate my sub, and we marched on. We passed Cold Mountain, my old stomping ground, and took in some awesome views. The views in Virginia have been like no other: I'm proud to call this state "home."
+At the shelter (it was dark by then), we found an older fellow sleeping with his two wily pit bulls. They growled at us but were a cute, innocent pair of pups. Someone had left a bag of food, so I ate three bags of oatmeal before falling asleep.
+---
+---
+date: '2010-04-14'
+start: Seely-Woodworth Shelter
+destination: Reed's Gap
+miles_today: 22.3
+trip_miles: 828.2
+facts:
+  trail_section: Trail section from Seely-Woodworth Shelter to Reed's Gap.
+  confidence: low
+---
+# Wednesday, April 14, 2010 — Reed's Gap
+**Start Location:** Seely-Woodworth Shelter
+**Miles Today:** 22.30
+**Trip Miles:** 828.20
+
+The next morning I was dragging painfully once again. We stopped in the fog for a climb to a view less Spy Rock, then made our way to The Priest Shelter. After the climb up Spy Rock I was feeling brighter. The fog was thick and soaked everything. At the shelter, we laughed at the trail register, where, going with the "Priest" theme, people had left all sorts of confessions (mostly about skipping miles and not paying at hostels). They were hilarious. From there, we dropped off the edge of The Priest into the valley below. There, the Tye River paralleled a highway, and we walked down the road to get chocolate and soda and hitched back. The climb up from the valley to Three Ridges wasn't as bad as we expected (we'd been dreading it all day). The views were spectacular on top. I took some amazing photos and was in high spirits.
+
+A side note: when I say "high spirits", I mean a sort of bursting joy that I scarcely find in civilization. It's a strange mix of physical exhaustion, emotional exhilaration, and mental consolidation. I'll miss that when this is all through.
+
+Knee-Deep and I had planned to stay at Rusty's Hard-Time Hollow, but we decided to move on to cowboy camp. There were plenty of awesome overlooks, and we hiked into the night for an hour before finding a great spot at Reed's Gap. It was a 360-degree view of the mountains and stars. We bedded down on the grass and fell asleep.
+P.S. Where's God been the last several weeks? I don't know...surely not loud like before.
+---
+---
+date: '2010-04-15'
+start: Reed's Gap
+destination: Wesley's frat house (Charlottesville, VA)
+miles_today: 28.0
+trip_miles: 856.2
+facts:
+  weather: High 71°F, low 34°F. Mainly clear.
+  trail_section: Trail section from Reed's Gap to Wesley's frat house (Charlottesville,
+    VA).
+  town_events: Events
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+  - https://appalachiantrail.org/events/
+---
+# Thursday, April 15, 2010 — Wesley's frat house (Charlottesville, VA)
+**Start Location:** Reed's Gap
+**Miles Today:** 28
+**Trip Miles:** 856.20
+
+As usual, getting started that day was hard. I always drag in the mornings. My right foot was killing me. Knee-Deep's snoring that night had kept my awake, so I was doubly tired as well. Also, I was hungry and out of food. Knee-Deep gave some to me, but my stomach was still grumbling. Those were all the lows.
+
+The highs were plenty, as I ended the day in C'ville. But first, running 8 miles before 4:45 was a rewarding yet painful event. That made my day. Wesley picked me up from there and took us (Knee-Deep hung back and we picked him up at I-64) out to dinner at the A.Y.C.E. dining hall, and I drank Legends Brown Ale and listened to the Avett Brothers that evening. There was a frat party, but I didn't feel like going. It was an awesome night.
+---
+---
+date: '2010-04-16'
+start: Wesley's frat house (Charlottesville, VA)
+destination: Pinefield Hut
+miles_today: 26.2
+trip_miles: 882.4
+facts:
+  weather: High 72°F, low 44°F. Overcast.
+  trail_section: Trail section from Wesley's frat house (Charlottesville, VA) to Pinefield
+    Hut.
+  town_events: 'The Virginia Creeper Trail: Then & Now'
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+  - https://appalachiantrail.org/event/the-virginia-creeper-trail-then-now/
+---
+# Friday, April 16, 2010 — Pinefield Hut
+**Start Location:** Wesley's frat house (Charlottesville, VA)
+**Miles Today:** 26.20
+**Trip Miles:** 882.40
+
+Toggle navigation[Trail Journals](https://www.trailjournals.com/)
+
+- [Journals](https://www.trailjournals.com/journal/entry/306438#)  - [Journals](https://www.trailjournals.com/journals)
+  - [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail/2026)
+  - [Pacific Crest Trail](https://www.trailjournals.com/journals/pacific_crest_trail/2026)
+  - [Colorado Trail](https://www.trailjournals.com/journals/colorado_trail/2026)
+  - [Continental Divide Trail](https://www.trailjournals.com/journals/continental_divide_trail/2026)
+  - [Long Trail - Vermont](https://www.trailjournals.com/journals/the_long_trail_-_vermont/2026)
+  - [Florida Trail](https://www.trailjournals.com/journals/the_florida_trail/2026)
+  - [Arizona Trail](https://www.trailjournals.com/journals/arizona_trail/2026)
+  - [John Muir Trail](https://www.trailjournals.com/journals/john_muir_trail/2026)
+  - [Camino de Santiago](https://www.trailjournals.com/journals/camino_de_santiago/2026)
+  - [American Discovery Trail](https://www.trailjournals.com/journals/american_discovery_trail/2026)
+  - [Coast to Coast Walk](https://www.trailjournals.com/journals/coast_to_coast_walk/2026)
+  - [More...](https://www.trailjournals.com/journals/)
+- [Trails](https://www.trailjournals.com/trails/)
+- [Photos](https://www.trailjournals.com/photos/2026)
+- [Gear](https://www.trailjournals.com/journal/entry/306438#)  - [Current Sales](https://www.trailjournals.com/gear/deals/onsale)
+  - [REI](https://www.trailjournals.com/gear/rei)
+  - [ULA](https://www.trailjournals.com/gear/ula)
+  - [Patagonia](https://www.trailjournals.com/gear/patagonia)
+  - [Cabela's](https://www.trailjournals.com/gear/cabela)
+- [Planning](https://www.trailjournals.com/journal/entry/306438#)  - [Plan Your Hike](https://www.trailjournals.com/planning/)
+  - [Gear](https://www.trailjournals.com/gear/)
+  - [Books](https://www.trailjournals.com/books/)
+  - [Links](https://www.trailjournals.com/links/)
+- [Search](https://www.trailjournals.com/search/)
+- [About](https://www.trailjournals.com/journal/entry/306438#)  - [About Trailjournals](https://www.trailjournals.com/about/)
+  - [Login](https://www.trailjournals.com/user/login)
+  - [Join](https://www.trailjournals.com/join)
+  - [Support Trailjournals](https://www.trailjournals.com/about/donate/)
+  - [Contact](https://www.trailjournals.com/about/contact)
+  - [Store](https://www.trailjournals.com/store/)
+
+Backpacking Journals and Photos from Long Distance Hikers
+
+1. [Home](https://www.trailjournals.com/)
+2. [Journals](https://www.trailjournals.com/journals)
+3. [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail)
+4. [2010](https://www.trailjournals.com/journals/appalachian_trail/2010)
+5. [Uncle Frank](https://www.trailjournals.com/journal/10467)
+6. [Entries](https://www.trailjournals.com/journal/entries/10467/uncle%20-frank)
+7. April 16, 2010
+
+Toggle navigation
+
+- [Journal](https://www.trailjournals.com/journal/10467)
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+- [My Journals](https://www.trailjournals.com/myjournals/10467)
+- [View Guest Book](https://www.trailjournals.com/journal/guestbook/10467)
+- [Sign Guest Book](https://www.trailjournals.com/journal/guestbook/sign/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/2a.gif)
+
+[Journal](https://www.trailjournals.com/journal/10467)
+
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+
+--Choose--01/21/1002/06/1002/07/1002/08/1002/09/1002/10/1002/11/1002/12/1002/13/1002/14/1002/15/1002/16/1002/17/1002/18/1002/19/1002/20/1002/21/1002/22/1002/23/1002/24/1002/25/1002/26/1002/27/1002/28/1003/01/1003/02/1003/03/1003/04/1003/05/1003/06/1003/07/1003/08/1003/09/1003/11/1003/12/1003/13/1003/14/1003/15/1003/16/1003/17/1003/18/1003/19/1003/20/1003/21/1003/24/1003/25/1003/26/1003/27/1003/28/1003/29/1003/30/1003/31/1004/01/1004/02/1004/03/1004/04/1004/05/1004/06/1004/07/1004/08/1004/09/1004/10/1004/11/1004/12/1004/13/1004/14/1004/15/1004/16/1004/17/1004/18/1004/19/1004/20/1004/21/1004/23/1004/24/1004/25/1004/26/1004/27/1004/28/1004/29/1004/30/1005/01/1005/02/1005/03/1005/04/1005/05/1005/06/1005/07/1005/08/1005/09/1005/10/1005/11/1005/12/1005/13/1005/14/1005/15/1005/16/1005/17/1005/18/1005/19/1005/20/1005/21/1005/22/1005/23/1005/24/1005/25/1005/26/1005/27/1005/28/1005/29/1005/30/1005/31/1006/01/1006/02/1006/03/1006/04/1006/05/1006/06/1006/07/1006/08/1006/09/1006/10/1006/11/1006/12/1006/13/1006/14/1006/15/1006/16/1006/17/1006/18/1006/19/1006/20/1006/21/10
+
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+
+Guest Book
+
+- [Sign](https://www.trailjournals.com/journal/guestbook/sign/10467)
+- [View](https://www.trailjournals.com/journal/guestbook/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/2a.gif)
+
+- [AT Journals](https://www.trailjournals.com/journals/appalachian_trail)
+- [AT Photos](https://www.trailjournals.com/photos/appalachian_trail)
+- [AT Books](https://www.trailjournals.com/books/appalachian_trail)
+- [Appalachian Trail](http://www.appalachiantrail.org/)
+
+[Join](https://www.trailjournals.com/join) [Login](https://www.trailjournals.com/user/login)
+
+[RSS](https://www.trailjournals.com/journal/rss/10467/xml)
+
+# Uncle Frank's 2010  Appalachian Trail Journal
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/305233) [Next](https://www.trailjournals.com/journal/entry/306439) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+Friday, April 16, 2010
+
+Destination:Pinefield Hut
+
+Today's Miles:26.20
+
+Start Location:Wesley's frat house (Charlottesville, VA)
+
+Trip Miles:882.40
+
+Destination:Pinefield Hut
+
+Start Location:Wesley's frat house (Charlottesville, VA)
+
+Today's Miles:26.20
+
+Trip Miles:882.40
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/305233) [Next](https://www.trailjournals.com/journal/entry/306439) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+### Hiker Entries April 16, 2010
+
+|  | Journalist | Destination | Trail |
+| --- | --- | --- | --- |
+|  | [magic man](https://www.trailjournals.com/journal/about/12513) | [nantahala outdoor center](https://www.trailjournals.com/journal/entry/361075) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DidgeridudeandDoodlebug_9852TN.jpg) | [Didgeridude and Doodlebug](https://www.trailjournals.com/journal/about/9852) | [Devil Fork Gap- Asheville](https://www.trailjournals.com/journal/entry/334629) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2014Sundance_6768TN.jpg) | [Sundance](https://www.trailjournals.com/journal/about/6768) | [Roaring Forks Shelter](https://www.trailjournals.com/journal/entry/333693) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Superman_10150TN.jpg) | [Superman](https://www.trailjournals.com/journal/about/10150) | [Tellico River Road](https://www.trailjournals.com/journal/entry/330110) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Peru_10969TN.jpg) | [Peru](https://www.trailjournals.com/journal/about/10969) | [Hiawassee](https://www.trailjournals.com/journal/entry/325327) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Dilly Dally & Cubbie](https://www.trailjournals.com/journal/about/10450) | [Spence Field Shelter](https://www.trailjournals.com/journal/entry/324872) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Opus](https://www.trailjournals.com/journal/about/10015) | [Russel Field shelter](https://www.trailjournals.com/journal/entry/314949) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010BruceCook_9777TN.jpg) | [HooYaa!](https://www.trailjournals.com/journal/about/9777) | [Dick's Creek Gap](https://www.trailjournals.com/journal/entry/314470) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2011ErictheRed_9407TN.jpg) | [Eric the Red](https://www.trailjournals.com/journal/about/9407) | [Grassy Gap (138.1)](https://www.trailjournals.com/journal/entry/313497) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Tintin_9861TN.jpg) | [Tintin](https://www.trailjournals.com/journal/about/9861) | [Overmountain Shelter](https://www.trailjournals.com/journal/entry/311126) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| [More...](https://www.trailjournals.com/entries/2010/04/16) [Grouped By Trail...](https://www.trailjournals.com/entries/2010/04/16/trail) |
+
+|     |
+| --- |
+| The woods here are alive with vibrant color, the temps are right on, and the falling dark reminded me of all those days when I was hiking out West and making miles before the headlight needed to be switched on. ... <br>[Uncle Tom](https://www.trailjournals.com/journal/entry/437077) —<br>[Continental Divide Trail](https://www.trailjournals.com/journals/continental_divide_trail) [2013](https://www.trailjournals.com/journals/continental_divide_trail/2013) |
+
+[![Trailjournals](https://www.trailjournals.com/images/logo.png)](https://www.trailjournals.com/)
+
+#### Hiking
+
+- [Trails](https://www.trailjournals.com/trails/list)
+- [Journals](https://www.trailjournals.com/journals)
+- [Photos](https://www.trailjournals.com/photos)
+- [Calendar](https://www.trailjournals.com/calendar)
+- Gear
+- [Links](https://www.trailjournals.com/links)
+
+#### Partners
+
+- [ULA Equipment](https://ula-equipment.sjv.io/drN9K)
+- [REI](http://www.avantlink.com/click.php?tt=ml&ti=45265&pw=68025)
+- [Patagonia](http://www.avantlink.com/click.php?tt=ml&ti=45781&pw=68025)
+
+#### Network
+
+- [Trail Forums](http://www.trailforums.com/)
+- Trail News
+
+#### About Us
+
+- [Contact](https://www.trailjournals.com/about/contact)
+- [Donate](https://www.trailjournals.com/about/donate)
+- [Join](https://www.trailjournals.com/join)
+- [Login](https://www.trailjournals.com/user/login)
+- [Help](https://www.trailjournals.com/help)
+
+#### Follow Us
+
+- [Facebook](https://www.facebook.com/trailjournals)
+- [Instagram](https://instagram.com/trailjournals/)
+- [Twitter](https://twitter.com/trailjournals)
+- [Pinterest](https://www.pinterest.com/trailjournals/)
+- [Linkedin](https://www.linkedin.com/company/trailjournals-llc)
+
+Top Photo © Renee Patrick - Pacific Crest Trail,
+05/21/2006 by
+[She-ra](https://www.trailjournals.com/journal/2942)
+
+Trailjournals LLC © 2026
+All Rights Reserved. [privacy policy](https://www.trailjournals.com/about/privacy)
+
+Newburyport, MA 01950
+
+[Terms under which this service is provided to you.](https://www.trailjournals.com/about/privacy)
+
+Build: 20210226:165913 [Manage Settings](https://www.trailjournals.com/about/settings)
+---
+---
+date: '2010-04-17'
+start: Pinefield Hut
+destination: Bearfence Mountain Hut
+miles_today: 20.6
+trip_miles: 903.0
+facts:
+  trail_section: Trail section from Pinefield Hut to Bearfence Mountain Hut.
+  confidence: low
+---
+# Saturday, April 17, 2010 — Bearfence Mountain Hut
+**Start Location:** Pinefield Hut
+**Miles Today:** 20.60
+**Trip Miles:** 903
+
+Toggle navigation[Trail Journals](https://www.trailjournals.com/)
+
+- [Journals](https://www.trailjournals.com/journal/entry/306439#)  - [Journals](https://www.trailjournals.com/journals)
+  - [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail/2026)
+  - [Pacific Crest Trail](https://www.trailjournals.com/journals/pacific_crest_trail/2026)
+  - [Colorado Trail](https://www.trailjournals.com/journals/colorado_trail/2026)
+  - [Continental Divide Trail](https://www.trailjournals.com/journals/continental_divide_trail/2026)
+  - [Long Trail - Vermont](https://www.trailjournals.com/journals/the_long_trail_-_vermont/2026)
+  - [Florida Trail](https://www.trailjournals.com/journals/the_florida_trail/2026)
+  - [Arizona Trail](https://www.trailjournals.com/journals/arizona_trail/2026)
+  - [John Muir Trail](https://www.trailjournals.com/journals/john_muir_trail/2026)
+  - [Camino de Santiago](https://www.trailjournals.com/journals/camino_de_santiago/2026)
+  - [American Discovery Trail](https://www.trailjournals.com/journals/american_discovery_trail/2026)
+  - [Coast to Coast Walk](https://www.trailjournals.com/journals/coast_to_coast_walk/2026)
+  - [More...](https://www.trailjournals.com/journals/)
+- [Trails](https://www.trailjournals.com/trails/)
+- [Photos](https://www.trailjournals.com/photos/2026)
+- [Gear](https://www.trailjournals.com/journal/entry/306439#)  - [Current Sales](https://www.trailjournals.com/gear/deals/onsale)
+  - [REI](https://www.trailjournals.com/gear/rei)
+  - [ULA](https://www.trailjournals.com/gear/ula)
+  - [Patagonia](https://www.trailjournals.com/gear/patagonia)
+  - [Cabela's](https://www.trailjournals.com/gear/cabela)
+- [Planning](https://www.trailjournals.com/journal/entry/306439#)  - [Plan Your Hike](https://www.trailjournals.com/planning/)
+  - [Gear](https://www.trailjournals.com/gear/)
+  - [Books](https://www.trailjournals.com/books/)
+  - [Links](https://www.trailjournals.com/links/)
+- [Search](https://www.trailjournals.com/search/)
+- [About](https://www.trailjournals.com/journal/entry/306439#)  - [About Trailjournals](https://www.trailjournals.com/about/)
+  - [Login](https://www.trailjournals.com/user/login)
+  - [Join](https://www.trailjournals.com/join)
+  - [Support Trailjournals](https://www.trailjournals.com/about/donate/)
+  - [Contact](https://www.trailjournals.com/about/contact)
+  - [Store](https://www.trailjournals.com/store/)
+
+Backpacking Journals and Photos from Long Distance Hikers
+
+1. [Home](https://www.trailjournals.com/)
+2. [Journals](https://www.trailjournals.com/journals)
+3. [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail)
+4. [2010](https://www.trailjournals.com/journals/appalachian_trail/2010)
+5. [Uncle Frank](https://www.trailjournals.com/journal/10467)
+6. [Entries](https://www.trailjournals.com/journal/entries/10467/uncle%20-frank)
+7. April 17, 2010
+
+Toggle navigation
+
+- [Journal](https://www.trailjournals.com/journal/10467)
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+- [My Journals](https://www.trailjournals.com/myjournals/10467)
+- [View Guest Book](https://www.trailjournals.com/journal/guestbook/10467)
+- [Sign Guest Book](https://www.trailjournals.com/journal/guestbook/sign/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/2a.gif)
+
+[Journal](https://www.trailjournals.com/journal/10467)
+
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+
+--Choose--01/21/1002/06/1002/07/1002/08/1002/09/1002/10/1002/11/1002/12/1002/13/1002/14/1002/15/1002/16/1002/17/1002/18/1002/19/1002/20/1002/21/1002/22/1002/23/1002/24/1002/25/1002/26/1002/27/1002/28/1003/01/1003/02/1003/03/1003/04/1003/05/1003/06/1003/07/1003/08/1003/09/1003/11/1003/12/1003/13/1003/14/1003/15/1003/16/1003/17/1003/18/1003/19/1003/20/1003/21/1003/24/1003/25/1003/26/1003/27/1003/28/1003/29/1003/30/1003/31/1004/01/1004/02/1004/03/1004/04/1004/05/1004/06/1004/07/1004/08/1004/09/1004/10/1004/11/1004/12/1004/13/1004/14/1004/15/1004/16/1004/17/1004/18/1004/19/1004/20/1004/21/1004/23/1004/24/1004/25/1004/26/1004/27/1004/28/1004/29/1004/30/1005/01/1005/02/1005/03/1005/04/1005/05/1005/06/1005/07/1005/08/1005/09/1005/10/1005/11/1005/12/1005/13/1005/14/1005/15/1005/16/1005/17/1005/18/1005/19/1005/20/1005/21/1005/22/1005/23/1005/24/1005/25/1005/26/1005/27/1005/28/1005/29/1005/30/1005/31/1006/01/1006/02/1006/03/1006/04/1006/05/1006/06/1006/07/1006/08/1006/09/1006/10/1006/11/1006/12/1006/13/1006/14/1006/15/1006/16/1006/17/1006/18/1006/19/1006/20/1006/21/10
+
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+
+Guest Book
+
+- [Sign](https://www.trailjournals.com/journal/guestbook/sign/10467)
+- [View](https://www.trailjournals.com/journal/guestbook/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/2a.gif)
+
+- [AT Journals](https://www.trailjournals.com/journals/appalachian_trail)
+- [AT Photos](https://www.trailjournals.com/photos/appalachian_trail)
+- [AT Books](https://www.trailjournals.com/books/appalachian_trail)
+- [Appalachian Trail](http://www.appalachiantrail.org/)
+
+[Join](https://www.trailjournals.com/join) [Login](https://www.trailjournals.com/user/login)
+
+[RSS](https://www.trailjournals.com/journal/rss/10467/xml)
+
+# Uncle Frank's 2010  Appalachian Trail Journal
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/306438) [Next](https://www.trailjournals.com/journal/entry/306440) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+Saturday, April 17, 2010
+
+Destination:Bearfence Mountain Hut
+
+Today's Miles:20.60
+
+Start Location:Pinefield Hut
+
+Trip Miles:903
+
+Destination:Bearfence Mountain Hut
+
+Start Location:Pinefield Hut
+
+Today's Miles:20.60
+
+Trip Miles:903
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/306438) [Next](https://www.trailjournals.com/journal/entry/306440) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+### Hiker Entries April 17, 2010
+
+|  | Journalist | Destination | Trail |
+| --- | --- | --- | --- |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DidgeridudeandDoodlebug_9852TN.jpg) | [Didgeridude and Doodlebug](https://www.trailjournals.com/journal/about/9852) | [Asheville](https://www.trailjournals.com/journal/entry/334631) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2014Sundance_6768TN.jpg) | [Sundance](https://www.trailjournals.com/journal/about/6768) | [Hot Springs NC](https://www.trailjournals.com/journal/entry/333694) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010EUREKA!_10324TN.jpg) | [Jerry from Kentucky](https://www.trailjournals.com/journal/about/10324) | [Spring Mountain Shelter](https://www.trailjournals.com/journal/entry/333253) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Peru_10969TN.jpg) | [Peru](https://www.trailjournals.com/journal/about/10969) | [Hiawassee](https://www.trailjournals.com/journal/entry/325329) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Dilly Dally & Cubbie](https://www.trailjournals.com/journal/about/10450) | [Double Spring Shelter](https://www.trailjournals.com/journal/entry/324873) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [oakleaf](https://www.trailjournals.com/journal/about/10570) | [maine](https://www.trailjournals.com/journal/entry/322412) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Obi-Wan](https://www.trailjournals.com/journal/about/11050) | [\-\- View Entry --](https://www.trailjournals.com/journal/entry/321931) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Obi-Wan](https://www.trailjournals.com/journal/about/11050) | [Springer Mountain](https://www.trailjournals.com/journal/entry/321928) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Opus](https://www.trailjournals.com/journal/about/10015) | [Double-Spring Gap shelter](https://www.trailjournals.com/journal/entry/314950) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010BruceCook_9777TN.jpg) | [HooYaa!](https://www.trailjournals.com/journal/about/9777) | [Muskcrat Creek Shelter](https://www.trailjournals.com/journal/entry/314596) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| [More...](https://www.trailjournals.com/entries/2010/04/17) [Grouped By Trail...](https://www.trailjournals.com/entries/2010/04/17/trail) |
+
+|     |
+| --- |
+| The White Mountains are the hardest part of the trail and the most majestic. I feel lucky having hiked my whole life in this range, perhaps it’ll make other parts of the trail less daunting. ... <br>[Connor Litchman](https://www.trailjournals.com/journal/entry/441689) —<br>[Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail) [2014](https://www.trailjournals.com/journals/appalachian_trail/2014) |
+
+[![Trailjournals](https://www.trailjournals.com/images/logo.png)](https://www.trailjournals.com/)
+
+#### Hiking
+
+- [Trails](https://www.trailjournals.com/trails/list)
+- [Journals](https://www.trailjournals.com/journals)
+- [Photos](https://www.trailjournals.com/photos)
+- [Calendar](https://www.trailjournals.com/calendar)
+- Gear
+- [Links](https://www.trailjournals.com/links)
+
+#### Partners
+
+- [ULA Equipment](https://ula-equipment.sjv.io/drN9K)
+- [REI](http://www.avantlink.com/click.php?tt=ml&ti=45265&pw=68025)
+- [Patagonia](http://www.avantlink.com/click.php?tt=ml&ti=45781&pw=68025)
+
+#### Network
+
+- [Trail Forums](http://www.trailforums.com/)
+- Trail News
+
+#### About Us
+
+- [Contact](https://www.trailjournals.com/about/contact)
+- [Donate](https://www.trailjournals.com/about/donate)
+- [Join](https://www.trailjournals.com/join)
+- [Login](https://www.trailjournals.com/user/login)
+- [Help](https://www.trailjournals.com/help)
+
+#### Follow Us
+
+- [Facebook](https://www.facebook.com/trailjournals)
+- [Instagram](https://instagram.com/trailjournals/)
+- [Twitter](https://twitter.com/trailjournals)
+- [Pinterest](https://www.pinterest.com/trailjournals/)
+- [Linkedin](https://www.linkedin.com/company/trailjournals-llc)
+
+Top Photo © Renee Patrick - Pacific Crest Trail,
+05/21/2006 by
+[She-ra](https://www.trailjournals.com/journal/2942)
+
+Trailjournals LLC © 2026
+All Rights Reserved. [privacy policy](https://www.trailjournals.com/about/privacy)
+
+Newburyport, MA 01950
+
+[Terms under which this service is provided to you.](https://www.trailjournals.com/about/privacy)
+
+Build: 20210226:165913 [Manage Settings](https://www.trailjournals.com/about/settings)
+---
+---
+date: '2010-04-18'
+start: Bearfence Mountain Hut
+destination: Treehaus
+miles_today: 0.0
+trip_miles: 903.0
+facts:
+  trail_section: Trail section from Bearfence Mountain Hut to Treehaus.
+  confidence: low
+---
+# Sunday, April 18, 2010 — Treehaus
+**Start Location:** Bearfence Mountain Hut
+**Miles Today:** 0
+**Trip Miles:** 903
+
+Toggle navigation[Trail Journals](https://www.trailjournals.com/)
+
+- [Journals](https://www.trailjournals.com/journal/entry/306440#)  - [Journals](https://www.trailjournals.com/journals)
+  - [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail/2026)
+  - [Pacific Crest Trail](https://www.trailjournals.com/journals/pacific_crest_trail/2026)
+  - [Colorado Trail](https://www.trailjournals.com/journals/colorado_trail/2026)
+  - [Continental Divide Trail](https://www.trailjournals.com/journals/continental_divide_trail/2026)
+  - [Long Trail - Vermont](https://www.trailjournals.com/journals/the_long_trail_-_vermont/2026)
+  - [Florida Trail](https://www.trailjournals.com/journals/the_florida_trail/2026)
+  - [Arizona Trail](https://www.trailjournals.com/journals/arizona_trail/2026)
+  - [John Muir Trail](https://www.trailjournals.com/journals/john_muir_trail/2026)
+  - [Camino de Santiago](https://www.trailjournals.com/journals/camino_de_santiago/2026)
+  - [American Discovery Trail](https://www.trailjournals.com/journals/american_discovery_trail/2026)
+  - [Coast to Coast Walk](https://www.trailjournals.com/journals/coast_to_coast_walk/2026)
+  - [More...](https://www.trailjournals.com/journals/)
+- [Trails](https://www.trailjournals.com/trails/)
+- [Photos](https://www.trailjournals.com/photos/2026)
+- [Gear](https://www.trailjournals.com/journal/entry/306440#)  - [Current Sales](https://www.trailjournals.com/gear/deals/onsale)
+  - [REI](https://www.trailjournals.com/gear/rei)
+  - [ULA](https://www.trailjournals.com/gear/ula)
+  - [Patagonia](https://www.trailjournals.com/gear/patagonia)
+  - [Cabela's](https://www.trailjournals.com/gear/cabela)
+- [Planning](https://www.trailjournals.com/journal/entry/306440#)  - [Plan Your Hike](https://www.trailjournals.com/planning/)
+  - [Gear](https://www.trailjournals.com/gear/)
+  - [Books](https://www.trailjournals.com/books/)
+  - [Links](https://www.trailjournals.com/links/)
+- [Search](https://www.trailjournals.com/search/)
+- [About](https://www.trailjournals.com/journal/entry/306440#)  - [About Trailjournals](https://www.trailjournals.com/about/)
+  - [Login](https://www.trailjournals.com/user/login)
+  - [Join](https://www.trailjournals.com/join)
+  - [Support Trailjournals](https://www.trailjournals.com/about/donate/)
+  - [Contact](https://www.trailjournals.com/about/contact)
+  - [Store](https://www.trailjournals.com/store/)
+
+Backpacking Journals and Photos from Long Distance Hikers
+
+1. [Home](https://www.trailjournals.com/)
+2. [Journals](https://www.trailjournals.com/journals)
+3. [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail)
+4. [2010](https://www.trailjournals.com/journals/appalachian_trail/2010)
+5. [Uncle Frank](https://www.trailjournals.com/journal/10467)
+6. [Entries](https://www.trailjournals.com/journal/entries/10467/uncle%20-frank)
+7. April 18, 2010
+
+Toggle navigation
+
+- [Journal](https://www.trailjournals.com/journal/10467)
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+- [My Journals](https://www.trailjournals.com/myjournals/10467)
+- [View Guest Book](https://www.trailjournals.com/journal/guestbook/10467)
+- [Sign Guest Book](https://www.trailjournals.com/journal/guestbook/sign/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/4a.gif)
+
+[Journal](https://www.trailjournals.com/journal/10467)
+
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+
+--Choose--01/21/1002/06/1002/07/1002/08/1002/09/1002/10/1002/11/1002/12/1002/13/1002/14/1002/15/1002/16/1002/17/1002/18/1002/19/1002/20/1002/21/1002/22/1002/23/1002/24/1002/25/1002/26/1002/27/1002/28/1003/01/1003/02/1003/03/1003/04/1003/05/1003/06/1003/07/1003/08/1003/09/1003/11/1003/12/1003/13/1003/14/1003/15/1003/16/1003/17/1003/18/1003/19/1003/20/1003/21/1003/24/1003/25/1003/26/1003/27/1003/28/1003/29/1003/30/1003/31/1004/01/1004/02/1004/03/1004/04/1004/05/1004/06/1004/07/1004/08/1004/09/1004/10/1004/11/1004/12/1004/13/1004/14/1004/15/1004/16/1004/17/1004/18/1004/19/1004/20/1004/21/1004/23/1004/24/1004/25/1004/26/1004/27/1004/28/1004/29/1004/30/1005/01/1005/02/1005/03/1005/04/1005/05/1005/06/1005/07/1005/08/1005/09/1005/10/1005/11/1005/12/1005/13/1005/14/1005/15/1005/16/1005/17/1005/18/1005/19/1005/20/1005/21/1005/22/1005/23/1005/24/1005/25/1005/26/1005/27/1005/28/1005/29/1005/30/1005/31/1006/01/1006/02/1006/03/1006/04/1006/05/1006/06/1006/07/1006/08/1006/09/1006/10/1006/11/1006/12/1006/13/1006/14/1006/15/1006/16/1006/17/1006/18/1006/19/1006/20/1006/21/10
+
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+
+Guest Book
+
+- [Sign](https://www.trailjournals.com/journal/guestbook/sign/10467)
+- [View](https://www.trailjournals.com/journal/guestbook/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/4a.gif)
+
+- [AT Journals](https://www.trailjournals.com/journals/appalachian_trail)
+- [AT Photos](https://www.trailjournals.com/photos/appalachian_trail)
+- [AT Books](https://www.trailjournals.com/books/appalachian_trail)
+- [Appalachian Trail](http://www.appalachiantrail.org/)
+
+[Join](https://www.trailjournals.com/join) [Login](https://www.trailjournals.com/user/login)
+
+[RSS](https://www.trailjournals.com/journal/rss/10467/xml)
+
+# Uncle Frank's 2010  Appalachian Trail Journal
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/306439) [Next](https://www.trailjournals.com/journal/entry/306441) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+Sunday, April 18, 2010
+
+Destination:Treehaus
+
+Today's Miles:0
+
+Start Location:Bearfence Mountain Hut
+
+Trip Miles:903
+
+Destination:Treehaus
+
+Start Location:Bearfence Mountain Hut
+
+Today's Miles:0
+
+Trip Miles:903
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/306439) [Next](https://www.trailjournals.com/journal/entry/306441) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+### Hiker Entries April 18, 2010
+
+|  | Journalist | Destination | Trail |
+| --- | --- | --- | --- |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2007IPOD_5637TN.jpg) | [IPOD](https://www.trailjournals.com/journal/about/5637) | [Harper's Creek Shelter](https://www.trailjournals.com/journal/entry/350402) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2014Sundance_6768TN.jpg) | [Sundance](https://www.trailjournals.com/journal/about/6768) | [Hot Springs NC](https://www.trailjournals.com/journal/entry/333758) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Superman_10150TN.jpg) | [Superman](https://www.trailjournals.com/journal/about/10150) | [Cold Spring Gap](https://www.trailjournals.com/journal/entry/330111) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Peru_10969TN.jpg) | [Peru](https://www.trailjournals.com/journal/about/10969) | [Siler Bald Shelter](https://www.trailjournals.com/journal/entry/325328) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Dilly Dally & Cubbie](https://www.trailjournals.com/journal/about/10450) | [Pecks Corner Shelter](https://www.trailjournals.com/journal/entry/324874) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DannyGrady_10127TN.jpg) | [Teen Wolf](https://www.trailjournals.com/journal/about/10127) | [Campsite One Mile Past Neels Gap](https://www.trailjournals.com/journal/entry/319044) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Opus](https://www.trailjournals.com/journal/about/10015) | [Icewater Spring shelter](https://www.trailjournals.com/journal/entry/314952) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010BruceCook_9777TN.jpg) | [HooYaa!](https://www.trailjournals.com/journal/about/9777) | [Carter Gap Shelter](https://www.trailjournals.com/journal/entry/314784) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2011ErictheRed_9407TN.jpg) | [Eric the Red](https://www.trailjournals.com/journal/about/9407) | [Fontana Dam Shelter (163.7)](https://www.trailjournals.com/journal/entry/313499) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Tintin_9861TN.jpg) | [Tintin](https://www.trailjournals.com/journal/about/9861) | [Zero Day in Roan Mountain](https://www.trailjournals.com/journal/entry/311770) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| [More...](https://www.trailjournals.com/entries/2010/04/18) [Grouped By Trail...](https://www.trailjournals.com/entries/2010/04/18/trail) |
+
+|     |
+| --- |
+| As I embark on this journey, this fulfillment of a dream, this undertaking that will require all the physical, mental, and emotional strength that God grants me, I will travel toward my destination, proudly, as Don’s Brother. ... <br>[Don's Brother](https://www.trailjournals.com/journal/entry/400624) —<br>[Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail) [2013](https://www.trailjournals.com/journals/appalachian_trail/2013) |
+
+[![Trailjournals](https://www.trailjournals.com/images/logo.png)](https://www.trailjournals.com/)
+
+#### Hiking
+
+- [Trails](https://www.trailjournals.com/trails/list)
+- [Journals](https://www.trailjournals.com/journals)
+- [Photos](https://www.trailjournals.com/photos)
+- [Calendar](https://www.trailjournals.com/calendar)
+- Gear
+- [Links](https://www.trailjournals.com/links)
+
+#### Partners
+
+- [ULA Equipment](https://ula-equipment.sjv.io/drN9K)
+- [REI](http://www.avantlink.com/click.php?tt=ml&ti=45265&pw=68025)
+- [Patagonia](http://www.avantlink.com/click.php?tt=ml&ti=45781&pw=68025)
+
+#### Network
+
+- [Trail Forums](http://www.trailforums.com/)
+- Trail News
+
+#### About Us
+
+- [Contact](https://www.trailjournals.com/about/contact)
+- [Donate](https://www.trailjournals.com/about/donate)
+- [Join](https://www.trailjournals.com/join)
+- [Login](https://www.trailjournals.com/user/login)
+- [Help](https://www.trailjournals.com/help)
+
+#### Follow Us
+
+- [Facebook](https://www.facebook.com/trailjournals)
+- [Instagram](https://instagram.com/trailjournals/)
+- [Twitter](https://twitter.com/trailjournals)
+- [Pinterest](https://www.pinterest.com/trailjournals/)
+- [Linkedin](https://www.linkedin.com/company/trailjournals-llc)
+
+Top Photo © Renee Patrick - Pacific Crest Trail,
+05/21/2006 by
+[She-ra](https://www.trailjournals.com/journal/2942)
+
+Trailjournals LLC © 2026
+All Rights Reserved. [privacy policy](https://www.trailjournals.com/about/privacy)
+
+Newburyport, MA 01950
+
+[Terms under which this service is provided to you.](https://www.trailjournals.com/about/privacy)
+
+Build: 20210226:165913 [Manage Settings](https://www.trailjournals.com/about/settings)
+---
+---
+date: '2010-04-19'
+start: Treehaus
+destination: 'Byrd''s Nest #3'
+miles_today: 22.4
+trip_miles: 925.4
+facts:
+  trail_section: 'Trail section from Treehaus to Byrd''s Nest #3.'
+  confidence: low
+---
+# Monday, April 19, 2010 — Byrd's Nest #3
+**Start Location:** Treehaus
+**Miles Today:** 22.40
+**Trip Miles:** 925.40
+
+Toggle navigation[Trail Journals](https://www.trailjournals.com/)
+
+- [Journals](https://www.trailjournals.com/journal/entry/306441#)  - [Journals](https://www.trailjournals.com/journals)
+  - [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail/2026)
+  - [Pacific Crest Trail](https://www.trailjournals.com/journals/pacific_crest_trail/2026)
+  - [Colorado Trail](https://www.trailjournals.com/journals/colorado_trail/2026)
+  - [Continental Divide Trail](https://www.trailjournals.com/journals/continental_divide_trail/2026)
+  - [Long Trail - Vermont](https://www.trailjournals.com/journals/the_long_trail_-_vermont/2026)
+  - [Florida Trail](https://www.trailjournals.com/journals/the_florida_trail/2026)
+  - [Arizona Trail](https://www.trailjournals.com/journals/arizona_trail/2026)
+  - [John Muir Trail](https://www.trailjournals.com/journals/john_muir_trail/2026)
+  - [Camino de Santiago](https://www.trailjournals.com/journals/camino_de_santiago/2026)
+  - [American Discovery Trail](https://www.trailjournals.com/journals/american_discovery_trail/2026)
+  - [Coast to Coast Walk](https://www.trailjournals.com/journals/coast_to_coast_walk/2026)
+  - [More...](https://www.trailjournals.com/journals/)
+- [Trails](https://www.trailjournals.com/trails/)
+- [Photos](https://www.trailjournals.com/photos/2026)
+- [Gear](https://www.trailjournals.com/journal/entry/306441#)  - [Current Sales](https://www.trailjournals.com/gear/deals/onsale)
+  - [REI](https://www.trailjournals.com/gear/rei)
+  - [ULA](https://www.trailjournals.com/gear/ula)
+  - [Patagonia](https://www.trailjournals.com/gear/patagonia)
+  - [Cabela's](https://www.trailjournals.com/gear/cabela)
+- [Planning](https://www.trailjournals.com/journal/entry/306441#)  - [Plan Your Hike](https://www.trailjournals.com/planning/)
+  - [Gear](https://www.trailjournals.com/gear/)
+  - [Books](https://www.trailjournals.com/books/)
+  - [Links](https://www.trailjournals.com/links/)
+- [Search](https://www.trailjournals.com/search/)
+- [About](https://www.trailjournals.com/journal/entry/306441#)  - [About Trailjournals](https://www.trailjournals.com/about/)
+  - [Login](https://www.trailjournals.com/user/login)
+  - [Join](https://www.trailjournals.com/join)
+  - [Support Trailjournals](https://www.trailjournals.com/about/donate/)
+  - [Contact](https://www.trailjournals.com/about/contact)
+  - [Store](https://www.trailjournals.com/store/)
+
+Backpacking Journals and Photos from Long Distance Hikers
+
+1. [Home](https://www.trailjournals.com/)
+2. [Journals](https://www.trailjournals.com/journals)
+3. [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail)
+4. [2010](https://www.trailjournals.com/journals/appalachian_trail/2010)
+5. [Uncle Frank](https://www.trailjournals.com/journal/10467)
+6. [Entries](https://www.trailjournals.com/journal/entries/10467/uncle%20-frank)
+7. April 19, 2010
+
+Toggle navigation
+
+- [Journal](https://www.trailjournals.com/journal/10467)
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+- [My Journals](https://www.trailjournals.com/myjournals/10467)
+- [View Guest Book](https://www.trailjournals.com/journal/guestbook/10467)
+- [Sign Guest Book](https://www.trailjournals.com/journal/guestbook/sign/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/8a.gif)![](https://www.trailjournals.com/images/2a.gif)
+
+[Journal](https://www.trailjournals.com/journal/10467)
+
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+
+--Choose--01/21/1002/06/1002/07/1002/08/1002/09/1002/10/1002/11/1002/12/1002/13/1002/14/1002/15/1002/16/1002/17/1002/18/1002/19/1002/20/1002/21/1002/22/1002/23/1002/24/1002/25/1002/26/1002/27/1002/28/1003/01/1003/02/1003/03/1003/04/1003/05/1003/06/1003/07/1003/08/1003/09/1003/11/1003/12/1003/13/1003/14/1003/15/1003/16/1003/17/1003/18/1003/19/1003/20/1003/21/1003/24/1003/25/1003/26/1003/27/1003/28/1003/29/1003/30/1003/31/1004/01/1004/02/1004/03/1004/04/1004/05/1004/06/1004/07/1004/08/1004/09/1004/10/1004/11/1004/12/1004/13/1004/14/1004/15/1004/16/1004/17/1004/18/1004/19/1004/20/1004/21/1004/23/1004/24/1004/25/1004/26/1004/27/1004/28/1004/29/1004/30/1005/01/1005/02/1005/03/1005/04/1005/05/1005/06/1005/07/1005/08/1005/09/1005/10/1005/11/1005/12/1005/13/1005/14/1005/15/1005/16/1005/17/1005/18/1005/19/1005/20/1005/21/1005/22/1005/23/1005/24/1005/25/1005/26/1005/27/1005/28/1005/29/1005/30/1005/31/1006/01/1006/02/1006/03/1006/04/1006/05/1006/06/1006/07/1006/08/1006/09/1006/10/1006/11/1006/12/1006/13/1006/14/1006/15/1006/16/1006/17/1006/18/1006/19/1006/20/1006/21/10
+
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+
+Guest Book
+
+- [Sign](https://www.trailjournals.com/journal/guestbook/sign/10467)
+- [View](https://www.trailjournals.com/journal/guestbook/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/8a.gif)![](https://www.trailjournals.com/images/2a.gif)
+
+- [AT Journals](https://www.trailjournals.com/journals/appalachian_trail)
+- [AT Photos](https://www.trailjournals.com/photos/appalachian_trail)
+- [AT Books](https://www.trailjournals.com/books/appalachian_trail)
+- [Appalachian Trail](http://www.appalachiantrail.org/)
+
+[Join](https://www.trailjournals.com/join) [Login](https://www.trailjournals.com/user/login)
+
+[RSS](https://www.trailjournals.com/journal/rss/10467/xml)
+
+# Uncle Frank's 2010  Appalachian Trail Journal
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/306440) [Next](https://www.trailjournals.com/journal/entry/306442) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+Monday, April 19, 2010
+
+Destination:Byrd's Nest #3
+
+Today's Miles:22.40
+
+Start Location:Treehaus
+
+Trip Miles:925.40
+
+Destination:Byrd's Nest #3
+
+Start Location:Treehaus
+
+Today's Miles:22.40
+
+Trip Miles:925.40
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/306440) [Next](https://www.trailjournals.com/journal/entry/306442) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+### Hiker Entries April 19, 2010
+
+|  | Journalist | Destination | Trail |
+| --- | --- | --- | --- |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2007IPOD_5637TN.jpg) | [IPOD](https://www.trailjournals.com/journal/about/5637) | [dripping rock parking](https://www.trailjournals.com/journal/entry/350403) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DidgeridudeandDoodlebug_9852TN.jpg) | [Didgeridude and Doodlebug](https://www.trailjournals.com/journal/about/9852) | [campsite past Sam's gap](https://www.trailjournals.com/journal/entry/334632) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2014Sundance_6768TN.jpg) | [Sundance](https://www.trailjournals.com/journal/about/6768) | [Spring Mtn. Shelter](https://www.trailjournals.com/journal/entry/333759) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010BruceCook_9777TN.jpg) | [HooYaa!](https://www.trailjournals.com/journal/about/9777) | [Rock Gap Shelter](https://www.trailjournals.com/journal/entry/331901) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Superman_10150TN.jpg) | [Superman](https://www.trailjournals.com/journal/about/10150) | [Mile 177](https://www.trailjournals.com/journal/entry/330112) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Peru_10969TN.jpg) | [Peru](https://www.trailjournals.com/journal/about/10969) | [Cold Spring Shelter](https://www.trailjournals.com/journal/entry/325330) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Dilly Dally & Cubbie](https://www.trailjournals.com/journal/about/10450) | [Davenport Gap Shelter](https://www.trailjournals.com/journal/entry/324875) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010UnbreakableandNoTrace_9709TN.jpg) | [Unbreakable & No Trace](https://www.trailjournals.com/journal/about/9709) | [Mount Laguna](https://www.trailjournals.com/journal/entry/320920) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DannyGrady_10127TN.jpg) | [Teen Wolf](https://www.trailjournals.com/journal/about/10127) | [Blue Mountain Shelter](https://www.trailjournals.com/journal/entry/319046) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Opus](https://www.trailjournals.com/journal/about/10015) | [Cosby Knob shelter](https://www.trailjournals.com/journal/entry/314953) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| [More...](https://www.trailjournals.com/entries/2010/04/19) [Grouped By Trail...](https://www.trailjournals.com/entries/2010/04/19/trail) |
+
+|     |
+| --- |
+| "...had to chuckle at myself walking along at a blazing 3MPH! I would take about seven hours to hike seventeen miles today and those cars and trucks were doing the same mileage in about twenty minutes. It is so awesome to be out of "Life in the fast lane."... <br>[Soul Asylum](https://www.trailjournals.com/journal/entry/477737) —<br>[Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail) [2017](https://www.trailjournals.com/journals/appalachian_trail/2017) |
+
+[![Trailjournals](https://www.trailjournals.com/images/logo.png)](https://www.trailjournals.com/)
+
+#### Hiking
+
+- [Trails](https://www.trailjournals.com/trails/list)
+- [Journals](https://www.trailjournals.com/journals)
+- [Photos](https://www.trailjournals.com/photos)
+- [Calendar](https://www.trailjournals.com/calendar)
+- Gear
+- [Links](https://www.trailjournals.com/links)
+
+#### Partners
+
+- [ULA Equipment](https://ula-equipment.sjv.io/drN9K)
+- [REI](http://www.avantlink.com/click.php?tt=ml&ti=45265&pw=68025)
+- [Patagonia](http://www.avantlink.com/click.php?tt=ml&ti=45781&pw=68025)
+
+#### Network
+
+- [Trail Forums](http://www.trailforums.com/)
+- Trail News
+
+#### About Us
+
+- [Contact](https://www.trailjournals.com/about/contact)
+- [Donate](https://www.trailjournals.com/about/donate)
+- [Join](https://www.trailjournals.com/join)
+- [Login](https://www.trailjournals.com/user/login)
+- [Help](https://www.trailjournals.com/help)
+
+#### Follow Us
+
+- [Facebook](https://www.facebook.com/trailjournals)
+- [Instagram](https://instagram.com/trailjournals/)
+- [Twitter](https://twitter.com/trailjournals)
+- [Pinterest](https://www.pinterest.com/trailjournals/)
+- [Linkedin](https://www.linkedin.com/company/trailjournals-llc)
+
+Top Photo © Cindy - The Appalachian Trail,
+04/01/2002 by
+[MrsGorp](https://www.trailjournals.com/journal/569)
+
+Trailjournals LLC © 2026
+All Rights Reserved. [privacy policy](https://www.trailjournals.com/about/privacy)
+
+Newburyport, MA 01950
+
+[Terms under which this service is provided to you.](https://www.trailjournals.com/about/privacy)
+
+Build: 20210226:165913 [Manage Settings](https://www.trailjournals.com/about/settings)
+---
+---
+date: '2010-04-20'
+start: 'Byrd''s Nest #3'
+destination: Gravel Springs Hut
+miles_today: 17.5
+trip_miles: 942.9
+facts:
+  trail_section: 'Trail section from Byrd''s Nest #3 to Gravel Springs Hut.'
+  confidence: low
+---
+# Tuesday, April 20, 2010 — Gravel Springs Hut
+**Start Location:** Byrd's Nest #3
+**Miles Today:** 17.50
+**Trip Miles:** 942.90
+
+Toggle navigation[Trail Journals](https://www.trailjournals.com/)
+
+- [Journals](https://www.trailjournals.com/journal/entry/306442#)  - [Journals](https://www.trailjournals.com/journals)
+  - [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail/2026)
+  - [Pacific Crest Trail](https://www.trailjournals.com/journals/pacific_crest_trail/2026)
+  - [Colorado Trail](https://www.trailjournals.com/journals/colorado_trail/2026)
+  - [Continental Divide Trail](https://www.trailjournals.com/journals/continental_divide_trail/2026)
+  - [Long Trail - Vermont](https://www.trailjournals.com/journals/the_long_trail_-_vermont/2026)
+  - [Florida Trail](https://www.trailjournals.com/journals/the_florida_trail/2026)
+  - [Arizona Trail](https://www.trailjournals.com/journals/arizona_trail/2026)
+  - [John Muir Trail](https://www.trailjournals.com/journals/john_muir_trail/2026)
+  - [Camino de Santiago](https://www.trailjournals.com/journals/camino_de_santiago/2026)
+  - [American Discovery Trail](https://www.trailjournals.com/journals/american_discovery_trail/2026)
+  - [Coast to Coast Walk](https://www.trailjournals.com/journals/coast_to_coast_walk/2026)
+  - [More...](https://www.trailjournals.com/journals/)
+- [Trails](https://www.trailjournals.com/trails/)
+- [Photos](https://www.trailjournals.com/photos/2026)
+- [Gear](https://www.trailjournals.com/journal/entry/306442#)  - [Current Sales](https://www.trailjournals.com/gear/deals/onsale)
+  - [REI](https://www.trailjournals.com/gear/rei)
+  - [ULA](https://www.trailjournals.com/gear/ula)
+  - [Patagonia](https://www.trailjournals.com/gear/patagonia)
+  - [Cabela's](https://www.trailjournals.com/gear/cabela)
+- [Planning](https://www.trailjournals.com/journal/entry/306442#)  - [Plan Your Hike](https://www.trailjournals.com/planning/)
+  - [Gear](https://www.trailjournals.com/gear/)
+  - [Books](https://www.trailjournals.com/books/)
+  - [Links](https://www.trailjournals.com/links/)
+- [Search](https://www.trailjournals.com/search/)
+- [About](https://www.trailjournals.com/journal/entry/306442#)  - [About Trailjournals](https://www.trailjournals.com/about/)
+  - [Login](https://www.trailjournals.com/user/login)
+  - [Join](https://www.trailjournals.com/join)
+  - [Support Trailjournals](https://www.trailjournals.com/about/donate/)
+  - [Contact](https://www.trailjournals.com/about/contact)
+  - [Store](https://www.trailjournals.com/store/)
+
+Backpacking Journals and Photos from Long Distance Hikers
+
+1. [Home](https://www.trailjournals.com/)
+2. [Journals](https://www.trailjournals.com/journals)
+3. [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail)
+4. [2010](https://www.trailjournals.com/journals/appalachian_trail/2010)
+5. [Uncle Frank](https://www.trailjournals.com/journal/10467)
+6. [Entries](https://www.trailjournals.com/journal/entries/10467/uncle%20-frank)
+7. April 20, 2010
+
+Toggle navigation
+
+- [Journal](https://www.trailjournals.com/journal/10467)
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+- [My Journals](https://www.trailjournals.com/myjournals/10467)
+- [View Guest Book](https://www.trailjournals.com/journal/guestbook/10467)
+- [Sign Guest Book](https://www.trailjournals.com/journal/guestbook/sign/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/5a.gif)
+
+[Journal](https://www.trailjournals.com/journal/10467)
+
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+
+--Choose--01/21/1002/06/1002/07/1002/08/1002/09/1002/10/1002/11/1002/12/1002/13/1002/14/1002/15/1002/16/1002/17/1002/18/1002/19/1002/20/1002/21/1002/22/1002/23/1002/24/1002/25/1002/26/1002/27/1002/28/1003/01/1003/02/1003/03/1003/04/1003/05/1003/06/1003/07/1003/08/1003/09/1003/11/1003/12/1003/13/1003/14/1003/15/1003/16/1003/17/1003/18/1003/19/1003/20/1003/21/1003/24/1003/25/1003/26/1003/27/1003/28/1003/29/1003/30/1003/31/1004/01/1004/02/1004/03/1004/04/1004/05/1004/06/1004/07/1004/08/1004/09/1004/10/1004/11/1004/12/1004/13/1004/14/1004/15/1004/16/1004/17/1004/18/1004/19/1004/20/1004/21/1004/23/1004/24/1004/25/1004/26/1004/27/1004/28/1004/29/1004/30/1005/01/1005/02/1005/03/1005/04/1005/05/1005/06/1005/07/1005/08/1005/09/1005/10/1005/11/1005/12/1005/13/1005/14/1005/15/1005/16/1005/17/1005/18/1005/19/1005/20/1005/21/1005/22/1005/23/1005/24/1005/25/1005/26/1005/27/1005/28/1005/29/1005/30/1005/31/1006/01/1006/02/1006/03/1006/04/1006/05/1006/06/1006/07/1006/08/1006/09/1006/10/1006/11/1006/12/1006/13/1006/14/1006/15/1006/16/1006/17/1006/18/1006/19/1006/20/1006/21/10
+
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+
+Guest Book
+
+- [Sign](https://www.trailjournals.com/journal/guestbook/sign/10467)
+- [View](https://www.trailjournals.com/journal/guestbook/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/5a.gif)
+
+- [AT Journals](https://www.trailjournals.com/journals/appalachian_trail)
+- [AT Photos](https://www.trailjournals.com/photos/appalachian_trail)
+- [AT Books](https://www.trailjournals.com/books/appalachian_trail)
+- [Appalachian Trail](http://www.appalachiantrail.org/)
+
+[Join](https://www.trailjournals.com/join) [Login](https://www.trailjournals.com/user/login)
+
+[RSS](https://www.trailjournals.com/journal/rss/10467/xml)
+
+# Uncle Frank's 2010  Appalachian Trail Journal
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/306441) [Next](https://www.trailjournals.com/journal/entry/306443) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+Tuesday, April 20, 2010
+
+Destination:Gravel Springs Hut
+
+Today's Miles:17.50
+
+Start Location:Byrd's Nest #3
+
+Trip Miles:942.90
+
+Destination:Gravel Springs Hut
+
+Start Location:Byrd's Nest #3
+
+Today's Miles:17.50
+
+Trip Miles:942.90
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/306441) [Next](https://www.trailjournals.com/journal/entry/306443) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+### Hiker Entries April 20, 2010
+
+|  | Journalist | Destination | Trail |
+| --- | --- | --- | --- |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2007IPOD_5637TN.jpg) | [IPOD](https://www.trailjournals.com/journal/about/5637) | [Waynesboro](https://www.trailjournals.com/journal/entry/350438) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DidgeridudeandDoodlebug_9852TN.jpg) | [Didgeridude and Doodlebug](https://www.trailjournals.com/journal/about/9852) | [Bald Mtn Shelter](https://www.trailjournals.com/journal/entry/334633) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2014Sundance_6768TN.jpg) | [Sundance](https://www.trailjournals.com/journal/about/6768) | [Jerry Cabin Shelter](https://www.trailjournals.com/journal/entry/333760) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010EUREKA!_10324TN.jpg) | [Jerry from Kentucky](https://www.trailjournals.com/journal/about/10324) | [Bald Mtn Shelter](https://www.trailjournals.com/journal/entry/333254) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010BruceCook_9777TN.jpg) | [HooYaa!](https://www.trailjournals.com/journal/about/9777) | [Winding Stair Gap](https://www.trailjournals.com/journal/entry/331939) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Superman_10150TN.jpg) | [Superman](https://www.trailjournals.com/journal/about/10150) | [Deals Gap Motel & Gas Station](https://www.trailjournals.com/journal/entry/330113) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Peru_10969TN.jpg) | [Peru](https://www.trailjournals.com/journal/about/10969) | [NOC](https://www.trailjournals.com/journal/entry/325331) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Dilly Dally & Cubbie](https://www.trailjournals.com/journal/about/10450) | [Standing Bear Hostel](https://www.trailjournals.com/journal/entry/324877) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DannyGrady_10127TN.jpg) | [Teen Wolf](https://www.trailjournals.com/journal/about/10127) | [Hiawasee Inn](https://www.trailjournals.com/journal/entry/319049) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Opus](https://www.trailjournals.com/journal/about/10015) | [Standing Bear Farm](https://www.trailjournals.com/journal/entry/315232) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| [More...](https://www.trailjournals.com/entries/2010/04/20) [Grouped By Trail...](https://www.trailjournals.com/entries/2010/04/20/trail) |
+
+|     |
+| --- |
+| Hiking through the Maine woods this morning, I couldn't help but notice how green they were. The pines are green and the floor of the forest is covered with mosses in various shades of green.... <br>[Dallas](https://www.trailjournals.com/journal/entry/474291) —<br>[Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail) [2014](https://www.trailjournals.com/journals/appalachian_trail/2014) |
+
+[![Trailjournals](https://www.trailjournals.com/images/logo.png)](https://www.trailjournals.com/)
+
+#### Hiking
+
+- [Trails](https://www.trailjournals.com/trails/list)
+- [Journals](https://www.trailjournals.com/journals)
+- [Photos](https://www.trailjournals.com/photos)
+- [Calendar](https://www.trailjournals.com/calendar)
+- Gear
+- [Links](https://www.trailjournals.com/links)
+
+#### Partners
+
+- [ULA Equipment](https://ula-equipment.sjv.io/drN9K)
+- [REI](http://www.avantlink.com/click.php?tt=ml&ti=45265&pw=68025)
+- [Patagonia](http://www.avantlink.com/click.php?tt=ml&ti=45781&pw=68025)
+
+#### Network
+
+- [Trail Forums](http://www.trailforums.com/)
+- Trail News
+
+#### About Us
+
+- [Contact](https://www.trailjournals.com/about/contact)
+- [Donate](https://www.trailjournals.com/about/donate)
+- [Join](https://www.trailjournals.com/join)
+- [Login](https://www.trailjournals.com/user/login)
+- [Help](https://www.trailjournals.com/help)
+
+#### Follow Us
+
+- [Facebook](https://www.facebook.com/trailjournals)
+- [Instagram](https://instagram.com/trailjournals/)
+- [Twitter](https://twitter.com/trailjournals)
+- [Pinterest](https://www.pinterest.com/trailjournals/)
+- [Linkedin](https://www.linkedin.com/company/trailjournals-llc)
+
+Top Photo © Cindy - The Appalachian Trail,
+04/01/2002 by
+[MrsGorp](https://www.trailjournals.com/journal/569)
+
+Trailjournals LLC © 2026
+All Rights Reserved. [privacy policy](https://www.trailjournals.com/about/privacy)
+
+Newburyport, MA 01950
+
+[Terms under which this service is provided to you.](https://www.trailjournals.com/about/privacy)
+
+Build: 20210226:165913 [Manage Settings](https://www.trailjournals.com/about/settings)
+---
+---
+date: '2010-04-21'
+start: Gravel Springs Hut
+destination: Dick's Dome Shelter
+miles_today: 28.6
+trip_miles: 971.5
+facts:
+  trail_section: Trail section from Gravel Springs Hut to Dick's Dome Shelter.
+  confidence: low
+---
+# Wednesday, April 21, 2010 — Dick's Dome Shelter
+**Start Location:** Gravel Springs Hut
+**Miles Today:** 28.60
+**Trip Miles:** 971.50
+
+Toggle navigation[Trail Journals](https://www.trailjournals.com/)
+
+- [Journals](https://www.trailjournals.com/journal/entry/306443#)  - [Journals](https://www.trailjournals.com/journals)
+  - [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail/2026)
+  - [Pacific Crest Trail](https://www.trailjournals.com/journals/pacific_crest_trail/2026)
+  - [Colorado Trail](https://www.trailjournals.com/journals/colorado_trail/2026)
+  - [Continental Divide Trail](https://www.trailjournals.com/journals/continental_divide_trail/2026)
+  - [Long Trail - Vermont](https://www.trailjournals.com/journals/the_long_trail_-_vermont/2026)
+  - [Florida Trail](https://www.trailjournals.com/journals/the_florida_trail/2026)
+  - [Arizona Trail](https://www.trailjournals.com/journals/arizona_trail/2026)
+  - [John Muir Trail](https://www.trailjournals.com/journals/john_muir_trail/2026)
+  - [Camino de Santiago](https://www.trailjournals.com/journals/camino_de_santiago/2026)
+  - [American Discovery Trail](https://www.trailjournals.com/journals/american_discovery_trail/2026)
+  - [Coast to Coast Walk](https://www.trailjournals.com/journals/coast_to_coast_walk/2026)
+  - [More...](https://www.trailjournals.com/journals/)
+- [Trails](https://www.trailjournals.com/trails/)
+- [Photos](https://www.trailjournals.com/photos/2026)
+- [Gear](https://www.trailjournals.com/journal/entry/306443#)  - [Current Sales](https://www.trailjournals.com/gear/deals/onsale)
+  - [REI](https://www.trailjournals.com/gear/rei)
+  - [ULA](https://www.trailjournals.com/gear/ula)
+  - [Patagonia](https://www.trailjournals.com/gear/patagonia)
+  - [Cabela's](https://www.trailjournals.com/gear/cabela)
+- [Planning](https://www.trailjournals.com/journal/entry/306443#)  - [Plan Your Hike](https://www.trailjournals.com/planning/)
+  - [Gear](https://www.trailjournals.com/gear/)
+  - [Books](https://www.trailjournals.com/books/)
+  - [Links](https://www.trailjournals.com/links/)
+- [Search](https://www.trailjournals.com/search/)
+- [About](https://www.trailjournals.com/journal/entry/306443#)  - [About Trailjournals](https://www.trailjournals.com/about/)
+  - [Login](https://www.trailjournals.com/user/login)
+  - [Join](https://www.trailjournals.com/join)
+  - [Support Trailjournals](https://www.trailjournals.com/about/donate/)
+  - [Contact](https://www.trailjournals.com/about/contact)
+  - [Store](https://www.trailjournals.com/store/)
+
+Backpacking Journals and Photos from Long Distance Hikers
+
+1. [Home](https://www.trailjournals.com/)
+2. [Journals](https://www.trailjournals.com/journals)
+3. [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail)
+4. [2010](https://www.trailjournals.com/journals/appalachian_trail/2010)
+5. [Uncle Frank](https://www.trailjournals.com/journal/10467)
+6. [Entries](https://www.trailjournals.com/journal/entries/10467/uncle%20-frank)
+7. April 21, 2010
+
+Toggle navigation
+
+- [Journal](https://www.trailjournals.com/journal/10467)
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+- [My Journals](https://www.trailjournals.com/myjournals/10467)
+- [View Guest Book](https://www.trailjournals.com/journal/guestbook/10467)
+- [Sign Guest Book](https://www.trailjournals.com/journal/guestbook/sign/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/8a.gif)![](https://www.trailjournals.com/images/2a.gif)
+
+[Journal](https://www.trailjournals.com/journal/10467)
+
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+
+--Choose--01/21/1002/06/1002/07/1002/08/1002/09/1002/10/1002/11/1002/12/1002/13/1002/14/1002/15/1002/16/1002/17/1002/18/1002/19/1002/20/1002/21/1002/22/1002/23/1002/24/1002/25/1002/26/1002/27/1002/28/1003/01/1003/02/1003/03/1003/04/1003/05/1003/06/1003/07/1003/08/1003/09/1003/11/1003/12/1003/13/1003/14/1003/15/1003/16/1003/17/1003/18/1003/19/1003/20/1003/21/1003/24/1003/25/1003/26/1003/27/1003/28/1003/29/1003/30/1003/31/1004/01/1004/02/1004/03/1004/04/1004/05/1004/06/1004/07/1004/08/1004/09/1004/10/1004/11/1004/12/1004/13/1004/14/1004/15/1004/16/1004/17/1004/18/1004/19/1004/20/1004/21/1004/23/1004/24/1004/25/1004/26/1004/27/1004/28/1004/29/1004/30/1005/01/1005/02/1005/03/1005/04/1005/05/1005/06/1005/07/1005/08/1005/09/1005/10/1005/11/1005/12/1005/13/1005/14/1005/15/1005/16/1005/17/1005/18/1005/19/1005/20/1005/21/1005/22/1005/23/1005/24/1005/25/1005/26/1005/27/1005/28/1005/29/1005/30/1005/31/1006/01/1006/02/1006/03/1006/04/1006/05/1006/06/1006/07/1006/08/1006/09/1006/10/1006/11/1006/12/1006/13/1006/14/1006/15/1006/16/1006/17/1006/18/1006/19/1006/20/1006/21/10
+
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+
+Guest Book
+
+- [Sign](https://www.trailjournals.com/journal/guestbook/sign/10467)
+- [View](https://www.trailjournals.com/journal/guestbook/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/8a.gif)![](https://www.trailjournals.com/images/2a.gif)
+
+- [AT Journals](https://www.trailjournals.com/journals/appalachian_trail)
+- [AT Photos](https://www.trailjournals.com/photos/appalachian_trail)
+- [AT Books](https://www.trailjournals.com/books/appalachian_trail)
+- [Appalachian Trail](http://www.appalachiantrail.org/)
+
+[Join](https://www.trailjournals.com/join) [Login](https://www.trailjournals.com/user/login)
+
+[RSS](https://www.trailjournals.com/journal/rss/10467/xml)
+
+# Uncle Frank's 2010  Appalachian Trail Journal
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/306442) [Next](https://www.trailjournals.com/journal/entry/306446) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+Wednesday, April 21, 2010
+
+Destination:Dick's Dome Shelter
+
+Today's Miles:28.60
+
+Start Location:Gravel Springs Hut
+
+Trip Miles:971.50
+
+Destination:Dick's Dome Shelter
+
+Start Location:Gravel Springs Hut
+
+Today's Miles:28.60
+
+Trip Miles:971.50
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/306442) [Next](https://www.trailjournals.com/journal/entry/306446) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+### Hiker Entries April 21, 2010
+
+|  | Journalist | Destination | Trail |
+| --- | --- | --- | --- |
+|  | [Deluxe](https://www.trailjournals.com/journal/about/21877) | [\-\- View Entry --](https://www.trailjournals.com/journal/entry/566478) | [Nepal Trekking](https://www.trailjournals.com/journals/Nepal%20_Trekking) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2007IPOD_5637TN.jpg) | [IPOD](https://www.trailjournals.com/journal/about/5637) | [middle of nowhere](https://www.trailjournals.com/journal/entry/350439) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DidgeridudeandDoodlebug_9852TN.jpg) | [Didgeridude and Doodlebug](https://www.trailjournals.com/journal/about/9852) | [No Business Knob Shelter](https://www.trailjournals.com/journal/entry/334635) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2014Sundance_6768TN.jpg) | [Sundance](https://www.trailjournals.com/journal/about/6768) | [Hogback Ridge Shelter](https://www.trailjournals.com/journal/entry/333761) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010EUREKA!_10324TN.jpg) | [Jerry from Kentucky](https://www.trailjournals.com/journal/about/10324) | [Erwin](https://www.trailjournals.com/journal/entry/333256) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010BruceCook_9777TN.jpg) | [HooYaa!](https://www.trailjournals.com/journal/about/9777) | [Wayah Shelter](https://www.trailjournals.com/journal/entry/331940) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Superman_10150TN.jpg) | [Superman](https://www.trailjournals.com/journal/about/10150) | [Fontana Dam](https://www.trailjournals.com/journal/entry/330115) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DannyGrady_10127TN.jpg) | [Teen Wolf](https://www.trailjournals.com/journal/about/10127) | [\-\- View Entry --](https://www.trailjournals.com/journal/entry/329682) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Psycho_10726TN.jpg) | [Psycho & Apricots](https://www.trailjournals.com/journal/about/10726) | [Warner Springs](https://www.trailjournals.com/journal/entry/329536) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Peru_10969TN.jpg) | [Peru](https://www.trailjournals.com/journal/about/10969) | [NOC](https://www.trailjournals.com/journal/entry/325332) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| [More...](https://www.trailjournals.com/entries/2010/04/21) [Grouped By Trail...](https://www.trailjournals.com/entries/2010/04/21/trail) |
+
+|     |
+| --- |
+| It has been another great day on the Trail in spite of the rain. Tomorrow's forecast is for more rain but we'll take what comes. That's life on the Trail...you can't beat it!!... <br>[Footsteps](https://www.trailjournals.com/journal/entry/8770) —<br>[Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail) [2001](https://www.trailjournals.com/journals/appalachian_trail/2001) |
+
+[![Trailjournals](https://www.trailjournals.com/images/logo.png)](https://www.trailjournals.com/)
+
+#### Hiking
+
+- [Trails](https://www.trailjournals.com/trails/list)
+- [Journals](https://www.trailjournals.com/journals)
+- [Photos](https://www.trailjournals.com/photos)
+- [Calendar](https://www.trailjournals.com/calendar)
+- Gear
+- [Links](https://www.trailjournals.com/links)
+
+#### Partners
+
+- [ULA Equipment](https://ula-equipment.sjv.io/drN9K)
+- [REI](http://www.avantlink.com/click.php?tt=ml&ti=45265&pw=68025)
+- [Patagonia](http://www.avantlink.com/click.php?tt=ml&ti=45781&pw=68025)
+
+#### Network
+
+- [Trail Forums](http://www.trailforums.com/)
+- Trail News
+
+#### About Us
+
+- [Contact](https://www.trailjournals.com/about/contact)
+- [Donate](https://www.trailjournals.com/about/donate)
+- [Join](https://www.trailjournals.com/join)
+- [Login](https://www.trailjournals.com/user/login)
+- [Help](https://www.trailjournals.com/help)
+
+#### Follow Us
+
+- [Facebook](https://www.facebook.com/trailjournals)
+- [Instagram](https://instagram.com/trailjournals/)
+- [Twitter](https://twitter.com/trailjournals)
+- [Pinterest](https://www.pinterest.com/trailjournals/)
+- [Linkedin](https://www.linkedin.com/company/trailjournals-llc)
+
+Top Photo © Cindy - The Appalachian Trail,
+04/01/2002 by
+[MrsGorp](https://www.trailjournals.com/journal/569)
+
+Trailjournals LLC © 2026
+All Rights Reserved. [privacy policy](https://www.trailjournals.com/about/privacy)
+
+Newburyport, MA 01950
+
+[Terms under which this service is provided to you.](https://www.trailjournals.com/about/privacy)
+
+Build: 20210226:165913 [Manage Settings](https://www.trailjournals.com/about/settings)
+---
+---
+date: '2010-04-23'
+start: Dick's Dome Shelter
+destination: Bear's Den Hostel
+miles_today: 18.3
+trip_miles: 989.8
+facts:
+  trail_section: Trail section from Dick's Dome Shelter to Bear's Den Hostel.
+  confidence: low
+---
+# Friday, April 23, 2010 — Bear's Den Hostel
+**Start Location:** Dick's Dome Shelter
+**Miles Today:** 18.30
+**Trip Miles:** 989.80
+
+Toggle navigation[Trail Journals](https://www.trailjournals.com/)
+
+- [Journals](https://www.trailjournals.com/journal/entry/306446#)  - [Journals](https://www.trailjournals.com/journals)
+  - [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail/2026)
+  - [Pacific Crest Trail](https://www.trailjournals.com/journals/pacific_crest_trail/2026)
+  - [Colorado Trail](https://www.trailjournals.com/journals/colorado_trail/2026)
+  - [Continental Divide Trail](https://www.trailjournals.com/journals/continental_divide_trail/2026)
+  - [Long Trail - Vermont](https://www.trailjournals.com/journals/the_long_trail_-_vermont/2026)
+  - [Florida Trail](https://www.trailjournals.com/journals/the_florida_trail/2026)
+  - [Arizona Trail](https://www.trailjournals.com/journals/arizona_trail/2026)
+  - [John Muir Trail](https://www.trailjournals.com/journals/john_muir_trail/2026)
+  - [Camino de Santiago](https://www.trailjournals.com/journals/camino_de_santiago/2026)
+  - [American Discovery Trail](https://www.trailjournals.com/journals/american_discovery_trail/2026)
+  - [Coast to Coast Walk](https://www.trailjournals.com/journals/coast_to_coast_walk/2026)
+  - [More...](https://www.trailjournals.com/journals/)
+- [Trails](https://www.trailjournals.com/trails/)
+- [Photos](https://www.trailjournals.com/photos/2026)
+- [Gear](https://www.trailjournals.com/journal/entry/306446#)  - [Current Sales](https://www.trailjournals.com/gear/deals/onsale)
+  - [REI](https://www.trailjournals.com/gear/rei)
+  - [ULA](https://www.trailjournals.com/gear/ula)
+  - [Patagonia](https://www.trailjournals.com/gear/patagonia)
+  - [Cabela's](https://www.trailjournals.com/gear/cabela)
+- [Planning](https://www.trailjournals.com/journal/entry/306446#)  - [Plan Your Hike](https://www.trailjournals.com/planning/)
+  - [Gear](https://www.trailjournals.com/gear/)
+  - [Books](https://www.trailjournals.com/books/)
+  - [Links](https://www.trailjournals.com/links/)
+- [Search](https://www.trailjournals.com/search/)
+- [About](https://www.trailjournals.com/journal/entry/306446#)  - [About Trailjournals](https://www.trailjournals.com/about/)
+  - [Login](https://www.trailjournals.com/user/login)
+  - [Join](https://www.trailjournals.com/join)
+  - [Support Trailjournals](https://www.trailjournals.com/about/donate/)
+  - [Contact](https://www.trailjournals.com/about/contact)
+  - [Store](https://www.trailjournals.com/store/)
+
+Backpacking Journals and Photos from Long Distance Hikers
+
+1. [Home](https://www.trailjournals.com/)
+2. [Journals](https://www.trailjournals.com/journals)
+3. [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail)
+4. [2010](https://www.trailjournals.com/journals/appalachian_trail/2010)
+5. [Uncle Frank](https://www.trailjournals.com/journal/10467)
+6. [Entries](https://www.trailjournals.com/journal/entries/10467/uncle%20-frank)
+7. April 23, 2010
+
+Toggle navigation
+
+- [Journal](https://www.trailjournals.com/journal/10467)
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+- [My Journals](https://www.trailjournals.com/myjournals/10467)
+- [View Guest Book](https://www.trailjournals.com/journal/guestbook/10467)
+- [Sign Guest Book](https://www.trailjournals.com/journal/guestbook/sign/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/8a.gif)
+
+[Journal](https://www.trailjournals.com/journal/10467)
+
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+
+--Choose--01/21/1002/06/1002/07/1002/08/1002/09/1002/10/1002/11/1002/12/1002/13/1002/14/1002/15/1002/16/1002/17/1002/18/1002/19/1002/20/1002/21/1002/22/1002/23/1002/24/1002/25/1002/26/1002/27/1002/28/1003/01/1003/02/1003/03/1003/04/1003/05/1003/06/1003/07/1003/08/1003/09/1003/11/1003/12/1003/13/1003/14/1003/15/1003/16/1003/17/1003/18/1003/19/1003/20/1003/21/1003/24/1003/25/1003/26/1003/27/1003/28/1003/29/1003/30/1003/31/1004/01/1004/02/1004/03/1004/04/1004/05/1004/06/1004/07/1004/08/1004/09/1004/10/1004/11/1004/12/1004/13/1004/14/1004/15/1004/16/1004/17/1004/18/1004/19/1004/20/1004/21/1004/23/1004/24/1004/25/1004/26/1004/27/1004/28/1004/29/1004/30/1005/01/1005/02/1005/03/1005/04/1005/05/1005/06/1005/07/1005/08/1005/09/1005/10/1005/11/1005/12/1005/13/1005/14/1005/15/1005/16/1005/17/1005/18/1005/19/1005/20/1005/21/1005/22/1005/23/1005/24/1005/25/1005/26/1005/27/1005/28/1005/29/1005/30/1005/31/1006/01/1006/02/1006/03/1006/04/1006/05/1006/06/1006/07/1006/08/1006/09/1006/10/1006/11/1006/12/1006/13/1006/14/1006/15/1006/16/1006/17/1006/18/1006/19/1006/20/1006/21/10
+
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+
+Guest Book
+
+- [Sign](https://www.trailjournals.com/journal/guestbook/sign/10467)
+- [View](https://www.trailjournals.com/journal/guestbook/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/8a.gif)
+
+- [AT Journals](https://www.trailjournals.com/journals/appalachian_trail)
+- [AT Photos](https://www.trailjournals.com/photos/appalachian_trail)
+- [AT Books](https://www.trailjournals.com/books/appalachian_trail)
+- [Appalachian Trail](http://www.appalachiantrail.org/)
+
+[Join](https://www.trailjournals.com/join) [Login](https://www.trailjournals.com/user/login)
+
+[RSS](https://www.trailjournals.com/journal/rss/10467/xml)
+
+# Uncle Frank's 2010  Appalachian Trail Journal
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/306443) [Next](https://www.trailjournals.com/journal/entry/307855) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+Friday, April 23, 2010
+
+Destination:Bear's Den Hostel
+
+Today's Miles:18.30
+
+Start Location:Dick's Dome Shelter
+
+Trip Miles:989.80
+
+Destination:Bear's Den Hostel
+
+Start Location:Dick's Dome Shelter
+
+Today's Miles:18.30
+
+Trip Miles:989.80
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/306443) [Next](https://www.trailjournals.com/journal/entry/307855) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+### Hiker Entries April 23, 2010
+
+|  | Journalist | Destination | Trail |
+| --- | --- | --- | --- |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DriveThruHikers_23038TN.jpg) | [Drive Thru Hikers](https://www.trailjournals.com/journal/about/23038) | [Pa 72, Swatara Gap](https://www.trailjournals.com/journal/entry/599583) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Transient](https://www.trailjournals.com/journal/about/13775) | [Lake Moreno](https://www.trailjournals.com/journal/entry/380532) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+|  | [RuhRoh](https://www.trailjournals.com/journal/about/13023) | [Harpers Ferry](https://www.trailjournals.com/journal/entry/366122) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010BigDaddy_5653TN.jpg) | [Big Daddy](https://www.trailjournals.com/journal/about/5653) | [Frazier Discovery trail](https://www.trailjournals.com/journal/entry/352581) | [Camino de Portugues](https://www.trailjournals.com/journals/Camino%20_de%20_Portugues) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2007IPOD_5637TN.jpg) | [IPOD](https://www.trailjournals.com/journal/about/5637) | [Frazier Discovery Trail](https://www.trailjournals.com/journal/entry/350441) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DidgeridudeandDoodlebug_9852TN.jpg) | [Didgeridude and Doodlebug](https://www.trailjournals.com/journal/about/9852) | [Unaka mtn](https://www.trailjournals.com/journal/entry/334637) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2014Sundance_6768TN.jpg) | [Sundance](https://www.trailjournals.com/journal/about/6768) | [Erwin TN](https://www.trailjournals.com/journal/entry/333763) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DannyGrady_10127TN.jpg) | [Teen Wolf](https://www.trailjournals.com/journal/about/10127) | [\-\- View Entry --](https://www.trailjournals.com/journal/entry/333586) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010EUREKA!_10324TN.jpg) | [Jerry from Kentucky](https://www.trailjournals.com/journal/about/10324) | [Beauty Spot](https://www.trailjournals.com/journal/entry/333258) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Conservation Branch Trail](https://www.trailjournals.com/journal/about/11319) | [Darien Lake Lean-to (Darien Lakes State Park)](https://www.trailjournals.com/journal/entry/332311) | [Finger Lakes Trail](https://www.trailjournals.com/journals/Finger%20_Lakes%20_Trail) |
+| [More...](https://www.trailjournals.com/entries/2010/04/23) [Grouped By Trail...](https://www.trailjournals.com/entries/2010/04/23/trail) |
+
+|     |
+| --- |
+| It's amazing while you sit home planning your hike and all the logistics that go with it. You start forming these images in your head of how the towns you will be walking through will look like or how the trail meanders through the mountains.<br>Boy was I off base... Pretty much just the opposite of what I envisioned.... <br>[Goliath](https://www.trailjournals.com/journal/entry/517326) —<br>[Pacific Crest Trail](https://www.trailjournals.com/journals/pacific_crest_trail) [2018](https://www.trailjournals.com/journals/pacific_crest_trail/2018) |
+
+[![Trailjournals](https://www.trailjournals.com/images/logo.png)](https://www.trailjournals.com/)
+
+#### Hiking
+
+- [Trails](https://www.trailjournals.com/trails/list)
+- [Journals](https://www.trailjournals.com/journals)
+- [Photos](https://www.trailjournals.com/photos)
+- [Calendar](https://www.trailjournals.com/calendar)
+- Gear
+- [Links](https://www.trailjournals.com/links)
+
+#### Partners
+
+- [ULA Equipment](https://ula-equipment.sjv.io/drN9K)
+- [REI](http://www.avantlink.com/click.php?tt=ml&ti=45265&pw=68025)
+- [Patagonia](http://www.avantlink.com/click.php?tt=ml&ti=45781&pw=68025)
+
+#### Network
+
+- [Trail Forums](http://www.trailforums.com/)
+- Trail News
+
+#### About Us
+
+- [Contact](https://www.trailjournals.com/about/contact)
+- [Donate](https://www.trailjournals.com/about/donate)
+- [Join](https://www.trailjournals.com/join)
+- [Login](https://www.trailjournals.com/user/login)
+- [Help](https://www.trailjournals.com/help)
+
+#### Follow Us
+
+- [Facebook](https://www.facebook.com/trailjournals)
+- [Instagram](https://instagram.com/trailjournals/)
+- [Twitter](https://twitter.com/trailjournals)
+- [Pinterest](https://www.pinterest.com/trailjournals/)
+- [Linkedin](https://www.linkedin.com/company/trailjournals-llc)
+
+Top Photo © Cindy - The Appalachian Trail,
+04/01/2002 by
+[MrsGorp](https://www.trailjournals.com/journal/569)
+
+Trailjournals LLC © 2026
+All Rights Reserved. [privacy policy](https://www.trailjournals.com/about/privacy)
+
+Newburyport, MA 01950
+
+[Terms under which this service is provided to you.](https://www.trailjournals.com/about/privacy)
+
+Build: 20210226:165913 [Manage Settings](https://www.trailjournals.com/about/settings)
+---
+---
+date: '2010-04-24'
+start: Bear's Den Hostel
+destination: Blackburn Trail Center
+miles_today: 8.0
+trip_miles: 997.8
+facts:
+  weather: High 58°F, low 47°F. Dense drizzle.
+  trail_section: Trail section from Bear's Den Hostel to Blackburn Trail Center.
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+---
+# Saturday, April 24, 2010 — Blackburn Trail Center
+**Start Location:** Bear's Den Hostel
+**Miles Today:** 8
+**Trip Miles:** 997.80
+
+It was raining when I left the gazebo at Bear's Den. Several miles into the last leg of the "Roller Coaster", I hid from the wind and crawled under a slab of stone for a nap. I woke up feeling discouraged and angry. I planned on meeting Sean in Harper's Ferry that day (18 miles), but a mid-day stop at Blackburn Trail Center became my stop for the night. Here's why: Cold, hungry and above all immensely bored of walking (to the point of anger), I arrived at Blackburn after a measely 8 miles from Bear's Den. The the door a lady loaded groceries from the car trunk, and I offered a hand. Rita was a long-time ATC employee who now works with local schoolteachers to incorporate the Appalachian Trail into the curriculum. That very moment, a high school group was hiking towards the Trail Center for an end-of-semester field trip. They would hike in, spend the night, and hike out the next day. Rita was unloading groceries to feed the group, and she tried convince me to stay for dinner while feeding me strawberries, cheese, and salad greens. The kids would love to meet a thru-hiker, she said. Her food bribe worked and I called Sean to change plans.
+
+Sean arrived around dusk and we ate with the group. After dinner, we drove to Harper's Ferry and skateboarded around town and drank beer by the railroad tracks. A train flattened a penny and I decided I'd carry it the rest of the way to Maine. On the way home we did some doughnuts in a field and stopped to shoot pellets at empty cans.
+
+It was a great night, and I really appreciated all the energy Sean brought into a phase in my hike which, at the moment, was feeling pretty drab.
+---
+---
+date: '2010-04-25'
+start: Blackburn Trail Center
+destination: Harper's Ferry Hostel
+miles_today: 12.5
+trip_miles: 1010.3
+facts:
+  weather: High 70°F, low 46°F. Moderate rain.
+  trail_section: Trail section from Blackburn Trail Center to Harper's Ferry Hostel.
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+---
+# Sunday, April 25, 2010 — Harper's Ferry Hostel
+**Start Location:** Blackburn Trail Center
+**Miles Today:** 12.50
+**Trip Miles:** 1010.30
+
+Sean and I slept in the car that night. We got up, yogi-ed from pineapple juice and scrambled eggs from the high school group. By 9 o'clock we were hiking on the AT to a gap 5 miles away, where a parent chaperone kindly agreed to shuttle Sean's car. Sean and had some good conversation, which honestly we don't do much of. When I'm with Sean it's alot of action and not alot of idle chit-chat, but a causual hike was a good combination of the two.
+
+For the first time in the trip, I decided to skip a 7-mile section from the road to Harper's Ferry, so Sean and I drove into town to eat and drop me off at the hostel for the night. A quick disclaimer on the trail-skipping: First of all, I ended up going back that day and hiking the section, so I didn't end up skipping any miles. It was less guilt than boredom that led me to hitch back to the trail (after a thousand miles my trail-morals are going gray). I just didn't feel like sitting around the hostel until the owner returned.
+
+Well, the rest of the hike was nice. I trail-ran most of the way (with no food my pack was light as a feather), stopping every couple minutes to listen to the thunder of a a swift-approaching thunderstorm. At the Potomac River I yipped and yelled and danced across the bridge. Cars honked at me and I honked back. I was excited because Harper's Ferry was the half-way point, and I was crossing into it. One of those trip milestones.
+
+At Harper's Ferry the storm hit. I still had 4 miles to cover, including a time-consuming stop to register as a "thru-hiker" at the Appalachian Trail Conservancy HQ. I chatted with lady at the AT HQ and decided that, though she was maybe 40, I would have asked her on a date had the time been right. Nomads don't go on dates.
+
+Lightning exploded overhead and torrential rain came rushing down the old stone steps into downtown Harper's Ferry (the trail passes right through town). I thought about the probability of being struck and decided it wasn't high enough to warrant a stop, so I kept hiking towards the hostel.
+
+The storm cleared and I arrived at the hostel at dusk. I sure do love a post-storm evening, when the air smells like rain and lightening and the birds aren't sure if they should come back out or call it for the night. At the hostel I tore into a maildrop and chowed on a bag of home-made muffins (THANKS MA!!!). I greeted Kevin, my Smoky-Mountains hiking partner, after nearly 2 months of separation. Pancakes were free, so I cooked a couple before bed. Kevin, Muffin-Mit and I planned to hike 40 miles the next day (a.k.a. the Maryland Challenge, where hikers enter Maryland from W.Va and leave it into Penn. in the same 40-mile day.).
+---
+---
+date: '2010-04-26'
+start: Harper's Ferry Hostel
+destination: Pine Knob Shelter
+miles_today: 22.9
+trip_miles: 1033.2
+facts:
+  trail_section: Trail section from Harper's Ferry Hostel to Pine Knob Shelter.
+  confidence: low
+---
+# Monday, April 26, 2010 — Pine Knob Shelter
+**Start Location:** Harper's Ferry Hostel
+**Miles Today:** 22.90
+**Trip Miles:** 1033.20
+
+A rainy day and lonely hike to Pine Knob. Failed the Maryland Challenege thanks to a big pancake breakfast, a late start, and a steady, disheartening downpour throughout the day. Talked to myself in Spanish and a New Zealand accent for several hours out of boredom. Spent an hour in a shelter writing a rap song while the lightening passed. Got the Pine Knob in the dark.
+---
+---
+date: '2010-04-27'
+start: Pine Knob Shelter
+destination: near Devil's Racecourse Shelter
+miles_today: 13.1
+trip_miles: 1046.3
+facts:
+  trail_section: Trail section from Pine Knob Shelter to near Devil's Racecourse Shelter.
+  confidence: low
+---
+# Tuesday, April 27, 2010 — near Devil's Racecourse Shelter
+**Start Location:** Pine Knob Shelter
+**Miles Today:** 13.10
+**Trip Miles:** 1046.30
+
+A really crappy day. I'd been excited at the hostel to run into two fellow thru-hikers (I was desperate for some company for motivation), but one was already a day ahead and another a day behind. I was alone again, and it had it's effects. I trudged along all day, eating way too much food and covering way too few miles. I stopped at the trailhead leading to Devil's Racecourse Shelter and didn't even have the motivation to walk the 0.3 miles to the shelter itself, so I rolled out my sleeping bag right there and fell asleep for the night. What a bad day.
+---
+---
+date: '2010-04-28'
+start: near Devil's Racecourse Shelter
+destination: Tumbling Run Shelters
+miles_today: 13.2
+trip_miles: 1059.5
+facts:
+  weather: High 53°F, low 36°F. Overcast.
+  trail_section: Trail section from near Devil's Racecourse Shelter to Tumbling Run
+    Shelters.
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+---
+# Wednesday, April 28, 2010 — Tumbling Run Shelters
+**Start Location:** near Devil's Racecourse Shelter
+**Miles Today:** 13.20
+**Trip Miles:** 1059.50
+
+Met up with the Georgia boys today. Like a dream-come-true, the caught up to me near the Pennsylvania-Maryland border as I stood on the railroad tracks looking dazed and confused (which I was). An hour before, I'd curled up in a bathroom in a park and awoken to a old man poking me with his trash-picker. "Wake up! What are you doing here," he demanded. I told him the wind was cold and I was a tired hiker, and he told me to fetch some fried chicken and a half-drinken bottle of lemonade. I had a piece left, and I gave it to the Georgia boys to split. Reckless and Boomerang were they're names, and I let out a sigh of relief: I'd found some good hiking partners at last.
+
+We hiked to the Tumbling Run Shelters that night, only a 13 mile day for me but a 26 mile day for them. There were two shelters, one for "SNORING" and the other labeled "NON-SNORING". Boomerang carries a guitar, so he played an old Texas tune as I drifted to sleep. I slept outside the shelter on the picnic table and woke up to some brilliant stars.
+---
+---
+date: '2010-04-29'
+start: Tumbling Run Shelters
+destination: Tom's Run Shelters
+miles_today: 25.8
+trip_miles: 1085.3
+facts:
+  weather: High 63°F, low 36°F. Overcast.
+  trail_section: Trail section from Tumbling Run Shelters to Tom's Run Shelters.
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+---
+# Thursday, April 29, 2010 — Tom's Run Shelters
+**Start Location:** Tumbling Run Shelters
+**Miles Today:** 25.80
+**Trip Miles:** 1085.30
+
+A good day with the Georgia boys. I left early and hiked the first 10 miles alone, and at noon we met up and hiked together for the last 16 miles. During our lunchbreak, we bummmed fresh milk, carrots, bananas, and pretzels off a state-sponsored pre-school group that had extra. "They give us way too much food," said the chaperone. A black girl about our age swatted at gnats and asked us how we'd spend 2 months in the woods. "I'm like...\*swat\*...like I can't stand it out here!," she said. We laughed. We talked about how much we'd like to see a pretty girl, and Reckless produced a zip-lock back. He showed us a photo of his pretty girlfriend and unzipped the bag to let us smell the contents, a perfumed-scented letter from her. He smiled proudly.
+
+We made it to the shelter in good time that night, and I boiled water over the fire with my pot. I was hungry and out of food (thanks to gorging 2 days before), and I went to bed with my stomach growling. The next morning, we planned to pass the official halfway point of the AT (Milepost 1089.55) and continue three miles into Pine Furnace State Park to accomplish the "Half-Gallon Challenge". As tradition goes, thru-hikers mark the mid-point by consuming an absurd amount of ice-cream.
+
+"I'm listening to Boomerang sing 'Ain't Never Gonna Be Satisfied' on his guitar, and I'm thinking about the 1/2 Gallon Challenge tomorrow and wondering how true that is," said my entry into the shelter logbook.
+---
+---
+date: '2010-04-30'
+start: Tom's Run Shelters
+destination: north of Boiling Springs
+miles_today: 27.8
+trip_miles: 1113.1
+facts:
+  weather: High 78°F, low 45°F. Overcast.
+  trail_section: Trail section from Tom's Run Shelters to north of Boiling Springs.
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+---
+# Friday, April 30, 2010 — north of Boiling Springs
+**Start Location:** Tom's Run Shelters
+**Miles Today:** 27.80
+**Trip Miles:** 1113.10
+
+A good hard day of hiking. After waiting around until noon for the owner of the general store, we abandoned the "1/2 Gallon Challenge" and started hiking. For nearly 7 hours we hiked hard, racing across the 22 miles to Boiling Springs. I was ahead of the Georgia Boys by an hour, and I met up with a couple at Boiling Springs and they invited me for a picnic. Fresh flatbread with roastbeef, cheese and mustard, triscuts with hummus, grapes and an apple, fig-newtons, and several cups of fruit juice! I thanked them and moved on around sunset. This area, called the Cumberland Gap, was the first break in mountains on the AT. The Georgia Boys stayed in town, but I ambled along into the night down narrow corridors of woods between huge corn fields. I stopped to watch a big fireworks show by some locals. I slept in a field under the moon and stars. Tomorrow, I'd meet up with my dad.
+---
+---
+date: '2010-05-01'
+start: north of Boiling Springs
+destination: Red Roof Inn (Duncannon, PA)
+miles_today: 20.7
+trip_miles: 1133.8
+facts:
+  trail_section: Trail section from north of Boiling Springs to Red Roof Inn (Duncannon,
+    PA).
+  confidence: low
+---
+# Saturday, May 01, 2010 — Red Roof Inn (Duncannon, PA)
+**Start Location:** north of Boiling Springs
+**Miles Today:** 20.70
+**Trip Miles:** 1133.80
+
+Hiked relentlessly through the heat to meet my Dad at the gap by noon. Stopped to get some water from a farm hose and a cyclist rode by and said, "You're not going to get there by sitting here!". Thanks, man.
+
+From the shade I saw a day-hiker walk by. Yes! The motivation of company! I followed behind the day-hiker, a local lawyer, to ride out my exhaustion. Several miles from the gap, I took off running and made it just as my Dad pulled up. We hugged, laughed, high-fived, and hugged again. It was good to feel back home again, even it I was in Pennslyvania.
+
+The rest of the hike was only 10 miles, but I was struggling. The sprint to meet my Dad had bruised my feet, so I was in alot of pain as we climbed the last ridge before Duncannon. It was great being with Dad, however. His dry humor and lemonade-out-of-lemons attitude really kept me going. He also got to see me feeling crappy and how I dealt with it, which I appreciated. Now he knows.
+
+We limped into town and got Gatorades, and it was the best-tasting Gatorate I've ever had. Maybe it was the heat, maybe it was the hunger, but I swear it was the best Gatorade I've ever had. We got to his car, and ate Mom's blond-brownies on the way to the hotel. That night we went to an Italian resaurant to eat. I had an AWESOME grilled salmon. We got coffee afterwards, bought some atheletic shorts and new socks, and hung out at the bookstore until 11. I stayed up until 2:30 getting my iPod all "synced". That's right, Ford Prior has let an iPod infiltrate his pure, all-natural AT "vision-quest". Let me just say this: it's necessity, okay? I'm about to die of boredome here. The other day I told a lady I was bored out of my mind and she said, "How do you get bored of these beautiful woods?!" I bit my tongue but wished to say, "Listen, lady: YOU hike 1,000+ miles and then come talk to me."
+
+I took my sleeping medicine for the first time in 2+ weeks and I slept great that night.
+---
+---
+date: '2010-05-02'
+start: Red Roof Inn (Duncannon, PA)
+destination: Peters Mountain Shelter
+miles_today: 11.2
+trip_miles: 1145.0
+facts:
+  weather: High 82°F, low 62°F. Slight rain.
+  trail_section: Trail section from Red Roof Inn (Duncannon, PA) to Peters Mountain
+    Shelter.
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+---
+# Sunday, May 02, 2010 — Peters Mountain Shelter
+**Start Location:** Red Roof Inn (Duncannon, PA)
+**Miles Today:** 11.20
+**Trip Miles:** 1145
+
+I woke up early, about 6:30, and was stirring around. Dad got up quick like he always used to do, looking in need of a cup of coffee yet somehow also ready for the day. I love waking up with Dad. It reminds me of getting up at sunrise with him at the beach and taking long walks along the surf.
+
+Dad went and got some coffee while I packed up my things. We got in the car and drove to Cracker Barrel. I had 2 eggs, 2 slices of bacon, and 2 pancakes logged with maple syrup. We laughed and joked around.
+
+Next we drove to the grocery. I needed a resupply, and so Dad and I walked the aisles with a 4-day food plan written on a wrinkled notepad. It was a surprisingly tedious and consequently stressful affair. Each item's location in the store had nothing to do with the other items' locations. No easy A,B,C, arrangement; no map to follow; few employees to show the way. I left the grocery feeling wound up and taking a deep breath.
+
+It was 11:00 am. I was to hit the trail at 2:30, so Dad and I spend the next couple hours lounging at the bookstore. He patiently read a book while I updated my journal and drank coffee. Outside, the clouds looked ominous; heavy rains were fore casted for the afternoon. For an hour or two we hung out in the bookstore. I wish we could've chatted and played putt-putt or something.
+
+It was time to part ways, and I could feel in my stomach. We got 5 Guys for lunch and drove back to Duncannon. I hated it, sitting there about to leave, taping my feet and packing my pack with Dad right there. "Wanna get a beer?" I pleaded. No, he said. I had to get going. We hugged and I said "Damn it" and shook my head. It really sucked, and I kept shaking my head as I turned and walked off. Too bad I had to go my way and he had to go his. Too bad we couldn't of just gone together. I love my Dad, man. I've said it before and I'll say it again: he's my best friend.
+
+It was 4:00 PM and I waited for the downpour. Skies were gloomy and loaded with wetness. For 11 miles I walked with ease, listening to a Fleet Foxes album and a Corey Widmer sermon about wisdom. "The sages of Proverbs say that there are two paths before us: the path of Life and the path of Death," he said. He said our walk is a crooked march for Life that always draws like a magnet towards the path of Death. As we stumble between the two paths, we're confronted by situations that confuse us. These situations are entirely unique. They're unhelped by extensive self-help knowledge and generally-accepted tricks and unhelped by an understanding of black-and-white lines of morality. That is, these situations need WISDOM from above because Self-Help books and the 10 Commandments don't cut it. He mentioned that wisdom is a path to follow, not just some door to open. I took off my iPod and decided to listen to the birds (a little wiser, eh?).
+
+The rain held off on me all the way to the shelter. Only at the very end did it come down. At the shelter I met up with Reckless and Boomerang, including 2 flip-floppers and another thru-hiker named Muffin-Mittens. I broke out the banana bread from Mom and everyone dug in.
+
+The rain came down hard that night, and I filled up my water bottle with brown-tinted rainwater pouring from the gutters. Unhealthy? Most likely.
+---
+---
+date: '2010-05-03'
+start: Peters Mountain Shelter
+destination: Rausch Gap Shelter
+miles_today: 18.0
+trip_miles: 1163.0
+facts:
+  weather: High 77°F, low 66°F. Moderate rain.
+  trail_section: Trail section from Peters Mountain Shelter to Rausch Gap Shelter.
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+---
+# Monday, May 03, 2010 — Rausch Gap Shelter
+**Start Location:** Peters Mountain Shelter
+**Miles Today:** 18
+**Trip Miles:** 1163
+
+Oh, what a day. I left before 7am, while the rest were still asleep. The rain was gone but the forest was dripping and moist, and sharp-toothed gnats swarmed my face (these gnats are a bold species, unafraid to kamakazi into the ears and eyes). For some reason I was very tired, so I covered myself with a poncho and laid down for a nap nearly 10 miles into the day. I got up again, and again was overwhelmed with sleepiness. By mid-morning the last of the northbound pack passed me. I woke up and tried to catch up but still fatigue struck me down. Let me say here that it's times like these that I hate my narcolepsy; it's times like these that if feels like a real disability. I don't get angry at it. I just feel wronged by it sometimes.
+
+After my 3rd nap, I woke up and began walking. If I walked fast enough, I'd catch the group taking their lunchbreak. Well, I walked in the wrong direction...for 1.5 hours. I ran into Sampson (the flip-flopper), who I thought had passed me. "Hey man, did you turn around?" I said, quickly realizing by his face that something was amiss. "You're not heading North, are you?". He affirmed. I cursed aloud several times in front of Sampson, thanked him, and turned around. I cursed again and again. Between 6 and 8 miles lost. I was very angry. Rain showers came and went.
+
+Just before sundown I arrived at Rausch Gap Shelter. Sampson was there (he passed me during another nap) with another flip-flopper named Rewind. I ate and put up my feet. It would be another 14 miles to catch the others, and 14 miles meant a long night of hiking. HYOH (Hike Your Own Hike), I said to myself: I just didn't feel like moving along. It was a bad day and it felt better at the shelter. Happily, I shucked off the guilt of not hiking on and settled down for the night. That decision redeemed my day. By the way, Rausch Gap Shelter is awesome. Someone built a spring-fed retangular dish that constantly overflows with cold water. That night I slept great.
+---
+---
+date: '2010-05-04'
+start: Rausch Gap Shelter
+destination: The Pavilion (Port Clinton, PA)
+miles_today: 42.0
+trip_miles: 1205.0
+facts:
+  weather: High 74°F, low 56°F. Light drizzle.
+  trail_section: Trail section from Rausch Gap Shelter to The Pavilion (Port Clinton,
+    PA).
+  town_events: Day 110 | Port Clinton PA | Appalachian Trail Thru-hike
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+  - https://www.youtube.com/watch?v=cClKiaJlYFg
+---
+# Tuesday, May 04, 2010 — The Pavilion (Port Clinton, PA)
+**Start Location:** Rausch Gap Shelter
+**Miles Today:** 42
+**Trip Miles:** 1205
+
+That's right: 42 miles! Hard to believe but here it goes:
+
+It all started with a fresh start at sunrise. At the shelter the orange sun broke through the green canopy. The air was moist and filled with energy. I hit the trail at 6:45 and listened to my iPod for about an hour while munching on Muenster cheese. I stopped under an overpass for a 40-minute nap at about 9:15 am. An hour later, I had to throw my pack over a deep stream and leap over (kinda fun). For the 13 miles between my nap and the shelter I felt great. It was about noon, and I decided that I'd catch up that night. 42 was a big number, but I didn't really think about that. I just decided to go and went.
+
+At the 501 Shelter I found some instant coffee mix and shook up at water bottle of extremely-strong brew, probably as powerful as an espresso. I ate sunflower seeds and sipped on the potion as I march on. No foot or joint problems, no debilitating sleepiness. I felt strong as a bull. I never listened to my iPod. I was fine without it, rather enjoying rapping to myself with surprising flow (I'm secretly convinced that I could be a rapper if I tried). A strange isolated storm blew up from nowhere and narrowly missed me.
+
+It was almost dusk and I was about 16 miles from Port Clinton. I found myself staring at the sky at a road crossing, and suddenly an SUV came speeding akwardly towards me IN REVERSE. The car had slammed on the brakes and reversed back up to meet, and an Amish-looking bearded man rolled down the window. "You thru-hiking?" I said yes. "How does a fresh hot meal sound?". "Ahhhhh," I said, "I'm kinda on a time schedule. It's already going to be a late night." Then I paused and thought: you know, this may never happen again. Meanwhile, his son stared awkwardly. "You now what, screw it man! I'd love a hot meal." I hopped in.
+
+His name was Longnecker, and this was "Longnecker Country," he said. Sure enough, we passed his brother's house, his father's house, his sister's house, and the homes of several other family members on the way to Longnecker's place. It sat on the hilltop with a beautiful view of the valley. He had an enormous family, I guess a tradition of the Church of the Bretheren. I waded through kids to get from the car to the front door--actually, they kind of parted for me and stared curiously as I walked through. Upon entering the house (of modest size, I should note), Longnecker told his wife that "I've brought home a hiker! Can you hurry up? He needs to get back to the trail." She was a kind woman. Before dinner, I sat on the couch and talked to Longnecker. At least 10 kids surrounded us and listened quietly. At dinner call we all seated ourselves around a large table. Enchiladas, a salad, cookies, and a glass of milk was the dinner, and it was DELICIOUS. Everyone (even both parents), dipped their cookies in the milk. In fact, the mother even broke up a cookie for the smallest child and dipped it in for her! I thought that was interesting. A "thank you" and back to the trail.
+For the first hour I listened to the iPod, but soon darkness fell and I put it away (the night always makes me paranoid). It was a long and hard 16 miles but at last it was over. I trudged proudly into the shelter at 12:30 AM and collapsed. My feet were in bad shape, which I only realized after stopping for several minutes. The skin was white and blisters blood-red. I looked in the trashcan: three half-empty ice cream containers told me the boys had attempted the "Half-Gallon Challenge" and failed miserably. I polished off a box of cookie dough and fell asleep.
+---
+---
+date: '2010-05-05'
+start: The Pavilion (Port Clinton, PA)
+destination: Allentown Hiking Club Shelter
+miles_today: 22.6
+trip_miles: 1227.6
+facts:
+  weather: High 77°F, low 51°F. Clear sky.
+  trail_section: Trail section from The Pavilion (Port Clinton, PA) to Allentown Hiking
+    Club Shelter.
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+---
+# Wednesday, May 05, 2010 — Allentown Hiking Club Shelter
+**Start Location:** The Pavilion (Port Clinton, PA)
+**Miles Today:** 22.60
+**Trip Miles:** 1227.60
+
+In the morning my feet were really feeling the 42 miles from the day (night) before. My legs, too. We took a late start and walked over to 3 C's Diner for some pancakes and eggs. By 11:30 we left Port Clinton for Allentown, only 23 miles away.
+
+I napped at the first shelter and everyone passed me (as usual). I wasn't concerned by being behind, and lounged at the shelter for over an hour. The rest of the day was nice and kind of boring. You know, I'm kinda getting used to these long boring days in the sunlight. The gnats were obnoxious and I did get immensely bored with myself, but overall it wasn't so bad. I didn't even listen to the iPod much. I saw a couple day-hikers but not many people. The terrain was mild. For the last 2 hours I listened to the Lewis & Clark audiobook (Undaunted Courage), but at nightfall I cut it off. For 30 minutes I walked over sharp stones in near-darkness, impressed with my own depth-perception in dim light. When I saw the shelter I almost giggled with joy. I joked with the boys and ate some jerky before falling asleep. I woke up and ate some more nibbles.
+---
+---
+date: '2010-05-06'
+start: Allentown Hiking Club Shelter
+destination: The Jailhouse Hostel (Palmerton, PA)
+miles_today: 18.0
+trip_miles: 1245.6
+facts:
+  trail_section: Trail section from Allentown Hiking Club Shelter to The Jailhouse
+    Hostel (Palmerton, PA).
+  town_events: Day 87 | Hiking Into Palmerton, PA | Appalachian Trail Thru Hike 2021
+  confidence: low
+  sources:
+  - https://www.youtube.com/watch?v=ElpZWqtRryE
+---
+# Thursday, May 06, 2010 — The Jailhouse Hostel (Palmerton, PA)
+**Start Location:** Allentown Hiking Club Shelter
+**Miles Today:** 18
+**Trip Miles:** 1245.60
+
+Not a bad day (it's funny how negativity is the standard...that is, a day is expected to be bad and it's worth noting if it's not). I hiked alone until I got tired of hiking alone, then waited for the others to catch up. For the rest of the day we all hiked together, talking and laughing and stopping at a shelter for lunch. On the way down to Palmerton, Boomerang fell hard with his 45 lbs. pack and busted his knee, so I gave him 6 ibuprofen and carried his pack the rest of the 8 miles into town. I parted wit the boys and hitched to the Fine Lodge in Slatington to grab a mail-drop. We'd meet in Palmerton that evening. It was 4:00. My ride was a boisterous dad with black sunglasses and a black sleeveless t-shirt driving a big shiny black SUV. He had two sons and was a big Steelers fan. The Fine Lodge was a strange place. Disheveled people milled about listlessly, and I wondered where they were headed in life. I waited about 45 minutes for the proprietor to give me a free ride to Palmerton, and ate all my Mom's brownies.
+
+I dropped my pack in the hostel (the basement of the Police Station) and walked out to find the boys. I questioned some old ladies about their whereabouts ("I think they passed by. No they didn't. Wait, they did!"), a waitress who gave me a dirty look, a weird guy walking around with his shirt off, and several mentally-retarded guys sitting on a park bench (they couldn't really communicate, but I talked to them like they weren't disabled at all. I think ignoring their disability is the greatest gift a stranger can give the disabled) It was a strange town. I found the boys at a Pizza place. A guy pestered us and interrupted our conversation with stupid questions about hiking, and I told him I carried a pistol at all times.
+
+That night I took a shower and slept alright. A flip-flopper named Biff was snoring terribly and keeping all of us awake (we were having a conversation about how bad it was as Biff snored on), so I woke him up and asked him to roll over. That did it and the rest of the night was soundless.
+---
+---
+date: '2010-05-07'
+start: The Jailhouse Hostel (Palmerton, PA)
+destination: Kirkridge Shelter
+miles_today: 29.8
+trip_miles: 1275.4
+facts:
+  trail_section: Trail section from The Jailhouse Hostel (Palmerton, PA) to Kirkridge
+    Shelter.
+  town_events: A.T. Community™ Program - Appalachian Trail Conservancy
+  confidence: low
+  sources:
+  - https://appalachiantrail.org/protect/conservation/at-community-program/
+---
+# Friday, May 07, 2010 — Kirkridge Shelter
+**Start Location:** The Jailhouse Hostel (Palmerton, PA)
+**Miles Today:** 29.80
+**Trip Miles:** 1275.40
+
+I had an early breakfast of a Farmer's Omelet at the diner before Duane the Pest Control Man shuttled us back to the trail head. The first ascent of the day as a near-vertical rock climb. Shocked my the ridiculous angle, Reckless paused to take a photo of me. We'd switched iPods because he wanted to hear the Into Thin Air audiobook. The next 8 miles traversed a mountainside leveled for zinc-mining many years before and still classified as a Superfund Site. It was strangely open and grassy and, in fact, prettier than the rest of PA. Several hours of fast and strong hiking brought us (Reckless, Boomerang, Muffin Mittens and I) to a grassy spot in the woods. I had a good conversation with Muffin Mittens about his 6 years of service in the U.S. Army. I took a nap and the group moved on.
+
+The naps multiplied as often do, and soon I was hours behind the group. I just didn't care. I made it to the shelter after a long and obnoxious night hike through some of the worst rocky sections we'd yet crossed. My feet were killing me.
+
+Oh yea! And tonight we caught up with Fahma and Klipspringer. More on that later, but for tonight I slept well.
+---
+---
+date: '2010-05-08'
+start: Kirkridge Shelter
+destination: Church of the Mountain Hostel (Delaware-Water Gap)
+miles_today: 6.5
+trip_miles: 1281.9
+facts:
+  weather: High 67°F, low 53°F. Light drizzle.
+  trail_section: Trail section from Kirkridge Shelter to Church of the Mountain Hostel
+    (Delaware-Water Gap).
+  town_events: Pocono Mountains Towns and Villages - Delaware Water Gap
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+  - https://www.youtube.com/watch?v=1LcdZYB3gNE
+---
+# Saturday, May 08, 2010 — Church of the Mountain Hostel (Delaware-Water Gap)
+**Start Location:** Kirkridge Shelter
+**Miles Today:** 6.50
+**Trip Miles:** 1281.90
+
+Our "near-o" day. Late start, time alone at shelter, sunny walk down to town, Ben & Jerry's Pint, beer and pizza, pie and hotdog, homemade cookies, alot of old hikers, early bedtime
+---
+---
+date: '2010-05-09'
+start: Church of the Mountain Hostel (Delaware-Water Gap)
+destination: Brink Rd. Shelter
+miles_today: 25.0
+trip_miles: 1306.9
+facts:
+  weather: High 51°F, low 38°F. Overcast.
+  trail_section: Trail section from Church of the Mountain Hostel (Delaware-Water
+    Gap) to Brink Rd. Shelter.
+  town_events: 'Appalachian Trail Community: Delaware Water Gap'
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+  - https://appalachiantrail.com/20140626/appalachian-trail-community-delaware-water-gap/
+---
+# Sunday, May 09, 2010 — Brink Rd. Shelter
+**Start Location:** Church of the Mountain Hostel (Delaware-Water Gap)
+**Miles Today:** 25
+**Trip Miles:** 1306.90
+
+Breakfast (2 eggs and 2 bacon between 2 slices of Rainsin bread smeared w/ honey), good quick day (I kept up and didn't nap until last 3 miles), MOuntain House w/ water boiled over fire, NO BEARS, 1st Day in NJ ain't bad
+---
+---
+date: '2010-05-10'
+start: Brink Rd. Shelter
+destination: The Mayor's House (Unionville, NY)
+miles_today: 27.0
+trip_miles: 1333.9
+facts:
+  trail_section: Trail section from Brink Rd. Shelter to The Mayor's House (Unionville,
+    NY).
+  town_events: Into and out of Unionville, NY (MM 1342-1354) - YouTube
+  confidence: low
+  sources:
+  - https://www.youtube.com/watch?v=46llWpFxWjI
+---
+# Monday, May 10, 2010 — The Mayor's House (Unionville, NY)
+**Start Location:** Brink Rd. Shelter
+**Miles Today:** 27
+**Trip Miles:** 1333.90
+
+We awoke in the shelter shivering. It had been a cold night, and I was just warm enough to sleep. I didn't want to get out of my bag, but at last I unzipped and jumped to my feet. A quick pack-up and we hit the road to Unionville, some 27 miles away. The first several hours of hiking were pleasant. We stopped at a deli for a breakfast sandwich and coffee, then continued sleepily. Today we talked and joked happily, and the miles passed by quickly. For 2 hours I listened to Guns, Germs, and Steel on audiobook. Before I knew it, we were only 9 miles from Unionville, and Reckless did a commendable job keeping me awake. At one point, he saw I was dragging with sleepiness and screamed as loud as he could. The scream jerked me awake and I was fine for the rest of the day. I owe him one for that.
+
+At the road, the hostel owner picked us up. "If you call me sir one more time I'm gonna hit you," he told Reckless. He was a hilarious guy, hilarious not in a clever way but in a ridiculous way. "We're gonna bust your balls," he said. "You get one free beer and the rest are 50 cents. You must take a shower. Dinner'll be ready soon so get showered quickly." He did a great job of making us feel at home, and that, he said, was his mission: "You see that sign by the door? It says, 'When you leave this home, you are friends.' The last word should be 'brothers,'" he said. He believed strongly in the verse: I am my brother's keeper, and I deeply respected him for it. In return, "We think what you guys are doing is f\*\*\*ing stupid, but we respect you for it," he said. "The Mayor beleives in starting what you finnish."
+
+the old guy cussing, visit to the grocery store, the video of britians got talent, finding out about kevin
+
+It's 2:49 am, I'm dead tired, and the Mayor is getting us up at 6:30 tomorrow so I've got to cut this short. THanks for reading everyone. Until next entry.
+---
+---
+date: '2010-05-11'
+start: The Mayor's House (Unionville, NY)
+destination: Linden Motel pool house (Greenwood Lake, NY)
+miles_today: 26.8
+trip_miles: 1360.7
+facts:
+  weather: High 52°F, low 36°F. Overcast.
+  trail_section: Trail section from The Mayor's House (Unionville, NY) to Linden Motel
+    pool house (Greenwood Lake, NY).
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+---
+# Tuesday, May 11, 2010 — Linden Motel pool house (Greenwood Lake, NY)
+**Start Location:** The Mayor's House (Unionville, NY)
+**Miles Today:** 26.80
+**Trip Miles:** 1360.70
+
+Old Bill, the miserable cursing caretaker at the Mayor's House ("You wanna buy a house? It comes with a dishwasher. His name's Bill," said Butch) woke us up at precisely 6:30 for a breakfast of sausage, eggs and hashbrowns. I drank several cups of strong black coffee and scarfed down the food. Several hours later, Butch was driving us to the trailhead. The morning passed nicely through cool forests and warm fields. Before noon we stopped at a rocky overlook for a 20-minute snack break. We marched on.
+
+As morning passed to afternoon, sleepiness came over me; still, I kept walking. By 4:00 I could barely walk out of weariness. Boomerang and Reckless tried in vain to keep me awake (we'd been hiking together all day), and I say with no exaggeration that it was the most tired I'd ever been. At last I collapsed on the trail for a 10-minute combat nap. The Georgia boys walked on. Within 30 minutes of awakening I caught up to cover the last 8 miles with them. The smooth blue of Greenwood Lake lay down in the valley, looking flat and pure against the patchy green-cottonball mountains. The lake was huge, perfect for sailing.
+Greenwood Village, situated on the lake's shore and .9 miles from the AT, was a nice town. Kids played backyard ball and on playgrounds, filling the evening with the sounds of summer. "I'm feelin' that summer vibe," I told the Georgia boys, "and I like it." A guy gave us a lift to the Chinese Buffet in town, and after eating (I didn't eat much) walked over to the Linden Motel. Anticipating bad weather that night, we had arranged to sleep in the Linden's poolhouse for free. I bought a Snickers bar and went to sleep with knife in hand.
+---
+---
+date: '2010-05-12'
+start: Linden Motel pool house (Greenwood Lake, NY)
+destination: Fingerboard Shelter
+miles_today: 16.4
+trip_miles: 1377.1
+facts:
+  weather: High 48°F, low 38°F. Slight snow.
+  trail_section: Trail section from Linden Motel pool house (Greenwood Lake, NY) to
+    Fingerboard Shelter.
+  town_events: Appalachian Trail view near Greenwood Lake - Facebook
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+  - https://www.facebook.com/groups/thehudsonvalley/posts/2749626821987910/
+---
+# Wednesday, May 12, 2010 — Fingerboard Shelter
+**Start Location:** Linden Motel pool house (Greenwood Lake, NY)
+**Miles Today:** 16.40
+**Trip Miles:** 1377.10
+
+An Indian man stood at the side of the poolhouse, looking in. I got up to shake his hand and explain our being there. Luckily, it was the same manager who'd OK'd it earlier. We walked over to the gas station and I got a honeybun for breakfast, then walked down to a diner for another breakfast. It was a small pastry shop owned by a spunky middle-aged woman. I watched hwe and her assistant, a teenage girl, joke and carry on behind the counter. I asked them questions about their life and they willingly answered. Customers entered, grabbed their breakfasts-to-go, and exited. One customer stayed to eat, and I got to talking to her. Lisa was a local pet-sitter. As a local, she was very knowledgeable about the area's history and (to my delight) geology. We talked about local attitudes, the Rainbow Coalition, and hitching trains. Boomerang entered and got breakfast next to me. When she left, Lisa picked up both of our $5.00 tabs. She saif "God Bless" and left. Rain fell and the air was cold, and there was a silent consensus between the Georgia boys and I: we would wait a while before hiking.
+Down at the library, I updated my journal and took a nap in a chair. I met Raury, a long-distance runner from Manhattan. He looked like your classic crazy black man bum and plague to the local library, but he spoke articulately like a Harvard scholar. He was big into long-distance running and had completed countless marathons. He offered to give us a ride anywhere we wanted. I took his phone number and walked to the pizza shop to meet the Georgia boys. The prettiest girl in the world was behind the counter. She smiled and asked me about the trip. I thought about her for the rest of the day. I called Raury and he took us to the trailhead. It was drizzling and cold.
+It was already 1:00, a late start out of Greenwood Lakes. We marched 16-some miles into a beautiful state park, scrambling incredible rock faces and passing sleepy lakes. The park was teeming with wildlife--huge woodpeckers darting about, bushy squirrels bounding to trees, muscular deer staring at us, songbirds singing, and a great owl flappig silently away.
+At the shelter, an ancient stone edifice with dual chimneys, we settled down for the night. Night fell and so did I into sleep.
+---
+---
+date: '2010-05-13'
+start: Fingerboard Shelter
+destination: Graymore Spriritual Center
+miles_today: 21.0
+trip_miles: 1398.1
+facts:
+  trail_section: Trail section from Fingerboard Shelter to Graymore Spriritual Center.
+  confidence: low
+---
+# Thursday, May 13, 2010 — Graymore Spriritual Center
+**Start Location:** Fingerboard Shelter
+**Miles Today:** 21
+**Trip Miles:** 1398.10
+
+Alot of highs today: Hiking in the morning through the state park (a meadowy open forest), hopping a 10-foot barbed-wire fence for water, seeing the zoo at Bear Mountain State Park, talking to the Sisters of Life nuns, getting a 101 lesson from a party of birdwatchers, crossing the Bear Mountain Bridge, drinking a Coors Light tallboy on the trail, talking in Spanish to an Ecuadorian store owner, and SEEING THE NEW YORK CITY SKYLINE! The sight of NYC was, by far, the most awe-inspiring thing I've yet seen. I almost lost my breath, like I'd just seen a miracle performed. I just couldn't beleive it: I simply cannot put into words the feelings I felt then.
+Lows? Getting lost was frusterating (I missed Bear Mountain and crossed several almost-as-high peaks to the east, then hit the 1777 Trail that followed back to the State Park), and that night a queer Southbounder in the shelter snored incessantly.
+---
+---
+date: '2010-05-14'
+start: Graymore Spriritual Center
+destination: Morgan Steward Shelter
+miles_today: 28.0
+trip_miles: 1426.1
+facts:
+  trail_section: Trail section from Graymore Spriritual Center to Morgan Steward Shelter.
+  confidence: low
+---
+# Friday, May 14, 2010 — Morgan Steward Shelter
+**Start Location:** Graymore Spriritual Center
+**Miles Today:** 28
+**Trip Miles:** 1426.10
+
+Highs: Hiking with Dave (or Boomerang) for a while, running into a Yale philosophy major with an upcoming fellowship at Cambridge, ENG, the rains cleared up by noon and the sun poured down to redeem the day, chomping into a pizza at the roadside deli, s'mores that night at the shelter (thanks to come guys from West Point).
+Lows: my feet got serious blisters (not bloody but very close), finding Kevin at the shelter (an awkward situation given his denial of some unproven yet highly-probable section-skipping), and laboring to catch up after napping always sucks.
+---
+---
+date: '2010-05-15'
+start: Morgan Steward Shelter
+destination: Bill's House (Ridgefield, CT)
+miles_today: 22.0
+trip_miles: 1448.1
+facts:
+  trail_section: Trail section from Morgan Steward Shelter to Bill's House (Ridgefield,
+    CT).
+  town_events: Events
+  confidence: low
+  sources:
+  - https://appalachiantrail.org/events/
+---
+# Saturday, May 15, 2010 — Bill's House (Ridgefield, CT)
+**Start Location:** Morgan Steward Shelter
+**Miles Today:** 22
+**Trip Miles:** 1448.10
+
+Highs: meeting up with Uncle Bill at the day's end was the climax of the day; I enjoyed meeting a group of young Brooklyners who had taken the day off from stressful city life. Seeing those kids really reawoke a nagging desire I have to move to NYC for a short time...it's so magical! The SUNSHINE! brought up the temps and made the day ideal for hiking; I enjoyed trail-running along a gentler trail than the day before; that night, Bill treatd the Georgia boys and I to wings, a reuben, a beer, AND desert at the Corner Pub. Bill also showed us his masterpiece, a year-long garage/workshop/office/guest house he built from scratch.OH YEA!- I saw the biggest oak on the AT! It was a beautiful monster (see the pic I found on the internet...No, that's not me in the photo)
+
+Lows: none to speak of. Honestly, I felt great today. My pack without food and water (its most common state, as I'm carrying only 1-2 days of food these days) is 12 lbs. at most makes the going easy for my joints, muscles, and most of all feet. I skip up hills and run down the backsides. On the contrary, the Georgia boys were hurting as usual (their packs are significantly heavier than mine).
+
+A quick word on the spirit. Like I've said, the weather is dandy these days. The pain and misery has died down, yet so has the volume of the Lord's voice. I just don't hear God anymore like I used to, and I don't know whether to remedy the silence or embrace it for what it is. Maybe he's showed me what he wanted to show me - you know, demonstrated Truth - and now the ball is in MY court. Maybe I'm supposed to activate change. I don't know. But still, though I'm more faithful now thanks to the hardships of winter, I still long for those days. When I could really hear and feel him by my side.
+
+Thanks everyone for reading this journal and for all your support! I'm currently at Mile 1,448 (only 731 from Katahdin!) and still can't beleive I've made it this far. Leave a comment in my "Guest Book"...it says almost 10,000 people have read my journal since last week so I'm kinda curious who exactly these 10,000 people are.
+---
+---
+date: '2010-05-16'
+start: Bill's House (Ridgefield, CT)
+destination: Stewart Hollow Brook Lean-to
+miles_today: 14.0
+trip_miles: 1462.1
+facts:
+  weather: High 66°F, low 48°F. Overcast.
+  trail_section: Trail section from Bill's House (Ridgefield, CT) to Stewart Hollow
+    Brook Lean-to.
+  town_events: A.T. Community™ Program - Appalachian Trail Conservancy
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+  - https://appalachiantrail.org/protect/conservation/at-community-program/
+---
+# Sunday, May 16, 2010 — Stewart Hollow Brook Lean-to
+**Start Location:** Bill's House (Ridgefield, CT)
+**Miles Today:** 14
+**Trip Miles:** 1462.10
+
+Toggle navigation[Trail Journals](https://www.trailjournals.com/)
+
+- [Journals](https://www.trailjournals.com/journal/entry/311304#)  - [Journals](https://www.trailjournals.com/journals)
+  - [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail/2026)
+  - [Pacific Crest Trail](https://www.trailjournals.com/journals/pacific_crest_trail/2026)
+  - [Colorado Trail](https://www.trailjournals.com/journals/colorado_trail/2026)
+  - [Continental Divide Trail](https://www.trailjournals.com/journals/continental_divide_trail/2026)
+  - [Long Trail - Vermont](https://www.trailjournals.com/journals/the_long_trail_-_vermont/2026)
+  - [Florida Trail](https://www.trailjournals.com/journals/the_florida_trail/2026)
+  - [Arizona Trail](https://www.trailjournals.com/journals/arizona_trail/2026)
+  - [John Muir Trail](https://www.trailjournals.com/journals/john_muir_trail/2026)
+  - [Camino de Santiago](https://www.trailjournals.com/journals/camino_de_santiago/2026)
+  - [American Discovery Trail](https://www.trailjournals.com/journals/american_discovery_trail/2026)
+  - [Coast to Coast Walk](https://www.trailjournals.com/journals/coast_to_coast_walk/2026)
+  - [More...](https://www.trailjournals.com/journals/)
+- [Trails](https://www.trailjournals.com/trails/)
+- [Photos](https://www.trailjournals.com/photos/2026)
+- [Gear](https://www.trailjournals.com/journal/entry/311304#)  - [Current Sales](https://www.trailjournals.com/gear/deals/onsale)
+  - [REI](https://www.trailjournals.com/gear/rei)
+  - [ULA](https://www.trailjournals.com/gear/ula)
+  - [Patagonia](https://www.trailjournals.com/gear/patagonia)
+  - [Cabela's](https://www.trailjournals.com/gear/cabela)
+- [Planning](https://www.trailjournals.com/journal/entry/311304#)  - [Plan Your Hike](https://www.trailjournals.com/planning/)
+  - [Gear](https://www.trailjournals.com/gear/)
+  - [Books](https://www.trailjournals.com/books/)
+  - [Links](https://www.trailjournals.com/links/)
+- [Search](https://www.trailjournals.com/search/)
+- [About](https://www.trailjournals.com/journal/entry/311304#)  - [About Trailjournals](https://www.trailjournals.com/about/)
+  - [Login](https://www.trailjournals.com/user/login)
+  - [Join](https://www.trailjournals.com/join)
+  - [Support Trailjournals](https://www.trailjournals.com/about/donate/)
+  - [Contact](https://www.trailjournals.com/about/contact)
+  - [Store](https://www.trailjournals.com/store/)
+
+Backpacking Journals and Photos from Long Distance Hikers
+
+1. [Home](https://www.trailjournals.com/)
+2. [Journals](https://www.trailjournals.com/journals)
+3. [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail)
+4. [2010](https://www.trailjournals.com/journals/appalachian_trail/2010)
+5. [Uncle Frank](https://www.trailjournals.com/journal/10467)
+6. [Entries](https://www.trailjournals.com/journal/entries/10467/uncle%20-frank)
+7. May 16, 2010
+
+Toggle navigation
+
+- [Journal](https://www.trailjournals.com/journal/10467)
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+- [My Journals](https://www.trailjournals.com/myjournals/10467)
+- [View Guest Book](https://www.trailjournals.com/journal/guestbook/10467)
+- [Sign Guest Book](https://www.trailjournals.com/journal/guestbook/sign/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/9a.gif)![](https://www.trailjournals.com/images/7a.gif)
+
+[Journal](https://www.trailjournals.com/journal/10467)
+
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+
+--Choose--01/21/1002/06/1002/07/1002/08/1002/09/1002/10/1002/11/1002/12/1002/13/1002/14/1002/15/1002/16/1002/17/1002/18/1002/19/1002/20/1002/21/1002/22/1002/23/1002/24/1002/25/1002/26/1002/27/1002/28/1003/01/1003/02/1003/03/1003/04/1003/05/1003/06/1003/07/1003/08/1003/09/1003/11/1003/12/1003/13/1003/14/1003/15/1003/16/1003/17/1003/18/1003/19/1003/20/1003/21/1003/24/1003/25/1003/26/1003/27/1003/28/1003/29/1003/30/1003/31/1004/01/1004/02/1004/03/1004/04/1004/05/1004/06/1004/07/1004/08/1004/09/1004/10/1004/11/1004/12/1004/13/1004/14/1004/15/1004/16/1004/17/1004/18/1004/19/1004/20/1004/21/1004/23/1004/24/1004/25/1004/26/1004/27/1004/28/1004/29/1004/30/1005/01/1005/02/1005/03/1005/04/1005/05/1005/06/1005/07/1005/08/1005/09/1005/10/1005/11/1005/12/1005/13/1005/14/1005/15/1005/16/1005/17/1005/18/1005/19/1005/20/1005/21/1005/22/1005/23/1005/24/1005/25/1005/26/1005/27/1005/28/1005/29/1005/30/1005/31/1006/01/1006/02/1006/03/1006/04/1006/05/1006/06/1006/07/1006/08/1006/09/1006/10/1006/11/1006/12/1006/13/1006/14/1006/15/1006/16/1006/17/1006/18/1006/19/1006/20/1006/21/10
+
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+
+Guest Book
+
+- [Sign](https://www.trailjournals.com/journal/guestbook/sign/10467)
+- [View](https://www.trailjournals.com/journal/guestbook/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/9a.gif)![](https://www.trailjournals.com/images/7a.gif)
+
+- [AT Journals](https://www.trailjournals.com/journals/appalachian_trail)
+- [AT Photos](https://www.trailjournals.com/photos/appalachian_trail)
+- [AT Books](https://www.trailjournals.com/books/appalachian_trail)
+- [Appalachian Trail](http://www.appalachiantrail.org/)
+
+[Join](https://www.trailjournals.com/join) [Login](https://www.trailjournals.com/user/login)
+
+[RSS](https://www.trailjournals.com/journal/rss/10467/xml)
+
+# Uncle Frank's 2010  Appalachian Trail Journal
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/310335) [Next](https://www.trailjournals.com/journal/entry/311305) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+Sunday, May 16, 2010
+
+Destination:Stewart Hollow Brook Lean-to
+
+Today's Miles:14
+
+Start Location:Bill's House (Ridgefield, CT)
+
+Trip Miles:1462.10
+
+Destination:Stewart Hollow Brook Lean-to
+
+Start Location:Bill's House (Ridgefield, CT)
+
+Today's Miles:14
+
+Trip Miles:1462.10
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/310335) [Next](https://www.trailjournals.com/journal/entry/311305) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+### Hiker Entries May 16, 2010
+
+|  | Journalist | Destination | Trail |
+| --- | --- | --- | --- |
+|  | [Dreams](https://www.trailjournals.com/journal/about/28321) | [Past Fuller Ridge (193.0)](https://www.trailjournals.com/journal/entry/679362) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+|  | [Deluxe](https://www.trailjournals.com/journal/about/21877) | [\-\- View Entry --](https://www.trailjournals.com/journal/entry/566497) | [Nepal Trekking](https://www.trailjournals.com/journals/Nepal%20_Trekking) |
+|  | [Arius](https://www.trailjournals.com/journal/about/14527) | [Spence Field](https://www.trailjournals.com/journal/entry/404800) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Transient](https://www.trailjournals.com/journal/about/13775) | [Wrightwood](https://www.trailjournals.com/journal/entry/380564) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Troll_3506TN.jpg) | [Troll](https://www.trailjournals.com/journal/about/3506) | [Atkins](https://www.trailjournals.com/journal/entry/355108) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [perager](https://www.trailjournals.com/journal/about/4262) | [Waynesboro, Va](https://www.trailjournals.com/journal/entry/342171) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DidgeridudeandDoodlebug_9852TN.jpg) | [Didgeridude and Doodlebug](https://www.trailjournals.com/journal/about/9852) | [Trail Days](https://www.trailjournals.com/journal/entry/334664) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | ["Dances with Wolfie"](https://www.trailjournals.com/journal/about/7342) | [Trindle road](https://www.trailjournals.com/journal/entry/333573) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Locomotive Breath](https://www.trailjournals.com/journal/about/10836) | [Pearisburg Shuttle for Hyway](https://www.trailjournals.com/journal/entry/327054) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Peru_10969TN.jpg) | [Peru](https://www.trailjournals.com/journal/about/10969) | [Hot Springs](https://www.trailjournals.com/journal/entry/325375) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| [More...](https://www.trailjournals.com/entries/2010/05/16) [Grouped By Trail...](https://www.trailjournals.com/entries/2010/05/16/trail) |
+
+|     |
+| --- |
+| I rarely ever dreamt about hiking on the trail while I was out there in the woods. Many others said that they dreamed about it every night. Now that I'm home I think and dream about it constantly and have been waking up prepared to hike in the morning. ... <br>[Terodactyle](https://www.trailjournals.com/journal/entry/547885) —<br>[Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail) [2016](https://www.trailjournals.com/journals/appalachian_trail/2016) |
+
+[![Trailjournals](https://www.trailjournals.com/images/logo.png)](https://www.trailjournals.com/)
+
+#### Hiking
+
+- [Trails](https://www.trailjournals.com/trails/list)
+- [Journals](https://www.trailjournals.com/journals)
+- [Photos](https://www.trailjournals.com/photos)
+- [Calendar](https://www.trailjournals.com/calendar)
+- Gear
+- [Links](https://www.trailjournals.com/links)
+
+#### Partners
+
+- [ULA Equipment](https://ula-equipment.sjv.io/drN9K)
+- [REI](http://www.avantlink.com/click.php?tt=ml&ti=45265&pw=68025)
+- [Patagonia](http://www.avantlink.com/click.php?tt=ml&ti=45781&pw=68025)
+
+#### Network
+
+- [Trail Forums](http://www.trailforums.com/)
+- Trail News
+
+#### About Us
+
+- [Contact](https://www.trailjournals.com/about/contact)
+- [Donate](https://www.trailjournals.com/about/donate)
+- [Join](https://www.trailjournals.com/join)
+- [Login](https://www.trailjournals.com/user/login)
+- [Help](https://www.trailjournals.com/help)
+
+#### Follow Us
+
+- [Facebook](https://www.facebook.com/trailjournals)
+- [Instagram](https://instagram.com/trailjournals/)
+- [Twitter](https://twitter.com/trailjournals)
+- [Pinterest](https://www.pinterest.com/trailjournals/)
+- [Linkedin](https://www.linkedin.com/company/trailjournals-llc)
+
+Top Photo © Gary Wright - The Appalachin Trail,
+08/28/2002 by
+[Radar](https://www.trailjournals.com/journal/543)
+
+Trailjournals LLC © 2026
+All Rights Reserved. [privacy policy](https://www.trailjournals.com/about/privacy)
+
+Newburyport, MA 01950
+
+[Terms under which this service is provided to you.](https://www.trailjournals.com/about/privacy)
+
+Build: 20210226:165913 [Manage Settings](https://www.trailjournals.com/about/settings)
+---
+---
+date: '2010-05-17'
+start: Stewart Hollow Brook Lean-to
+destination: Vanessa's Place (Salibury, CT)
+miles_today: 26.4
+trip_miles: 1488.5
+facts:
+  weather: High 71°F, low 48°F. Overcast.
+  trail_section: Trail section from Stewart Hollow Brook Lean-to to Vanessa's Place
+    (Salibury, CT).
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+---
+# Monday, May 17, 2010 — Vanessa's Place (Salibury, CT)
+**Start Location:** Stewart Hollow Brook Lean-to
+**Miles Today:** 26.40
+**Trip Miles:** 1488.50
+
+Toggle navigation[Trail Journals](https://www.trailjournals.com/)
+
+- [Journals](https://www.trailjournals.com/journal/entry/311305#)  - [Journals](https://www.trailjournals.com/journals)
+  - [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail/2026)
+  - [Pacific Crest Trail](https://www.trailjournals.com/journals/pacific_crest_trail/2026)
+  - [Colorado Trail](https://www.trailjournals.com/journals/colorado_trail/2026)
+  - [Continental Divide Trail](https://www.trailjournals.com/journals/continental_divide_trail/2026)
+  - [Long Trail - Vermont](https://www.trailjournals.com/journals/the_long_trail_-_vermont/2026)
+  - [Florida Trail](https://www.trailjournals.com/journals/the_florida_trail/2026)
+  - [Arizona Trail](https://www.trailjournals.com/journals/arizona_trail/2026)
+  - [John Muir Trail](https://www.trailjournals.com/journals/john_muir_trail/2026)
+  - [Camino de Santiago](https://www.trailjournals.com/journals/camino_de_santiago/2026)
+  - [American Discovery Trail](https://www.trailjournals.com/journals/american_discovery_trail/2026)
+  - [Coast to Coast Walk](https://www.trailjournals.com/journals/coast_to_coast_walk/2026)
+  - [More...](https://www.trailjournals.com/journals/)
+- [Trails](https://www.trailjournals.com/trails/)
+- [Photos](https://www.trailjournals.com/photos/2026)
+- [Gear](https://www.trailjournals.com/journal/entry/311305#)  - [Current Sales](https://www.trailjournals.com/gear/deals/onsale)
+  - [REI](https://www.trailjournals.com/gear/rei)
+  - [ULA](https://www.trailjournals.com/gear/ula)
+  - [Patagonia](https://www.trailjournals.com/gear/patagonia)
+  - [Cabela's](https://www.trailjournals.com/gear/cabela)
+- [Planning](https://www.trailjournals.com/journal/entry/311305#)  - [Plan Your Hike](https://www.trailjournals.com/planning/)
+  - [Gear](https://www.trailjournals.com/gear/)
+  - [Books](https://www.trailjournals.com/books/)
+  - [Links](https://www.trailjournals.com/links/)
+- [Search](https://www.trailjournals.com/search/)
+- [About](https://www.trailjournals.com/journal/entry/311305#)  - [About Trailjournals](https://www.trailjournals.com/about/)
+  - [Login](https://www.trailjournals.com/user/login)
+  - [Join](https://www.trailjournals.com/join)
+  - [Support Trailjournals](https://www.trailjournals.com/about/donate/)
+  - [Contact](https://www.trailjournals.com/about/contact)
+  - [Store](https://www.trailjournals.com/store/)
+
+Backpacking Journals and Photos from Long Distance Hikers
+
+1. [Home](https://www.trailjournals.com/)
+2. [Journals](https://www.trailjournals.com/journals)
+3. [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail)
+4. [2010](https://www.trailjournals.com/journals/appalachian_trail/2010)
+5. [Uncle Frank](https://www.trailjournals.com/journal/10467)
+6. [Entries](https://www.trailjournals.com/journal/entries/10467/uncle%20-frank)
+7. May 17, 2010
+
+Toggle navigation
+
+- [Journal](https://www.trailjournals.com/journal/10467)
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+- [My Journals](https://www.trailjournals.com/myjournals/10467)
+- [View Guest Book](https://www.trailjournals.com/journal/guestbook/10467)
+- [Sign Guest Book](https://www.trailjournals.com/journal/guestbook/sign/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/9a.gif)![](https://www.trailjournals.com/images/7a.gif)
+
+[Journal](https://www.trailjournals.com/journal/10467)
+
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+
+--Choose--01/21/1002/06/1002/07/1002/08/1002/09/1002/10/1002/11/1002/12/1002/13/1002/14/1002/15/1002/16/1002/17/1002/18/1002/19/1002/20/1002/21/1002/22/1002/23/1002/24/1002/25/1002/26/1002/27/1002/28/1003/01/1003/02/1003/03/1003/04/1003/05/1003/06/1003/07/1003/08/1003/09/1003/11/1003/12/1003/13/1003/14/1003/15/1003/16/1003/17/1003/18/1003/19/1003/20/1003/21/1003/24/1003/25/1003/26/1003/27/1003/28/1003/29/1003/30/1003/31/1004/01/1004/02/1004/03/1004/04/1004/05/1004/06/1004/07/1004/08/1004/09/1004/10/1004/11/1004/12/1004/13/1004/14/1004/15/1004/16/1004/17/1004/18/1004/19/1004/20/1004/21/1004/23/1004/24/1004/25/1004/26/1004/27/1004/28/1004/29/1004/30/1005/01/1005/02/1005/03/1005/04/1005/05/1005/06/1005/07/1005/08/1005/09/1005/10/1005/11/1005/12/1005/13/1005/14/1005/15/1005/16/1005/17/1005/18/1005/19/1005/20/1005/21/1005/22/1005/23/1005/24/1005/25/1005/26/1005/27/1005/28/1005/29/1005/30/1005/31/1006/01/1006/02/1006/03/1006/04/1006/05/1006/06/1006/07/1006/08/1006/09/1006/10/1006/11/1006/12/1006/13/1006/14/1006/15/1006/16/1006/17/1006/18/1006/19/1006/20/1006/21/10
+
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+
+Guest Book
+
+- [Sign](https://www.trailjournals.com/journal/guestbook/sign/10467)
+- [View](https://www.trailjournals.com/journal/guestbook/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/9a.gif)![](https://www.trailjournals.com/images/7a.gif)
+
+- [AT Journals](https://www.trailjournals.com/journals/appalachian_trail)
+- [AT Photos](https://www.trailjournals.com/photos/appalachian_trail)
+- [AT Books](https://www.trailjournals.com/books/appalachian_trail)
+- [Appalachian Trail](http://www.appalachiantrail.org/)
+
+[Join](https://www.trailjournals.com/join) [Login](https://www.trailjournals.com/user/login)
+
+[RSS](https://www.trailjournals.com/journal/rss/10467/xml)
+
+# Uncle Frank's 2010  Appalachian Trail Journal
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/311304) [Next](https://www.trailjournals.com/journal/entry/311306) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+Monday, May 17, 2010
+
+Destination:Vanessa's Place (Salibury, CT)
+
+Today's Miles:26.40
+
+Start Location:Stewart Hollow Brook Lean-to
+
+Trip Miles:1488.50
+
+Destination:Vanessa's Place (Salibury, CT)
+
+Start Location:Stewart Hollow Brook Lean-to
+
+Today's Miles:26.40
+
+Trip Miles:1488.50
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/311304) [Next](https://www.trailjournals.com/journal/entry/311306) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+### Hiker Entries May 17, 2010
+
+|  | Journalist | Destination | Trail |
+| --- | --- | --- | --- |
+|  | [Dreams](https://www.trailjournals.com/journal/about/28321) | [Whitewater Trout Farm (217.6)](https://www.trailjournals.com/journal/entry/679363) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+|  | [Deluxe](https://www.trailjournals.com/journal/about/21877) | [\-\- View Entry --](https://www.trailjournals.com/journal/entry/566501) | [Nepal Trekking](https://www.trailjournals.com/journals/Nepal%20_Trekking) |
+|  | [Arius](https://www.trailjournals.com/journal/about/14527) | [Mtn. Collins](https://www.trailjournals.com/journal/entry/404801) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Transient](https://www.trailjournals.com/journal/about/13775) | [South Fork Campground](https://www.trailjournals.com/journal/entry/380565) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Troll_3506TN.jpg) | [Troll](https://www.trailjournals.com/journal/about/3506) | [Atkins](https://www.trailjournals.com/journal/entry/355109) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [perager](https://www.trailjournals.com/journal/about/4262) | [Calf Mtn shelter](https://www.trailjournals.com/journal/entry/342172) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DidgeridudeandDoodlebug_9852TN.jpg) | [Didgeridude and Doodlebug](https://www.trailjournals.com/journal/about/9852) | [Trimpi Shelter](https://www.trailjournals.com/journal/entry/334665) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | ["Dances with Wolfie"](https://www.trailjournals.com/journal/about/7342) | [Darlington Shelter](https://www.trailjournals.com/journal/entry/333574) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Superman_10150TN.jpg) | [Superman](https://www.trailjournals.com/journal/about/10150) | [VA601 Beech Mountain Road](https://www.trailjournals.com/journal/entry/330130) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Locomotive Breath](https://www.trailjournals.com/journal/about/10836) | [Trimpi Shelter](https://www.trailjournals.com/journal/entry/327055) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| [More...](https://www.trailjournals.com/entries/2010/05/17) [Grouped By Trail...](https://www.trailjournals.com/entries/2010/05/17/trail) |
+
+|     |
+| --- |
+| I was enjoying the day and came across some horses which seemed as happy as I was to have some company.... <br>[YOYO](https://www.trailjournals.com/journal/entry/550905) —<br>[American Discovery Trail](https://www.trailjournals.com/journals/american_discovery_trail) [2016](https://www.trailjournals.com/journals/american_discovery_trail/2016) |
+
+[![Trailjournals](https://www.trailjournals.com/images/logo.png)](https://www.trailjournals.com/)
+
+#### Hiking
+
+- [Trails](https://www.trailjournals.com/trails/list)
+- [Journals](https://www.trailjournals.com/journals)
+- [Photos](https://www.trailjournals.com/photos)
+- [Calendar](https://www.trailjournals.com/calendar)
+- Gear
+- [Links](https://www.trailjournals.com/links)
+
+#### Partners
+
+- [ULA Equipment](https://ula-equipment.sjv.io/drN9K)
+- [REI](http://www.avantlink.com/click.php?tt=ml&ti=45265&pw=68025)
+- [Patagonia](http://www.avantlink.com/click.php?tt=ml&ti=45781&pw=68025)
+
+#### Network
+
+- [Trail Forums](http://www.trailforums.com/)
+- Trail News
+
+#### About Us
+
+- [Contact](https://www.trailjournals.com/about/contact)
+- [Donate](https://www.trailjournals.com/about/donate)
+- [Join](https://www.trailjournals.com/join)
+- [Login](https://www.trailjournals.com/user/login)
+- [Help](https://www.trailjournals.com/help)
+
+#### Follow Us
+
+- [Facebook](https://www.facebook.com/trailjournals)
+- [Instagram](https://instagram.com/trailjournals/)
+- [Twitter](https://twitter.com/trailjournals)
+- [Pinterest](https://www.pinterest.com/trailjournals/)
+- [Linkedin](https://www.linkedin.com/company/trailjournals-llc)
+
+Top Photo © Gary Wright - The Appalachin Trail,
+08/28/2002 by
+[Radar](https://www.trailjournals.com/journal/543)
+
+Trailjournals LLC © 2026
+All Rights Reserved. [privacy policy](https://www.trailjournals.com/about/privacy)
+
+Newburyport, MA 01950
+
+[Terms under which this service is provided to you.](https://www.trailjournals.com/about/privacy)
+
+Build: 20210226:165913 [Manage Settings](https://www.trailjournals.com/about/settings)
+---
+---
+date: '2010-05-18'
+start: Vanessa's Place (Salibury, CT)
+destination: Tom Lenoard Lean-to
+miles_today: 27.8
+trip_miles: 1516.3
+facts:
+  trail_section: Trail section from Vanessa's Place (Salibury, CT) to Tom Lenoard
+    Lean-to.
+  town_events: 'Appalachian Trail Hike Day 24: Rest and History in Salisbury, CT'
+  confidence: low
+  sources:
+  - https://www.facebook.com/groups/338899147027564/posts/1524861051764695/
+---
+# Tuesday, May 18, 2010 — Tom Lenoard Lean-to
+**Start Location:** Vanessa's Place (Salibury, CT)
+**Miles Today:** 27.80
+**Trip Miles:** 1516.30
+
+Toggle navigation[Trail Journals](https://www.trailjournals.com/)
+
+- [Journals](https://www.trailjournals.com/journal/entry/311306#)  - [Journals](https://www.trailjournals.com/journals)
+  - [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail/2026)
+  - [Pacific Crest Trail](https://www.trailjournals.com/journals/pacific_crest_trail/2026)
+  - [Colorado Trail](https://www.trailjournals.com/journals/colorado_trail/2026)
+  - [Continental Divide Trail](https://www.trailjournals.com/journals/continental_divide_trail/2026)
+  - [Long Trail - Vermont](https://www.trailjournals.com/journals/the_long_trail_-_vermont/2026)
+  - [Florida Trail](https://www.trailjournals.com/journals/the_florida_trail/2026)
+  - [Arizona Trail](https://www.trailjournals.com/journals/arizona_trail/2026)
+  - [John Muir Trail](https://www.trailjournals.com/journals/john_muir_trail/2026)
+  - [Camino de Santiago](https://www.trailjournals.com/journals/camino_de_santiago/2026)
+  - [American Discovery Trail](https://www.trailjournals.com/journals/american_discovery_trail/2026)
+  - [Coast to Coast Walk](https://www.trailjournals.com/journals/coast_to_coast_walk/2026)
+  - [More...](https://www.trailjournals.com/journals/)
+- [Trails](https://www.trailjournals.com/trails/)
+- [Photos](https://www.trailjournals.com/photos/2026)
+- [Gear](https://www.trailjournals.com/journal/entry/311306#)  - [Current Sales](https://www.trailjournals.com/gear/deals/onsale)
+  - [REI](https://www.trailjournals.com/gear/rei)
+  - [ULA](https://www.trailjournals.com/gear/ula)
+  - [Patagonia](https://www.trailjournals.com/gear/patagonia)
+  - [Cabela's](https://www.trailjournals.com/gear/cabela)
+- [Planning](https://www.trailjournals.com/journal/entry/311306#)  - [Plan Your Hike](https://www.trailjournals.com/planning/)
+  - [Gear](https://www.trailjournals.com/gear/)
+  - [Books](https://www.trailjournals.com/books/)
+  - [Links](https://www.trailjournals.com/links/)
+- [Search](https://www.trailjournals.com/search/)
+- [About](https://www.trailjournals.com/journal/entry/311306#)  - [About Trailjournals](https://www.trailjournals.com/about/)
+  - [Login](https://www.trailjournals.com/user/login)
+  - [Join](https://www.trailjournals.com/join)
+  - [Support Trailjournals](https://www.trailjournals.com/about/donate/)
+  - [Contact](https://www.trailjournals.com/about/contact)
+  - [Store](https://www.trailjournals.com/store/)
+
+Backpacking Journals and Photos from Long Distance Hikers
+
+1. [Home](https://www.trailjournals.com/)
+2. [Journals](https://www.trailjournals.com/journals)
+3. [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail)
+4. [2010](https://www.trailjournals.com/journals/appalachian_trail/2010)
+5. [Uncle Frank](https://www.trailjournals.com/journal/10467)
+6. [Entries](https://www.trailjournals.com/journal/entries/10467/uncle%20-frank)
+7. May 18, 2010
+
+Toggle navigation
+
+- [Journal](https://www.trailjournals.com/journal/10467)
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+- [My Journals](https://www.trailjournals.com/myjournals/10467)
+- [View Guest Book](https://www.trailjournals.com/journal/guestbook/10467)
+- [Sign Guest Book](https://www.trailjournals.com/journal/guestbook/sign/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/9a.gif)![](https://www.trailjournals.com/images/9a.gif)
+
+[Journal](https://www.trailjournals.com/journal/10467)
+
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+
+--Choose--01/21/1002/06/1002/07/1002/08/1002/09/1002/10/1002/11/1002/12/1002/13/1002/14/1002/15/1002/16/1002/17/1002/18/1002/19/1002/20/1002/21/1002/22/1002/23/1002/24/1002/25/1002/26/1002/27/1002/28/1003/01/1003/02/1003/03/1003/04/1003/05/1003/06/1003/07/1003/08/1003/09/1003/11/1003/12/1003/13/1003/14/1003/15/1003/16/1003/17/1003/18/1003/19/1003/20/1003/21/1003/24/1003/25/1003/26/1003/27/1003/28/1003/29/1003/30/1003/31/1004/01/1004/02/1004/03/1004/04/1004/05/1004/06/1004/07/1004/08/1004/09/1004/10/1004/11/1004/12/1004/13/1004/14/1004/15/1004/16/1004/17/1004/18/1004/19/1004/20/1004/21/1004/23/1004/24/1004/25/1004/26/1004/27/1004/28/1004/29/1004/30/1005/01/1005/02/1005/03/1005/04/1005/05/1005/06/1005/07/1005/08/1005/09/1005/10/1005/11/1005/12/1005/13/1005/14/1005/15/1005/16/1005/17/1005/18/1005/19/1005/20/1005/21/1005/22/1005/23/1005/24/1005/25/1005/26/1005/27/1005/28/1005/29/1005/30/1005/31/1006/01/1006/02/1006/03/1006/04/1006/05/1006/06/1006/07/1006/08/1006/09/1006/10/1006/11/1006/12/1006/13/1006/14/1006/15/1006/16/1006/17/1006/18/1006/19/1006/20/1006/21/10
+
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+
+Guest Book
+
+- [Sign](https://www.trailjournals.com/journal/guestbook/sign/10467)
+- [View](https://www.trailjournals.com/journal/guestbook/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/9a.gif)![](https://www.trailjournals.com/images/9a.gif)
+
+- [AT Journals](https://www.trailjournals.com/journals/appalachian_trail)
+- [AT Photos](https://www.trailjournals.com/photos/appalachian_trail)
+- [AT Books](https://www.trailjournals.com/books/appalachian_trail)
+- [Appalachian Trail](http://www.appalachiantrail.org/)
+
+[Join](https://www.trailjournals.com/join) [Login](https://www.trailjournals.com/user/login)
+
+[RSS](https://www.trailjournals.com/journal/rss/10467/xml)
+
+# Uncle Frank's 2010  Appalachian Trail Journal
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/311305) [Next](https://www.trailjournals.com/journal/entry/311307) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+Tuesday, May 18, 2010
+
+Destination:Tom Lenoard Lean-to
+
+Today's Miles:27.80
+
+Start Location:Vanessa's Place (Salibury, CT)
+
+Trip Miles:1516.30
+
+Destination:Tom Lenoard Lean-to
+
+Start Location:Vanessa's Place (Salibury, CT)
+
+Today's Miles:27.80
+
+Trip Miles:1516.30
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/311305) [Next](https://www.trailjournals.com/journal/entry/311307) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+### Hiker Entries May 18, 2010
+
+|  | Journalist | Destination | Trail |
+| --- | --- | --- | --- |
+|  | [Dreams](https://www.trailjournals.com/journal/about/28321) | [Mission Creek headwaters (238.0)](https://www.trailjournals.com/journal/entry/679364) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+|  | [Deluxe](https://www.trailjournals.com/journal/about/21877) | [\-\- View Entry --](https://www.trailjournals.com/journal/entry/566504) | [Nepal Trekking](https://www.trailjournals.com/journals/Nepal%20_Trekking) |
+|  | [Arius](https://www.trailjournals.com/journal/about/14527) | [Tri-Corner Knob](https://www.trailjournals.com/journal/entry/404804) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Transient](https://www.trailjournals.com/journal/about/13775) | [Mount Emma Road](https://www.trailjournals.com/journal/entry/380567) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+|  | [perager](https://www.trailjournals.com/journal/about/4262) | [Prep Section Hike](https://www.trailjournals.com/journal/entry/342173) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DidgeridudeandDoodlebug_9852TN.jpg) | [Didgeridude and Doodlebug](https://www.trailjournals.com/journal/about/9852) | [past Brushy Mtn](https://www.trailjournals.com/journal/entry/334666) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | ["Dances with Wolfie"](https://www.trailjournals.com/journal/about/7342) | [The Doyle](https://www.trailjournals.com/journal/entry/334469) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010EUREKA!_10324TN.jpg) | [Jerry from Kentucky](https://www.trailjournals.com/journal/about/10324) | [Sarver Mountain Shelter](https://www.trailjournals.com/journal/entry/333278) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Superman_10150TN.jpg) | [Superman](https://www.trailjournals.com/journal/about/10150) | [East Fork of Big Wilson](https://www.trailjournals.com/journal/entry/330131) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Locomotive Breath](https://www.trailjournals.com/journal/about/10836) | [Partnership Shelter](https://www.trailjournals.com/journal/entry/327116) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| [More...](https://www.trailjournals.com/entries/2010/05/18) [Grouped By Trail...](https://www.trailjournals.com/entries/2010/05/18/trail) |
+
+|     |
+| --- |
+| What a sight to see a shelter. I was so glad to be in it, as I threw my pack down, sat on the wooden planks with the protective roof above and just gave out a big 'whew'.... <br>[Figgy](https://www.trailjournals.com/journal/entry/464964) —<br>[Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail) [2014](https://www.trailjournals.com/journals/appalachian_trail/2014) |
+
+[![Trailjournals](https://www.trailjournals.com/images/logo.png)](https://www.trailjournals.com/)
+
+#### Hiking
+
+- [Trails](https://www.trailjournals.com/trails/list)
+- [Journals](https://www.trailjournals.com/journals)
+- [Photos](https://www.trailjournals.com/photos)
+- [Calendar](https://www.trailjournals.com/calendar)
+- Gear
+- [Links](https://www.trailjournals.com/links)
+
+#### Partners
+
+- [ULA Equipment](https://ula-equipment.sjv.io/drN9K)
+- [REI](http://www.avantlink.com/click.php?tt=ml&ti=45265&pw=68025)
+- [Patagonia](http://www.avantlink.com/click.php?tt=ml&ti=45781&pw=68025)
+
+#### Network
+
+- [Trail Forums](http://www.trailforums.com/)
+- Trail News
+
+#### About Us
+
+- [Contact](https://www.trailjournals.com/about/contact)
+- [Donate](https://www.trailjournals.com/about/donate)
+- [Join](https://www.trailjournals.com/join)
+- [Login](https://www.trailjournals.com/user/login)
+- [Help](https://www.trailjournals.com/help)
+
+#### Follow Us
+
+- [Facebook](https://www.facebook.com/trailjournals)
+- [Instagram](https://instagram.com/trailjournals/)
+- [Twitter](https://twitter.com/trailjournals)
+- [Pinterest](https://www.pinterest.com/trailjournals/)
+- [Linkedin](https://www.linkedin.com/company/trailjournals-llc)
+
+Top Photo © Gary Wright - The Appalachin Trail,
+08/28/2002 by
+[Radar](https://www.trailjournals.com/journal/543)
+
+Trailjournals LLC © 2026
+All Rights Reserved. [privacy policy](https://www.trailjournals.com/about/privacy)
+
+Newburyport, MA 01950
+
+[Terms under which this service is provided to you.](https://www.trailjournals.com/about/privacy)
+
+Build: 20210226:165913 [Manage Settings](https://www.trailjournals.com/about/settings)
+---
+---
+date: '2010-05-19'
+start: Tom Lenoard Lean-to
+destination: A pavillion (Lee, MA)
+miles_today: 23.0
+trip_miles: 1539.3
+facts:
+  weather: High 51°F, low 43°F. Moderate rain.
+  trail_section: Trail section from Tom Lenoard Lean-to to A pavillion (Lee, MA).
+  town_events: Lee, MA
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+  - https://appalachiantrail.org/protect/conservation/at-community-program/lee-ma/
+---
+# Wednesday, May 19, 2010 — A pavillion (Lee, MA)
+**Start Location:** Tom Lenoard Lean-to
+**Miles Today:** 23
+**Trip Miles:** 1539.30
+
+Toggle navigation[Trail Journals](https://www.trailjournals.com/)
+
+- [Journals](https://www.trailjournals.com/journal/entry/311307#)  - [Journals](https://www.trailjournals.com/journals)
+  - [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail/2026)
+  - [Pacific Crest Trail](https://www.trailjournals.com/journals/pacific_crest_trail/2026)
+  - [Colorado Trail](https://www.trailjournals.com/journals/colorado_trail/2026)
+  - [Continental Divide Trail](https://www.trailjournals.com/journals/continental_divide_trail/2026)
+  - [Long Trail - Vermont](https://www.trailjournals.com/journals/the_long_trail_-_vermont/2026)
+  - [Florida Trail](https://www.trailjournals.com/journals/the_florida_trail/2026)
+  - [Arizona Trail](https://www.trailjournals.com/journals/arizona_trail/2026)
+  - [John Muir Trail](https://www.trailjournals.com/journals/john_muir_trail/2026)
+  - [Camino de Santiago](https://www.trailjournals.com/journals/camino_de_santiago/2026)
+  - [American Discovery Trail](https://www.trailjournals.com/journals/american_discovery_trail/2026)
+  - [Coast to Coast Walk](https://www.trailjournals.com/journals/coast_to_coast_walk/2026)
+  - [More...](https://www.trailjournals.com/journals/)
+- [Trails](https://www.trailjournals.com/trails/)
+- [Photos](https://www.trailjournals.com/photos/2026)
+- [Gear](https://www.trailjournals.com/journal/entry/311307#)  - [Current Sales](https://www.trailjournals.com/gear/deals/onsale)
+  - [REI](https://www.trailjournals.com/gear/rei)
+  - [ULA](https://www.trailjournals.com/gear/ula)
+  - [Patagonia](https://www.trailjournals.com/gear/patagonia)
+  - [Cabela's](https://www.trailjournals.com/gear/cabela)
+- [Planning](https://www.trailjournals.com/journal/entry/311307#)  - [Plan Your Hike](https://www.trailjournals.com/planning/)
+  - [Gear](https://www.trailjournals.com/gear/)
+  - [Books](https://www.trailjournals.com/books/)
+  - [Links](https://www.trailjournals.com/links/)
+- [Search](https://www.trailjournals.com/search/)
+- [About](https://www.trailjournals.com/journal/entry/311307#)  - [About Trailjournals](https://www.trailjournals.com/about/)
+  - [Login](https://www.trailjournals.com/user/login)
+  - [Join](https://www.trailjournals.com/join)
+  - [Support Trailjournals](https://www.trailjournals.com/about/donate/)
+  - [Contact](https://www.trailjournals.com/about/contact)
+  - [Store](https://www.trailjournals.com/store/)
+
+Backpacking Journals and Photos from Long Distance Hikers
+
+1. [Home](https://www.trailjournals.com/)
+2. [Journals](https://www.trailjournals.com/journals)
+3. [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail)
+4. [2010](https://www.trailjournals.com/journals/appalachian_trail/2010)
+5. [Uncle Frank](https://www.trailjournals.com/journal/10467)
+6. [Entries](https://www.trailjournals.com/journal/entries/10467/uncle%20-frank)
+7. May 19, 2010
+
+Toggle navigation
+
+- [Journal](https://www.trailjournals.com/journal/10467)
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+- [My Journals](https://www.trailjournals.com/myjournals/10467)
+- [View Guest Book](https://www.trailjournals.com/journal/guestbook/10467)
+- [Sign Guest Book](https://www.trailjournals.com/journal/guestbook/sign/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/4a.gif)![](https://www.trailjournals.com/images/0a.gif)![](https://www.trailjournals.com/images/3a.gif)
+
+[Journal](https://www.trailjournals.com/journal/10467)
+
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+
+--Choose--01/21/1002/06/1002/07/1002/08/1002/09/1002/10/1002/11/1002/12/1002/13/1002/14/1002/15/1002/16/1002/17/1002/18/1002/19/1002/20/1002/21/1002/22/1002/23/1002/24/1002/25/1002/26/1002/27/1002/28/1003/01/1003/02/1003/03/1003/04/1003/05/1003/06/1003/07/1003/08/1003/09/1003/11/1003/12/1003/13/1003/14/1003/15/1003/16/1003/17/1003/18/1003/19/1003/20/1003/21/1003/24/1003/25/1003/26/1003/27/1003/28/1003/29/1003/30/1003/31/1004/01/1004/02/1004/03/1004/04/1004/05/1004/06/1004/07/1004/08/1004/09/1004/10/1004/11/1004/12/1004/13/1004/14/1004/15/1004/16/1004/17/1004/18/1004/19/1004/20/1004/21/1004/23/1004/24/1004/25/1004/26/1004/27/1004/28/1004/29/1004/30/1005/01/1005/02/1005/03/1005/04/1005/05/1005/06/1005/07/1005/08/1005/09/1005/10/1005/11/1005/12/1005/13/1005/14/1005/15/1005/16/1005/17/1005/18/1005/19/1005/20/1005/21/1005/22/1005/23/1005/24/1005/25/1005/26/1005/27/1005/28/1005/29/1005/30/1005/31/1006/01/1006/02/1006/03/1006/04/1006/05/1006/06/1006/07/1006/08/1006/09/1006/10/1006/11/1006/12/1006/13/1006/14/1006/15/1006/16/1006/17/1006/18/1006/19/1006/20/1006/21/10
+
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+
+Guest Book
+
+- [Sign](https://www.trailjournals.com/journal/guestbook/sign/10467)
+- [View](https://www.trailjournals.com/journal/guestbook/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/4a.gif)![](https://www.trailjournals.com/images/0a.gif)![](https://www.trailjournals.com/images/3a.gif)
+
+- [AT Journals](https://www.trailjournals.com/journals/appalachian_trail)
+- [AT Photos](https://www.trailjournals.com/photos/appalachian_trail)
+- [AT Books](https://www.trailjournals.com/books/appalachian_trail)
+- [Appalachian Trail](http://www.appalachiantrail.org/)
+
+[Join](https://www.trailjournals.com/join) [Login](https://www.trailjournals.com/user/login)
+
+[RSS](https://www.trailjournals.com/journal/rss/10467/xml)
+
+# Uncle Frank's 2010  Appalachian Trail Journal
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/311306) [Next](https://www.trailjournals.com/journal/entry/311308) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+Wednesday, May 19, 2010
+
+Destination:A pavillion (Lee, MA)
+
+Today's Miles:23
+
+Start Location:Tom Lenoard Lean-to
+
+Trip Miles:1539.30
+
+Destination:A pavillion (Lee, MA)
+
+Start Location:Tom Lenoard Lean-to
+
+Today's Miles:23
+
+Trip Miles:1539.30
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/311306) [Next](https://www.trailjournals.com/journal/entry/311308) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+### Hiker Entries May 19, 2010
+
+|  | Journalist | Destination | Trail |
+| --- | --- | --- | --- |
+|  | [Dreams](https://www.trailjournals.com/journal/about/28321) | [Big Bear City (265.3)](https://www.trailjournals.com/journal/entry/679365) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+|  | [Deluxe](https://www.trailjournals.com/journal/about/21877) | [\-\- View Entry --](https://www.trailjournals.com/journal/entry/566509) | [Nepal Trekking](https://www.trailjournals.com/journals/Nepal%20_Trekking) |
+|  | [Arius](https://www.trailjournals.com/journal/about/14527) | [Green Corner RD (SBF Hostel)](https://www.trailjournals.com/journal/entry/404805) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Transient](https://www.trailjournals.com/journal/about/13775) | [Mattox Canyon Creek](https://www.trailjournals.com/journal/entry/380569) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DidgeridudeandDoodlebug_9852TN.jpg) | [Didgeridude and Doodlebug](https://www.trailjournals.com/journal/about/9852) | [Rambunny's Atkins](https://www.trailjournals.com/journal/entry/334667) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | ["Dances with Wolfie"](https://www.trailjournals.com/journal/about/7342) | [Peters Mountain Shelter](https://www.trailjournals.com/journal/entry/334470) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Superman_10150TN.jpg) | [Superman](https://www.trailjournals.com/journal/about/10150) | [Troutdale](https://www.trailjournals.com/journal/entry/330132) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Locomotive Breath](https://www.trailjournals.com/journal/about/10836) | [Happy Hiker Hostel, Atkins](https://www.trailjournals.com/journal/entry/327117) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Peru_10969TN.jpg) | [Peru](https://www.trailjournals.com/journal/about/10969) | [Bald Mtn Shelter](https://www.trailjournals.com/journal/entry/325384) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Dilly Dally & Cubbie](https://www.trailjournals.com/journal/about/10450) | [Thunder Hill Shelter](https://www.trailjournals.com/journal/entry/325245) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| [More...](https://www.trailjournals.com/entries/2010/05/19) [Grouped By Trail...](https://www.trailjournals.com/entries/2010/05/19/trail) |
+
+|     |
+| --- |
+| I started a 6.5 mile ascent through the most beautiful snow covered trails. I have developed a good aerobic hiking pace and feel strong of limb and spirit. The cold morning air, constant movement and mental focus made this portion of the trail my favorite to date.... <br>[Arthur Veilleux](https://www.trailjournals.com/journal/entry/485986) —<br>[Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail) [2015](https://www.trailjournals.com/journals/appalachian_trail/2015) |
+
+[![Trailjournals](https://www.trailjournals.com/images/logo.png)](https://www.trailjournals.com/)
+
+#### Hiking
+
+- [Trails](https://www.trailjournals.com/trails/list)
+- [Journals](https://www.trailjournals.com/journals)
+- [Photos](https://www.trailjournals.com/photos)
+- [Calendar](https://www.trailjournals.com/calendar)
+- Gear
+- [Links](https://www.trailjournals.com/links)
+
+#### Partners
+
+- [ULA Equipment](https://ula-equipment.sjv.io/drN9K)
+- [REI](http://www.avantlink.com/click.php?tt=ml&ti=45265&pw=68025)
+- [Patagonia](http://www.avantlink.com/click.php?tt=ml&ti=45781&pw=68025)
+
+#### Network
+
+- [Trail Forums](http://www.trailforums.com/)
+- Trail News
+
+#### About Us
+
+- [Contact](https://www.trailjournals.com/about/contact)
+- [Donate](https://www.trailjournals.com/about/donate)
+- [Join](https://www.trailjournals.com/join)
+- [Login](https://www.trailjournals.com/user/login)
+- [Help](https://www.trailjournals.com/help)
+
+#### Follow Us
+
+- [Facebook](https://www.facebook.com/trailjournals)
+- [Instagram](https://instagram.com/trailjournals/)
+- [Twitter](https://twitter.com/trailjournals)
+- [Pinterest](https://www.pinterest.com/trailjournals/)
+- [Linkedin](https://www.linkedin.com/company/trailjournals-llc)
+
+Top Photo © Gary Wright - The Appalachin Trail,
+08/28/2002 by
+[Radar](https://www.trailjournals.com/journal/543)
+
+Trailjournals LLC © 2026
+All Rights Reserved. [privacy policy](https://www.trailjournals.com/about/privacy)
+
+Newburyport, MA 01950
+
+[Terms under which this service is provided to you.](https://www.trailjournals.com/about/privacy)
+
+Build: 20210226:165913 [Manage Settings](https://www.trailjournals.com/about/settings)
+---
+---
+date: '2010-05-20'
+start: A pavillion (Lee, MA)
+destination: Tom Levardi's home (Dalton, MA)
+miles_today: 19.0
+trip_miles: 1558.3
+facts:
+  weather: High 73°F, low 45°F. Light drizzle.
+  trail_section: Trail section from A pavillion (Lee, MA) to Tom Levardi's home (Dalton,
+    MA).
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+---
+# Thursday, May 20, 2010 — Tom Levardi's home (Dalton, MA)
+**Start Location:** A pavillion (Lee, MA)
+**Miles Today:** 19
+**Trip Miles:** 1558.30
+
+Toggle navigation[Trail Journals](https://www.trailjournals.com/)
+
+- [Journals](https://www.trailjournals.com/journal/entry/311308#)  - [Journals](https://www.trailjournals.com/journals)
+  - [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail/2026)
+  - [Pacific Crest Trail](https://www.trailjournals.com/journals/pacific_crest_trail/2026)
+  - [Colorado Trail](https://www.trailjournals.com/journals/colorado_trail/2026)
+  - [Continental Divide Trail](https://www.trailjournals.com/journals/continental_divide_trail/2026)
+  - [Long Trail - Vermont](https://www.trailjournals.com/journals/the_long_trail_-_vermont/2026)
+  - [Florida Trail](https://www.trailjournals.com/journals/the_florida_trail/2026)
+  - [Arizona Trail](https://www.trailjournals.com/journals/arizona_trail/2026)
+  - [John Muir Trail](https://www.trailjournals.com/journals/john_muir_trail/2026)
+  - [Camino de Santiago](https://www.trailjournals.com/journals/camino_de_santiago/2026)
+  - [American Discovery Trail](https://www.trailjournals.com/journals/american_discovery_trail/2026)
+  - [Coast to Coast Walk](https://www.trailjournals.com/journals/coast_to_coast_walk/2026)
+  - [More...](https://www.trailjournals.com/journals/)
+- [Trails](https://www.trailjournals.com/trails/)
+- [Photos](https://www.trailjournals.com/photos/2026)
+- [Gear](https://www.trailjournals.com/journal/entry/311308#)  - [Current Sales](https://www.trailjournals.com/gear/deals/onsale)
+  - [REI](https://www.trailjournals.com/gear/rei)
+  - [ULA](https://www.trailjournals.com/gear/ula)
+  - [Patagonia](https://www.trailjournals.com/gear/patagonia)
+  - [Cabela's](https://www.trailjournals.com/gear/cabela)
+- [Planning](https://www.trailjournals.com/journal/entry/311308#)  - [Plan Your Hike](https://www.trailjournals.com/planning/)
+  - [Gear](https://www.trailjournals.com/gear/)
+  - [Books](https://www.trailjournals.com/books/)
+  - [Links](https://www.trailjournals.com/links/)
+- [Search](https://www.trailjournals.com/search/)
+- [About](https://www.trailjournals.com/journal/entry/311308#)  - [About Trailjournals](https://www.trailjournals.com/about/)
+  - [Login](https://www.trailjournals.com/user/login)
+  - [Join](https://www.trailjournals.com/join)
+  - [Support Trailjournals](https://www.trailjournals.com/about/donate/)
+  - [Contact](https://www.trailjournals.com/about/contact)
+  - [Store](https://www.trailjournals.com/store/)
+
+Backpacking Journals and Photos from Long Distance Hikers
+
+1. [Home](https://www.trailjournals.com/)
+2. [Journals](https://www.trailjournals.com/journals)
+3. [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail)
+4. [2010](https://www.trailjournals.com/journals/appalachian_trail/2010)
+5. [Uncle Frank](https://www.trailjournals.com/journal/10467)
+6. [Entries](https://www.trailjournals.com/journal/entries/10467/uncle%20-frank)
+7. May 20, 2010
+
+Toggle navigation
+
+- [Journal](https://www.trailjournals.com/journal/10467)
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+- [My Journals](https://www.trailjournals.com/myjournals/10467)
+- [View Guest Book](https://www.trailjournals.com/journal/guestbook/10467)
+- [Sign Guest Book](https://www.trailjournals.com/journal/guestbook/sign/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/4a.gif)![](https://www.trailjournals.com/images/0a.gif)![](https://www.trailjournals.com/images/6a.gif)
+
+[Journal](https://www.trailjournals.com/journal/10467)
+
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+
+--Choose--01/21/1002/06/1002/07/1002/08/1002/09/1002/10/1002/11/1002/12/1002/13/1002/14/1002/15/1002/16/1002/17/1002/18/1002/19/1002/20/1002/21/1002/22/1002/23/1002/24/1002/25/1002/26/1002/27/1002/28/1003/01/1003/02/1003/03/1003/04/1003/05/1003/06/1003/07/1003/08/1003/09/1003/11/1003/12/1003/13/1003/14/1003/15/1003/16/1003/17/1003/18/1003/19/1003/20/1003/21/1003/24/1003/25/1003/26/1003/27/1003/28/1003/29/1003/30/1003/31/1004/01/1004/02/1004/03/1004/04/1004/05/1004/06/1004/07/1004/08/1004/09/1004/10/1004/11/1004/12/1004/13/1004/14/1004/15/1004/16/1004/17/1004/18/1004/19/1004/20/1004/21/1004/23/1004/24/1004/25/1004/26/1004/27/1004/28/1004/29/1004/30/1005/01/1005/02/1005/03/1005/04/1005/05/1005/06/1005/07/1005/08/1005/09/1005/10/1005/11/1005/12/1005/13/1005/14/1005/15/1005/16/1005/17/1005/18/1005/19/1005/20/1005/21/1005/22/1005/23/1005/24/1005/25/1005/26/1005/27/1005/28/1005/29/1005/30/1005/31/1006/01/1006/02/1006/03/1006/04/1006/05/1006/06/1006/07/1006/08/1006/09/1006/10/1006/11/1006/12/1006/13/1006/14/1006/15/1006/16/1006/17/1006/18/1006/19/1006/20/1006/21/10
+
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+
+Guest Book
+
+- [Sign](https://www.trailjournals.com/journal/guestbook/sign/10467)
+- [View](https://www.trailjournals.com/journal/guestbook/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/4a.gif)![](https://www.trailjournals.com/images/0a.gif)![](https://www.trailjournals.com/images/6a.gif)
+
+- [AT Journals](https://www.trailjournals.com/journals/appalachian_trail)
+- [AT Photos](https://www.trailjournals.com/photos/appalachian_trail)
+- [AT Books](https://www.trailjournals.com/books/appalachian_trail)
+- [Appalachian Trail](http://www.appalachiantrail.org/)
+
+[Join](https://www.trailjournals.com/join) [Login](https://www.trailjournals.com/user/login)
+
+[RSS](https://www.trailjournals.com/journal/rss/10467/xml)
+
+# Uncle Frank's 2010  Appalachian Trail Journal
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/311307) [Next](https://www.trailjournals.com/journal/entry/311313) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+Thursday, May 20, 2010
+
+Destination:Tom Levardi's home (Dalton, MA)
+
+Today's Miles:19
+
+Start Location:A pavillion (Lee, MA)
+
+Trip Miles:1558.30
+
+Destination:Tom Levardi's home (Dalton, MA)
+
+Start Location:A pavillion (Lee, MA)
+
+Today's Miles:19
+
+Trip Miles:1558.30
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/311307) [Next](https://www.trailjournals.com/journal/entry/311313) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+### Hiker Entries May 20, 2010
+
+|  | Journalist | Destination | Trail |
+| --- | --- | --- | --- |
+|  | [Dreams](https://www.trailjournals.com/journal/about/28321) | [Van Dusen Canyon (274.0)](https://www.trailjournals.com/journal/entry/679366) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+|  | [Deluxe](https://www.trailjournals.com/journal/about/21877) | [\-\- View Entry --](https://www.trailjournals.com/journal/entry/566512) | [Nepal Trekking](https://www.trailjournals.com/journals/Nepal%20_Trekking) |
+|  | [Transient](https://www.trailjournals.com/journal/about/13775) | [KOA Campground](https://www.trailjournals.com/journal/entry/380570) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DidgeridudeandDoodlebug_9852TN.jpg) | [Didgeridude and Doodlebug](https://www.trailjournals.com/journal/about/9852) | [stealth camp](https://www.trailjournals.com/journal/entry/334668) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | ["Dances with Wolfie"](https://www.trailjournals.com/journal/about/7342) | [Yellow Spring Village Campsite](https://www.trailjournals.com/journal/entry/334471) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Ohibro_10264TN.jpg) | [Ohibro](https://www.trailjournals.com/journal/about/10264) | [Chillicothe, Ohio](https://www.trailjournals.com/journal/entry/333706) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010EUREKA!_10324TN.jpg) | [Jerry from Kentucky](https://www.trailjournals.com/journal/about/10324) | [Catawba Mtn Shelter](https://www.trailjournals.com/journal/entry/333279) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Superman_10150TN.jpg) | [Superman](https://www.trailjournals.com/journal/about/10150) | [Bushy Mountain](https://www.trailjournals.com/journal/entry/330133) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Locomotive Breath](https://www.trailjournals.com/journal/about/10836) | [Shoulder of Garden Mountain](https://www.trailjournals.com/journal/entry/327118) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Peru_10969TN.jpg) | [Peru](https://www.trailjournals.com/journal/about/10969) | [Uncle Johnny's](https://www.trailjournals.com/journal/entry/325385) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| [More...](https://www.trailjournals.com/entries/2010/05/20) [Grouped By Trail...](https://www.trailjournals.com/entries/2010/05/20/trail) |
+
+|     |
+| --- |
+| It's definitely starting to feel like a new lifestyle out here, rather than just another weekend backpack trip. And boy does it feel great! If you're reading this, quit your job now and go for a long walk. You won't regret it.... <br>[Red Beard](https://www.trailjournals.com/journal/entry/412774) —<br>[Pacific Crest Trail](https://www.trailjournals.com/journals/pacific_crest_trail) [2013](https://www.trailjournals.com/journals/pacific_crest_trail/2013) |
+
+[![Trailjournals](https://www.trailjournals.com/images/logo.png)](https://www.trailjournals.com/)
+
+#### Hiking
+
+- [Trails](https://www.trailjournals.com/trails/list)
+- [Journals](https://www.trailjournals.com/journals)
+- [Photos](https://www.trailjournals.com/photos)
+- [Calendar](https://www.trailjournals.com/calendar)
+- Gear
+- [Links](https://www.trailjournals.com/links)
+
+#### Partners
+
+- [ULA Equipment](https://ula-equipment.sjv.io/drN9K)
+- [REI](http://www.avantlink.com/click.php?tt=ml&ti=45265&pw=68025)
+- [Patagonia](http://www.avantlink.com/click.php?tt=ml&ti=45781&pw=68025)
+
+#### Network
+
+- [Trail Forums](http://www.trailforums.com/)
+- Trail News
+
+#### About Us
+
+- [Contact](https://www.trailjournals.com/about/contact)
+- [Donate](https://www.trailjournals.com/about/donate)
+- [Join](https://www.trailjournals.com/join)
+- [Login](https://www.trailjournals.com/user/login)
+- [Help](https://www.trailjournals.com/help)
+
+#### Follow Us
+
+- [Facebook](https://www.facebook.com/trailjournals)
+- [Instagram](https://instagram.com/trailjournals/)
+- [Twitter](https://twitter.com/trailjournals)
+- [Pinterest](https://www.pinterest.com/trailjournals/)
+- [Linkedin](https://www.linkedin.com/company/trailjournals-llc)
+
+Top Photo © Gary Wright - The Appalachin Trail,
+08/28/2002 by
+[Radar](https://www.trailjournals.com/journal/543)
+
+Trailjournals LLC © 2026
+All Rights Reserved. [privacy policy](https://www.trailjournals.com/about/privacy)
+
+Newburyport, MA 01950
+
+[Terms under which this service is provided to you.](https://www.trailjournals.com/about/privacy)
+
+Build: 20210226:165913 [Manage Settings](https://www.trailjournals.com/about/settings)
+---
+---
+date: '2010-05-21'
+start: Tom Levardi's home (Dalton, MA)
+destination: Tom Levardi's home (Dalton, MA)
+miles_today: 24.0
+trip_miles: 1582.3
+facts:
+  weather: High 77°F, low 54°F. Overcast.
+  trail_section: Trail section from Tom Levardi's home (Dalton, MA) to Tom Levardi's
+    home (Dalton, MA).
+  town_events: Appalachian Trail, Dalton Massachusetts.
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+  - https://www.facebook.com/groups/127351843985408/posts/6614146828639178/
+---
+# Friday, May 21, 2010 — Tom Levardi's home (Dalton, MA)
+**Start Location:** Tom Levardi's home (Dalton, MA)
+**Miles Today:** 24
+**Trip Miles:** 1582.30
+
+I was up and adam this morning before 6 o'clock, sitting upright and alert on the couch where I slept. I was thrilled to be so awake. If I had been in the woods, I decided, I'd be on the trail. The house was warm and kept out the chilly morning, a chilly morning that would've normally paralyzed me in my sleeping bag. A general law of hking: the colder the morning the slower the rise.
+
+We all walked over to a diner for breakfast at 6:45 - Tom, the Georgia Boys and I. I spent $4.75 on the special (a heap of homefries, 2 eggs, toast and bottomless coffee) and a blueberry muffin that the waitress offered to "grill" (she brought it back blackened on both sides). I drank like five cups of coffee. Still out of money, the Georgia Boys spotted me on the bill.
+
+Tom drove us 24 miles North to where the AT intersects Williamstown (from there, we would walk back to his home via the AT). For once freed from our backpacks, and weexpected to cover the 24 miles up and over Graylock Mountain with leisure and ease. I was quite angry thanks to yet another baffled attempt at recieving my maildrop in Williamstown, but I swallowed and decided to forget about it for the day. This day was sunny and mine, and neither dark clouds nor or stresses were about to ruin it. I felt fresh as we parted ways and began walking.
+
+The 6-mile ascent to Graylock wasn't too bad. I sat at the top, spit sunflower seeds, and looked out across the most expansive view we'd seen for 500 miles. The view was mighty and powerful like a hammer, falling smooth yet strong. I don't know how to describe it, but it resonated inside and out.
+
+For the rest of the day (the last 18 miles), I hiked alone. I ran sometimes, walked others, and just calmly took in the day. The colors were outstanding, confined to the greens, blues and browns of the forest yet somehow glowing in a million shades. I sat on a soft bed of moss and thought about how LIFE lay around me. The walls and metal and plastics of the home aren't alive-they don't live. But there's something profound about sitting with LIFe around you. You can almost feel it breathing.
+
+Before 5 o'clock I arrived back in Dalton. I took a shower, a nap, and ate another excellent dinner prepared by Tom. A boiled medely of cabbage, carrots, and potatoes served with a salad, 2 cobs of corn and hot dogs. It was the first healthy meal I had in many weeks, and I gorged.
+---
+---
+date: '2010-05-22'
+start: Tom Levardi's home (Dalton, MA)
+destination: Goddard Shelter
+miles_today: 28.6
+trip_miles: 1610.9
+facts:
+  weather: High 74°F, low 54°F. Light drizzle.
+  trail_section: Trail section from Tom Levardi's home (Dalton, MA) to Goddard Shelter.
+  town_events: 'History Day on Trail: Tour of the Berkshires & Dalton, MA - YouTube'
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+  - https://www.youtube.com/watch?v=k2wDss3B32E
+---
+# Saturday, May 22, 2010 — Goddard Shelter
+**Start Location:** Tom Levardi's home (Dalton, MA)
+**Miles Today:** 28.60
+**Trip Miles:** 1610.90
+
+Three thirty-mile days into Rutland: that was my plan when Tom Levardi dropped me off at Massachusetts Rt. 2. It was 8:45 in the morning, and warm. I was alone and feeling fresh. Thirty miles lay ahead and I felt ready for them. The Georgia boys were about an hour behind.
+At dusk, I lay at the foot of a mountain. I was hungry, very hungry. I had scant food supply and hunger had set in early that day, so by sunset I felt like a skeleton. Thirty miles and I had one more mountain to climb. I couldn't breathe. I couldn't believe I was this hungry.
+A word on hunger: sometimes it sucks, sometimes it invigorates. For the affluent American, hunger is a negative state that usually occurs as an active choice that lasts, perhaps, for several short hours at the end of the day. In such cases, hunger is sought after. For relatively complacent Americans, a couple hours of monk-like discipline offers a hunger that makes one feel lean inside, potent, alive. But the pleasant sound of tummy-rumbles, coming just before a home-cooked meal after a long day at work, are invigorating yet entirely self-imposed. But the rumbles are not so pleasant when you're in the woods.
+Hunger bears down upon me in the mountains. Hiking hungry is okay from time to time, but after a while it begins to feel urgent. It oppresses morale, dims the spirit, and weakens the body. And there's nothing I can do about it. It is hopelessly out of my control. This is true hunger, I believe, and there's no romanticism to be found. In summary, I now understand the animalism awakened by this persistent, maddening sort of hunger. Looking at video footage of starving people in Africa, all I can say is that I understand like I didn't before. I know how it feels to be truly hungry, at least for three days (the collapse on the mountain was Day 1 of 3).
+Well, I made it to the shelter at the top of the mountain. There, a fire awaited me and, around it, three young guys drinking whiskey. I collapsed in the high grass. We exchanged glances. "You want some cheese and pepperoni, man?" I must have looked pretty bad. As the night wore on I drank whiskey and ate more cheese and pepperoni by the fire. Their names were Candyman, Bug Bite, and Clamspoon. Bug Bite said he was trapped in Vermont and that he was going to San Francisco to start over. I felt sort of inspired by that.
+---
+---
+date: '2010-05-23'
+start: Goddard Shelter
+destination: Next to VT Route 11 (Manchester Center, VT)
+miles_today: 30.0
+trip_miles: 1640.9
+facts:
+  weather: High 70°F, low 49°F. Overcast.
+  trail_section: Trail section from Goddard Shelter to Next to VT Route 11 (Manchester
+    Center, VT).
+  town_events: Manchester, VT
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+  - https://appalachiantrail.org/protect/conservation/at-community-program/manchester-vt/
+---
+# Sunday, May 23, 2010 — Next to VT Route 11 (Manchester Center, VT)
+**Start Location:** Goddard Shelter
+**Miles Today:** 30
+**Trip Miles:** 1640.90
+
+I got up early and took off before Candyman & Co. stirred. A short hike to the summit presented a tall fire-tower. I climbed it. At the top, the blue whisps of cloud raced by and a panoramic view flooded out in all directions.
+At the next shelter (Kidd Gore) I devoured a banana-nut bread Clif Bar. The sun was out strong and the view from the shelter was nice, so I hung around and continued eating (ripping into next day's bags). An hour later I'd eaten to the point of nausea and condemning myself to two days of constant hunger and begging along the trail. Self-control? At this point I have none.
+At the next shelter (Story Spring) I waited for the Georgia boys. They'd started their day 8 miles behind me, but by 2:00 pm they'd caught up. For the next several hours I hiked with them. At the top of Stratton Pond Mountain, the fire-tower view was, without a doubt, the most beautiful view yet in 1,700 miles. I cannot describe it here, but I will remember it forever. The blues, the greens, the whites. The lakes, the forests, the peaks. It all rang out in the core.
+I left the Georgia boys at the next shelter and moved on into the sunset. The bugs were terrible, so I was glad as night fell. My plan was to hike a 40-mile day, but I abandoned it for a 30 to Vermont Rt. 11. I fell asleep under the stars next to the highway.
+---
+---
+date: '2010-05-24'
+start: Next to VT Route 11 (Manchester Center, VT)
+destination: Minerva-Hinchey Shelter
+miles_today: 30.0
+trip_miles: 1670.9
+facts:
+  weather: High 76°F, low 50°F. Overcast.
+  trail_section: Trail section from Next to VT Route 11 (Manchester Center, VT) to
+    Minerva-Hinchey Shelter.
+  town_events: Manchester, VT
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+  - https://appalachiantrail.org/protect/conservation/at-community-program/manchester-vt/
+---
+# Monday, May 24, 2010 — Minerva-Hinchey Shelter
+**Start Location:** Next to VT Route 11 (Manchester Center, VT)
+**Miles Today:** 30
+**Trip Miles:** 1670.90
+
+I was on the trail at 6:00am. Actually, I fell asleep there so I never left the trail in the first place. I walked into the sunrise and to the top of Bromley Mountain, where I took in another spectacular view. The summit was claimed by the ski resort, so it was packed with lift machines, snow-blowing equipment, ski lodges and big ski trail signs. I walked into a small warming hut and called my dad on a phone there, then moved on.
+It was a long and boring day, but I wasn't upset about it. I just walked. By 3:00 I'd covered 20 miles, and I weighed my three options: another 10 before dusk to make 30, or another 20 into the night to make 40, or another 30 into the early morning to make a record of 50 miles. The 50-miler was almost out of the question, the 40-miler would be a push in itself, and the 30-miler my conservative plan. I was hungry to exhaustion as I walked the next 10-mile leg, and when I got to the shelter at sunset I mulled over moving on. A Long Trail thru-hiker offered me food and I kicked off my boots. Once the belly was full and feet free, that was that. I called it a day at 30.
+One interesting change in the forest was the morph from New England hardwoods into a boreal forest. The forest felt like a cathedral, echoing with birds and spacey for nearly a hundred yards in every direction. There were trees, yes--old hemlocks, spruces, and firs--but no shrubbery choking the understory. It was all open and cast blue in the shade. It smelled of Christmas, and red squirrels darted about. The hiking hurt but the scenery was incredible.
+---
+---
+date: '2010-05-25'
+start: Minerva-Hinchey Shelter
+destination: Back Home Again Hostel (Rutland, VT)
+miles_today: 20.0
+trip_miles: 1690.9
+facts:
+  weather: High 82°F, low 58°F. Overcast.
+  trail_section: Trail section from Minerva-Hinchey Shelter to Back Home Again Hostel
+    (Rutland, VT).
+  town_events: Appalachian trail events during nobo bubble? - Facebook
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+  - https://www.facebook.com/groups/819170279191773/posts/1535211077587686/
+---
+# Tuesday, May 25, 2010 — Back Home Again Hostel (Rutland, VT)
+**Start Location:** Minerva-Hinchey Shelter
+**Miles Today:** 20
+**Trip Miles:** 1690.90
+
+Today took me up and over Mount Killington on a beautiful trail cloaked in hemlocks and firs. The sun was brutal, but not in the shade of the forest. I was almost sure I had giardia, and my abs cramped and I stopped to relieve myself all the way up. I didn't eat but a couple granola bars until walking down to the VT 4 highway. I waved a bus down and jumped on. Rutland at last!
+I slept for most of the 20-minute bus ride, but entering the city I awoke. Beautiful old stone churches graced almost every corner, and, on this Friday afternoon, people walked and rode bikes on the sidewalk. It was an enlivening scene. I envied the town life.
+I got off the bus and walked over to the Back Home Again Cafe, where I was greeted by an enthusiastic bearded man. He led me upstairs to the hostel and I opened my mail-drop. The contents were: 4 days of food, the Spot GPS, a cell phone + charger, an iPod charger, a camera + USB cord, a pair of Nike shoes, and 2 loaves of homemade banana bread. I grabbed a foil-wrapped loaf and went down to the cafe. I stared at it for a while--I'd been looking forward to this moment for a long time--then peeled back the foil. Inside, mold covered the bread. "Oh well. Just looking at it is enough," I said to "H", the bearded owner who'd sat down next to me. He jumped up and grabbed a muffin at the counter. "Take this. It's not Mom's, but it was baked this morning."
+I got a Reuben and a beer from next door and made some phone calls on the street--Rawlz, Diesel, Seth, Wesley, Corey, Mom & Dad. Suddenly, I was surrounded by four bearded men with ponytails. "Wanna come to our gathering?" "If I can get my Reuben in a to-go box," I replied. I got in the car with them The Twelve Tribes is a denomination of Christianity that practices many Amish-like customs with a hippie attitude, and a small community of them owned and operated the Back Home Again Cafe. Men wear beards, women wear dresses, and multiple families all live under the same roof, and, honestly, that's the only real difference between us and them. They took me back to their homes--they'd bought up a small cluster of old houses less than a mile from the cafe--and witnessed their 'gathering'. Everyone stood in a circle quietly. In this informal setting, some shared spiritual revelation and others recounted a enlightening experiences from that day--for example: "It was a sunny day and I was listening to a woman complain to her husband on the cell phone, and it hit me how much we worry ourselves about what's not the present." They sang a song and let me go. I went to the library and read up on giardia, and a strange man approached me as I munched on my Reuben outside. "This town is bad, man. Watch out at night," he said.
+It was getting late and I walked to Wal-Mart. I bought a bar of dark chocolate and a gatorade, then walked over to the movie theater. The guy at the counter wouldn't charge me for a ticket, so I just walked in kind of confused. Shrek was boring, and when I woke up the theater was all black and the movie over. I walked back to the hostel and went to sleep.
+---
+---
+date: '2010-05-26'
+start: Back Home Again Hostel (Rutland, VT)
+destination: Stony Brook Shelter
+miles_today: 10.0
+trip_miles: 1700.9
+facts:
+  weather: High 85°F, low 61°F. Partly cloudy.
+  trail_section: Trail section from Back Home Again Hostel (Rutland, VT) to Stony
+    Brook Shelter.
+  town_events: Events
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+  - https://appalachiantrail.org/events/
+---
+# Wednesday, May 26, 2010 — Stony Brook Shelter
+**Start Location:** Back Home Again Hostel (Rutland, VT)
+**Miles Today:** 10
+**Trip Miles:** 1700.90
+
+Today was my half-zero day in Rutland, and here's what I did: I got up early and packed my pack, received an early breakfast of 3 eggs, toast, and granola with milk, then did three hours of work-for-stay. In the kitchen I peeled bananas, cored tomatoes, sliced peppers, washed dishes, and mopped/swept the floor. I was actually pretty enjoyable because I got to talk to H, the quirky manager.
+After the work-for-stay, H ordered me a free smoothie and I walked over to the movie theater to see Robin Hood! I was so excited, and got a pint of Ben & Jerry's for the occassion. As I expected the movie was AWESOME, and I thought about it all that evening as I walked in the woods to the Stony Brook Shelter to meet the Georgia Boys. On the 10-mile march, I hung up my old boots on a large birch tree next to a huge boulder by a lake. In case I ever go back to Rutland, I'll come for them. It wasn't hard leaving Rutland, but it wasn't easy either. The folks there were so kind and the town itself so pretty and lively. Something tells me I'm going to always regret leaving places like Rutland before even getting to know them. At any rate, in the dark I trudged into the Stony Brook Shelter and hit the sack. Back in the woods again...
+---
+---
+date: '2010-05-27'
+start: Stony Brook Shelter
+destination: Next to a road (Pomfret, VT)
+miles_today: 16.0
+trip_miles: 1716.9
+facts:
+  weather: High 74°F, low 54°F. Light drizzle.
+  trail_section: Trail section from Stony Brook Shelter to Next to a road (Pomfret,
+    VT).
+  town_events: 'Appalachian Trail Conservancy: Home'
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+  - https://appalachiantrail.org/
+---
+# Thursday, May 27, 2010 — Next to a road (Pomfret, VT)
+**Start Location:** Stony Brook Shelter
+**Miles Today:** 16
+**Trip Miles:** 1716.90
+
+I needed it, so today I lounged in the shelter while everyone else moved on. For nearly two hours I dozed in perfect silence, read Call of the Wild, and walked about the clearing. Eventually I hit the dusty trail, but my pace was slow all day. I just couldn't get "into it," and stopped again and again to sit on stumps and eat. By dusk, I hadn't even covered 20 miles! I didn't want to hike in the dark (and couldn't tolerate the overly-talkative fellow in the shelter), so I laid out my sleeping bag on the trail and fell asleep. The next morning I planned to rise before 6 and catch up with the Georgia Boys in the next shelter. I had dreams of alligators...
+---
+---
+date: '2010-05-28'
+start: Next to a road (Pomfret, VT)
+destination: Bob Boon's Home
+miles_today: 21.0
+trip_miles: 1737.9
+facts:
+  weather: High 76°F, low 50°F. Overcast.
+  trail_section: Trail section from Next to a road (Pomfret, VT) to Bob Boon's Home.
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+---
+# Friday, May 28, 2010 — Bob Boon's Home
+**Start Location:** Next to a road (Pomfret, VT)
+**Miles Today:** 21
+**Trip Miles:** 1737.90
+
+|     |
+| --- |
+| [![](https://www.trailjournals.com/images/photos/journals/10467/tj10467_060410_112854_537283.jpg)](https://www.trailjournals.com/journal/photos/10467/537283/312661)<br>**_The work of Bob Boon_** |
+
+What a day! I really do want to go into detail and tell the world the story of how Bob Boon took us in, but I just can't here. I just had time to update a couple entires and I've got to hit the trail again...coming soon!
+---
+---
+date: '2010-05-29'
+start: Bob Boon's Home
+destination: Bob Boon's Home (Hanover, NH)
+miles_today: 18.0
+trip_miles: 1755.9
+facts:
+  weather: High 75°F, low 54°F. Light drizzle.
+  trail_section: Trail section from Bob Boon's Home to Bob Boon's Home (Hanover, NH).
+  town_events: Appalachian Trail Hikers Appreciation Day in Hanover, NH - Facebook
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+  - https://www.facebook.com/groups/thruhikers/posts/3766795623639109/
+---
+# Saturday, May 29, 2010 — Bob Boon's Home (Hanover, NH)
+**Start Location:** Bob Boon's Home
+**Miles Today:** 18
+**Trip Miles:** 1755.90
+
+|     |
+| --- |
+| [![](https://www.trailjournals.com/images/photos/journals/10467/tj10467_060410_114151_537288.jpg)](https://www.trailjournals.com/journal/photos/10467/537288/312885)<br>**_Slackpacking on Moose Mtn._** |
+
+Accepting charity is always a tricky thing to on and off the trail. My mantra is always "Just say yes; they're offering it for a reason," but the Georgia boys take a more shy and reserved approach. For example, when I'm sitting in the kitchen at Bob Boon's house and Bob says, "Help yourself to anything in the fridge," I have no qualms with pouring myself a glass of OJ; contrarily, the Georgia boys would take the offer as an empty formality and sit still. I can't say which is the best approach--one must be virtuous and the other not--but as I accumulate encounters with 'Trail Magic' I'm beginning to see myself as a sly beggar, a beggar with instincts trained to exploit the kindhearted. In a word, the trail has turned me into a dirty hobo with an insatiable appetite for mooching.
+---
+---
+date: '2010-05-30'
+start: Bob Boon's Home (Hanover, NH)
+destination: Hikers Welcome Hostel
+miles_today: 25.0
+trip_miles: 1780.9
+facts:
+  weather: High 72°F, low 56°F. Overcast.
+  trail_section: Trail section from Bob Boon's Home (Hanover, NH) to Hikers Welcome
+    Hostel.
+  town_events: Appalachian Trail Hikers Appreciation Day in Hanover, NH - Facebook
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+  - https://www.facebook.com/groups/thruhikers/posts/3766795623639109/
+---
+# Sunday, May 30, 2010 — Hikers Welcome Hostel
+**Start Location:** Bob Boon's Home (Hanover, NH)
+**Miles Today:** 25
+**Trip Miles:** 1780.90
+
+|     |
+| --- |
+| [![](https://www.trailjournals.com/images/photos/journals/10467/tj10467_060410_113145_537285.jpg)](https://www.trailjournals.com/journal/photos/10467/537285/313078)<br>**_View on Smarts Mountain_** |
+
+It was Sunday, and after enjoying Bob's breakfast (bacon-and-egg biscuts, doughnuts, bananas, and OJ), Bob drove us to the trail. We left his care and hit the trail, aiming for a shelter 9 miles away (Reckless had spent all night in the ER, so we shortened the day). I took my time like I do sometimes, taking long and frequent breaks to snack, nap, or just stare at the sky. I enjoyed an especially long lunch at the foot of the fire tower on Smarts Mtn., and the Georgia Boys went on far ahead. At the 9-mile shelter (Hexacube), I left a note and kept walking. "Onto Glen Cliffs for the night (signed) UF," it read. And that I did, stopping at another shelter halfway to convince Sore Foot to accompany me into the night. Sore Foot and I marched on a difficult night-hike marked only by nearly stumbling over a porcipine. We arrived at 11:20 pm at the Hikers Welcome Hostel. I ate a poptart and drank a soda before bed (as dinner I'd skipped), and took a deep breath for Moosilauke the following day.
+---
+---
+date: '2010-05-31'
+start: Hikers Welcome Hostel
+destination: Lonesome Lakes Hut
+miles_today: 23.0
+trip_miles: 1803.9
+facts:
+  trail_section: Trail section from Hikers Welcome Hostel to Lonesome Lakes Hut.
+  confidence: low
+---
+# Monday, May 31, 2010 — Lonesome Lakes Hut
+**Start Location:** Hikers Welcome Hostel
+**Miles Today:** 23
+**Trip Miles:** 1803.90
+
+|     |
+| --- |
+| [![](https://www.trailjournals.com/images/photos/journals/10467/tj10467_060410_113605_537287.jpg)](https://www.trailjournals.com/journal/photos/10467/537287/313886)<br>**_Mount Moosilauke_** |
+
+Hey everyone! Sorry for the belated entries, but here's the next installment in Uncle Frank's trek to Maine...
+
+My feet were sore so I lounged the next morning at the Hikers Welcome Hostel, watching the news over coffee and chatting with the hostelliers. At 10:45, I hit the trail up Mt. Moosilauke (the hurdle of the infamous White Mountains) on fuel of 3 poptarts and 3 cups of coffee to match. In shelter sitting at the foot of Moosilauke, I found an old baseball to carry to Mt. Washington. Up the backside of Moosilauke I flew, stopping only once to provide isopropyl and medical tape for a lady who took a nasty spill on the rocks. Soon I was on top, standing in awe by the sign (Mt. Moosilauke 4802 ft). Here was the most beautiful thing I'd witnessed for 1,900 miles. I laughed like a lunatic, holding back the yips and yells that would've come out HAD so many day-hikers not shared the summit. I ate some sunflower seeds, a woman took my photo, and I tip-toed down the steep backside of the mountain. A beautiful stream cascaded down parallel to the trail, emitting a sweet-smelling mist. I ascented the next hurdle (name?), and the next, and encountered a memorably-painful three miles leading up to the Lonesome Lakes Hut. I'd covered 23 miles, a suprising feat given the terrain. The summits here are steep, unforgiving, leg-burning and calorie-sapping monsters, and their peaks demand a high-fee of pain for their spectacular views.
+
+It was dark when I knocked on the hut at Lonesome Lakes. Yellow light glowed inside, and I could soo several croo-members playing cards. One opened and I asked for some shelter in exchange for labor. Yes, they had some work-for-stay, so I entered and kicked off my shoes as the hutmaster gave me a huge can of cold beans with a spoon in it. A perfect dinner. I walked down to the lake for a bath. The night was clear and starry. The water was cool and black. I stripped down and flushed the sweat, blood, spider-webs and dead blackflies off my body. It felt so good to be clean. I walked back to the bunkhouse and collapsed into bed. An perfect end to an perfect day.
+---
+---
+date: '2010-06-01'
+start: Lonesome Lakes Hut
+destination: Galehead Hut
+miles_today: 16.0
+trip_miles: 1819.9
+facts:
+  trail_section: Trail section from Lonesome Lakes Hut to Galehead Hut.
+  confidence: low
+---
+# Tuesday, June 01, 2010 — Galehead Hut
+**Start Location:** Lonesome Lakes Hut
+**Miles Today:** 16
+**Trip Miles:** 1819.90
+
+After making beds and organizing a food pantry, I bagged some granola/Lucky Charms and took a nap. By 11:00 (another late start), I was packed and on the trail. To Galehead Hut I marched, and the weather was nasty. Rain drizzled and poured, and winds blew hard. On the famed Franconia Ridge the views were all white-out (a minor disappointment). It was cold, windy, and wet above the tree-line, and I was miserable. I couldn't wait to get off the ridge and down to the forest. As I trudged I thought about the two-faced nature of this well-known ridge. It was either a maiden or a monster, either a cold and cloud-covered forced-march or a balmy cake-walk with spectacular views. The difference was a single day. Down at Galehead Hut, the croo served me warm soup and homemade pizza. I chatted with a very pretty girl (yea, that's a big deal). I couldn't believe the hospitality, and I fell asleep that night thinking, "I could get used to this." A perfect end to a not-perfect day.
+---
+---
+date: '2010-06-02'
+start: Galehead Hut
+destination: Lakes of the Clouds Hut
+miles_today: 26.0
+trip_miles: 1845.9
+facts:
+  trail_section: Trail section from Galehead Hut to Lakes of the Clouds Hut.
+  confidence: low
+---
+# Wednesday, June 02, 2010 — Lakes of the Clouds Hut
+**Start Location:** Galehead Hut
+**Miles Today:** 26
+**Trip Miles:** 1845.90
+
+|     |
+| --- |
+| [![](https://www.trailjournals.com/images/photos/journals/10467/tj10467_060410_113004_537284.jpg)](https://www.trailjournals.com/journal/photos/10467/537284/313894)<br>**_Dusk on Mt. Franklin_** |
+
+"Redemption?": That was the first word out of my mouth that morning, spoken as I peered out of the window into beaming morning light. Believe it or not, the rain had moved out overnight and all clouds were gone. I layed out my wet gear in the sunlight to dry, and sat down at a set table for a croo-served breakfast of coffee and hot oatmeal with brown sugar, walnuts, strawberries, raisins, and apples. "No Brains", a warm-hearted section-hiker on his second-to-last leg, shared my complete awe of croo's degree of hospitality. We took turns singing praise to the croo, trying to convey gratitude that they would never understand in full. I scarfed down the breakfast and walked out to forage sticks to the compost, washed some dishes, and threw my pack on. It was 8:45, and off I marched to Lakes of the Clouds Hut, 26 miles away.
+
+The sun was beaming and each peak, one after another, grew higher and grander and more majestic than the last, until I was standing at sunset on Mt. Franklin. I stopped then, looking out as the heavens lay opened before me. It brought tears to my eyes, this most perfectly-beautiful place in the world. There's something about windy peaks that strikes a chord deep in the soul of man. Why can't a dense green forest strike it too? Perhaps, it's the feeling of nakedness of a mountaintop, where it's too high for those wordly distractions to grow. There it's pure, like life was meant to be. Up on those high-alpine peaks, perhaps we "haunted by the echoes of Eden."
+
+I descended down to the Lakes of the Clouds Hut, posted at the foot of Mt. Washington, the infamous jewel of the White Mountains crown. It was balmy and clear out, but ominous clouds engulfed the mountain, covering the peak from view.
+---
+---
+date: '2010-06-03'
+start: Lakes of the Clouds Hut
+destination: Hikers Paradise Hostel (Gorham, NH)
+miles_today: 13.5
+trip_miles: 1859.4
+facts:
+  weather: High 64°F, low 52°F. Slight rain.
+  trail_section: Trail section from Lakes of the Clouds Hut to Hikers Paradise Hostel
+    (Gorham, NH).
+  town_events: A.T. Community™ Program - Appalachian Trail Conservancy
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+  - https://appalachiantrail.org/protect/conservation/at-community-program/
+---
+# Thursday, June 03, 2010 — Hikers Paradise Hostel (Gorham, NH)
+**Start Location:** Lakes of the Clouds Hut
+**Miles Today:** 13.50
+**Trip Miles:** 1859.40
+
+|     |
+| --- |
+| [![](https://www.trailjournals.com/images/photos/journals/10467/tj10467_060410_113340_537286.jpg)](https://www.trailjournals.com/journal/photos/10467/537286/313908)<br>**_Gritting my Teeth on Mt. Washington_** |
+
+The next morning I awoke in The Dungeon, where the Lakes of th Clouds croo had put me up for the night. Just to give you an idea of what 'The Dungeon' implied, I'll simply say that the place was damper and smellier than my feet. Forecasts said the rain would blow over by 8am, so I awoke about that time. Dense fog cloaked the mountain and reduced visibility to zero, but the rains held off. Considering the ornery temperment of Mt. Washington, I decided weather was good enough to climb. So, I drank a protein shake and hit the trail at 7:45.
+
+The ascent was just as perilous as I expected. Visibility was near-zero, allowing just enough room to see from one mound of rocks to the next. All else was cloud. Wind speeds picked up as the rock mounds led up and up and up, soon strong enough to blow me off the trail. The terrain was 100% rocks. No vegetation dared grow. After 30 minutes of climbing I made out the shape of a mighty tower. I passed the tower, passed some buildings, and finally I was standing on the summit of Mount Washington, the high-point of AT-traversing past North Carolina. It snapped a photo and went inside the lodge (that's right, one of east-coast mountaineering's most covetted peaks has a yuppie LODGE on top, complete with Snickers, Sodas, and Hot Dogs...all of which I purchased). I hung out in the lodge for several hours, journaling and eating junk food in the warmth. At about noon I descending, taking a 7-mile short-cut around Mt.Adams, J.Q. Adams, and Madison because of the weather. It was a nasty day at the home of the worst weather in America, and I was eager to get down into the valley. At about 3pm, I arrived at Pinkham's Notch and hitched into Gorham. There, I got a bunk at the hostel and picked up a maildrop from home. Oh, Mom's muffins...
+---
+---
+date: '2010-06-04'
+start: Hikers Paradise Hostel (Gorham, NH)
+destination: Doc's front porch (Gorham, NH)
+miles_today: 21.1
+trip_miles: 1880.5
+facts:
+  weather: High 67°F, low 53°F. Light drizzle.
+  trail_section: Trail section from Hikers Paradise Hostel (Gorham, NH) to Doc's front
+    porch (Gorham, NH).
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+---
+# Friday, June 04, 2010 — Doc's front porch (Gorham, NH)
+**Start Location:** Hikers Paradise Hostel (Gorham, NH)
+**Miles Today:** 21.10
+**Trip Miles:** 1880.50
+
+|     |
+| --- |
+| [![](https://www.trailjournals.com/images/photos/journals/10467/tj10467_061410_170842_541171.jpg)](https://www.trailjournals.com/journal/photos/10467/541171/315595)<br>**_Bedding on Doc's porch_** |
+
+At first light I was on my feet, as has been the case lately. I walked over to grab a muffin and Gatorade at the convenience store, then dined on my way back. It was warm out, sign of another gorgeous day in the White Mountains. I threw my pack on my back and strolled down for some caffeine stimulus before the library opened at 10 o'clock. The waitress smiled and moved excitedly about the cafe. At ten I entered the library and opened a tab for computer use at a dollar/half-hour (theft, in my opinion). At noon I grudgingly paid the clerk after almost three hours of updating trail journals and writing emails. "I bet yall make a fortune off hikers needing to use your computers," I said bitterly and left. Outside, a quick hitch to Pinkham Notch and I was on the trail.
+The trail was sunny and I took a nap on a couch in a ski patrol hut ontop Wildcat Mountain. Then, I descended to the Carter Notch Hut for a swim in the lake and a nature lesson from the hut's croo ("Friendly fir, spiny spruce," I learned). I had no gear, so I had to decline the hutmaster's offer for a meal and overnight stay. "I'll be back for the hut experience one day," I told him. I moved on. By evening I was back in town, devouring a foot-long sub after a hard day in the mountains. With permission, I bedded down on "Doc's" front porch as rain began to fall.
+---
+---
+date: '2010-06-05'
+start: Doc's front porch
+destination: Gentian Pond Shelter
+miles_today: 11.8
+trip_miles: 1892.3
+facts:
+  weather: High 69°F, low 52°F. Moderate rain.
+  trail_section: Trail section from Doc's front porch to Gentian Pond Shelter.
+  town_events: A.T. Community™ Program - Appalachian Trail Conservancy
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+  - https://appalachiantrail.org/protect/conservation/at-community-program/
+---
+# Saturday, June 05, 2010 — Gentian Pond Shelter
+**Start Location:** Doc's front porch
+**Miles Today:** 11.80
+**Trip Miles:** 1892.30
+
+At 4 o'clock the next morning, I bought a ham-and-egg sandwhich, a honey bun, and some OJ at the convenience store, and as I packed my gear to go, a torrential rain began to fall. I cursed under my breath (visibe in the cold air, by the way), unrolled my sleeping bag, and went back to sleep. So much for a 5 o'clock start.
+At 7:30, I walked over for pancakes, bacon, and eggs, hoping that huge breakfast would somehow make the rain not-so-wet. I ate heartily and enjoyed it thoroughly. I've become the skinniest food glutton you've ever seen. I loved the waitresses New York accent.
+It took a while to get a hitch, but soon I was at the trailhead. After a frustrating episode trying to nap in a fog of mosquitoes and blackflies, I was on the trail at noon, moving towards the Full Goose Shelter 20 miles to the north. I ambled along lazily, not really wanting to be there but not really dissatisfied either. Just bored. I ate too much and found myself hiding in a shelter 10 miles short of Full Goose. A 70 year-old fellow named Grump really irritated me by talking my ear off. "If I'm talking too much, it's because I was a minister," he said. He was still talking as I drifted off to sleep.
+---
+---
+date: '2010-06-06'
+start: Gentian Pond Shelter
+destination: Carlo Col Shelter
+miles_today: 5.6
+trip_miles: 1897.9
+facts:
+  trail_section: Trail section from Gentian Pond Shelter to Carlo Col Shelter.
+  confidence: low
+---
+# Sunday, June 06, 2010 — Carlo Col Shelter
+**Start Location:** Gentian Pond Shelter
+**Miles Today:** 5.60
+**Trip Miles:** 1897.90
+
+This morning, I waited. But the rain never left, and into the afternoon it still poured. I was paralyzed, I discovered, by an element not yet encountered: rain. I'd mastered snow and heat, but rain? I shuddered. Let me add also that this was not a warm summer shower; this was cold Maine rain. Hours passed quickly sitting in the shelter, sleeping and eating off and on, and soon it was 5 o'clock in the evening. At last, it was calm out. The rain had subsided. I risked it and moved on to the next shelter, only to have the rain start again. By the time I arrived at Carlo Col, I was soaked and shivering. Unfortunately, the shelter was packed like a refugee camp with AMC trainees. I told one I was going to Acadia with my family. "You're going to Acadia?!?", one exclaimed. "I'm already planning a trip on my next day off! And they have the best lobster!" I laughed and tried to bring my mind out of the cold and wet and into the future, done with the trail and with my family in Acadia.
+---
+---
+date: '2010-06-07'
+start: Carlo Col Shelter
+destination: The Cabin (Andover, ME)
+miles_today: 14.1
+trip_miles: 1912.0
+facts:
+  weather: High 57°F, low 45°F. Light drizzle.
+  trail_section: Trail section from Carlo Col Shelter to The Cabin (Andover, ME).
+  town_events: Appalachian Trail Conservancy's 100th Anniversary To Be ...
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+  - https://andovermanews.com/appalachian-trail-conservancys-100th-anniversary-to-be-celebrated-in-andover/
+---
+# Monday, June 07, 2010 — The Cabin (Andover, ME)
+**Start Location:** Carlo Col Shelter
+**Miles Today:** 14.10
+**Trip Miles:** 1912
+
+|     |
+| --- |
+| [![](https://www.trailjournals.com/images/photos/journals/10467/tj10467_061410_170842_541175.jpg)](https://www.trailjournals.com/journal/photos/10467/541175/315600)<br>**_Morning view the way down to Rangely_** |
+
+I was out of the smelly, noisy shelter early. Up the first several ridged I climbed, cursing at the wind and cold. I felt like I was right back in the Smokies. It was all clouds, but at the top of one ridge I saw the sun glowing through. Suddenly it pierced through. The clouds broke and scattered, and I was surrounded by sweet blue sky. A panoramic view of rolling green mountains and cerulean lakes filled my eyes. Redemption! Still shivering, I called home to share the news. They said Corey was in the ICU, which re-clouded my sunny day. I'd been screaming with excitement; now I was silent and subdued. It hit me hard how far I was from home, how I'd let my family go in a big way. Homesickness swelled inside.
+Mahoosuc Notch was tricky, but it wasn't the dangerous mile of life-threatening bouldering I expected. I just kind of hopped through like a monkey. After Mahoosuc I made my way to the next road, where Earl from "The Cabin" waited for me in his pick-up. We met and he took me back to his home. I showered, laundered my clothes, changed into a clean set, and sat down for a dinner of grilled salmon, scallops, corn-on-the-cob, baked potatoes, and red wine. It was one of those meals I'll never forget. I cooked some maple-syrup pancakes (to take on the trail the next day) with some flour and syrup I found in a shelter the day before. I watched a movie on VHS (always a treat) and went to bed past midnight. It was the most comfortable night in recent memory.
+---
+---
+date: '2010-06-08'
+start: The Cabin (Andover, ME)
+destination: Bemis Mountain Lean-to
+miles_today: 29.1
+trip_miles: 1941.1
+facts:
+  weather: High 56°F, low 44°F. Light drizzle.
+  trail_section: Trail section from The Cabin (Andover, ME) to Bemis Mountain Lean-to.
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+---
+# Tuesday, June 08, 2010 — Bemis Mountain Lean-to
+**Start Location:** The Cabin (Andover, ME)
+**Miles Today:** 29.10
+**Trip Miles:** 1941.10
+
+|     |
+| --- |
+| [![](https://www.trailjournals.com/images/photos/journals/10467/tj10467_061410_170842_541169.jpg)](https://www.trailjournals.com/journal/photos/10467/541169/315601)<br>**_A hard climb made worth it...Summit of N. Crocker Mtn._** |
+
+At 5:00 AM, Earl woke me up to leave. He dropped me back at the trail by 6:30 and I was off up the first mountain. It was bitterly cold, and it became dangerously cold as I ascended. Up and up and up the trail went, following nearly a mile along the mountain's exposed rocky ridgeline to its summit. I froze up there in my t-shirt and shorts. It was the lowest moment of the trip since that snowy day on Derrick's Knob in the Smokies. It was just so damn cold. After what seemed like hours I descended back into the trees, almost incredulous as to what just happened.
+I caught up with the Georgia boys and hiked with them to the Bemis Mountain Lean-to. It was a hard day, but then again every day is a hard day so I had nothing to complain about. There was laughing and there was complaining, as usual. I found web-like mold in my dinner and had to throw it out (I'd found it in a hiker box from last year, so I can't say I was surprised).
+---
+---
+date: '2010-06-09'
+start: Bemis Mountain Lean-to
+destination: Bob's Hostel (Rangely, ME)
+miles_today: 17.7
+trip_miles: 1958.8
+facts:
+  weather: High 58°F, low 40°F. Overcast.
+  trail_section: Trail section from Bemis Mountain Lean-to to Bob's Hostel (Rangely,
+    ME).
+  town_events: Rangeley Trail Town Festival
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+  - https://appalachiantrail.org/event/rangeley-trail-town-festival/
+---
+# Wednesday, June 09, 2010 — Bob's Hostel (Rangely, ME)
+**Start Location:** Bemis Mountain Lean-to
+**Miles Today:** 17.70
+**Trip Miles:** 1958.80
+
+|     |
+| --- |
+| [![](https://www.trailjournals.com/images/photos/journals/10467/tj10467_061410_170842_541172.jpg)](https://www.trailjournals.com/journal/photos/10467/541172/315602)<br>**_One of Maine's ten million lakes_** |
+
+The next day was a pleasant one, down into the small town of Rangely, Maine. We passed some pretty lakes, and seeing the lapping water made me miss home. I brought my right back to sailing the Hobie with the family in the Bay. By 2:00 we were at the road, trying to hitch. We waited, thumb out, for almost two hours. I'd all but given up on humanity when an ambulance pulled over. "Hop on in!," said the paramedic. All three of us boarded for a 10-minute ride into Rangely. I was faint with hunger, and consumed a beer and small pizza in several minutes. At Bob's Hostel, I ate 6 eggs, 2 apples, 2 oranges, and blackberries. The healthiest gorge ever. I went to bed late that night, again up making pancakes for the next day's rations.
+---
+---
+date: '2010-06-10'
+start: Bob's Hostel (Rangely, ME)
+destination: Spaulding Mountain Lean-to
+miles_today: 10.7
+trip_miles: 1969.5
+facts:
+  weather: High 52°F, low 42°F. Moderate drizzle.
+  trail_section: Trail section from Bob's Hostel (Rangely, ME) to Spaulding Mountain
+    Lean-to.
+  town_events: Rangeley Trail Town Festival - Appalachian Trail Conservancy
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+  - https://appalachiantrail.org/event/rangeley-trail-town-festival/
+---
+# Thursday, June 10, 2010 — Spaulding Mountain Lean-to
+**Start Location:** Bob's Hostel (Rangely, ME)
+**Miles Today:** 10.70
+**Trip Miles:** 1969.50
+
+Toggle navigation[Trail Journals](https://www.trailjournals.com/)
+
+- [Journals](https://www.trailjournals.com/journal/entry/315603#)  - [Journals](https://www.trailjournals.com/journals)
+  - [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail/2026)
+  - [Pacific Crest Trail](https://www.trailjournals.com/journals/pacific_crest_trail/2026)
+  - [Colorado Trail](https://www.trailjournals.com/journals/colorado_trail/2026)
+  - [Continental Divide Trail](https://www.trailjournals.com/journals/continental_divide_trail/2026)
+  - [Long Trail - Vermont](https://www.trailjournals.com/journals/the_long_trail_-_vermont/2026)
+  - [Florida Trail](https://www.trailjournals.com/journals/the_florida_trail/2026)
+  - [Arizona Trail](https://www.trailjournals.com/journals/arizona_trail/2026)
+  - [John Muir Trail](https://www.trailjournals.com/journals/john_muir_trail/2026)
+  - [Camino de Santiago](https://www.trailjournals.com/journals/camino_de_santiago/2026)
+  - [American Discovery Trail](https://www.trailjournals.com/journals/american_discovery_trail/2026)
+  - [Coast to Coast Walk](https://www.trailjournals.com/journals/coast_to_coast_walk/2026)
+  - [More...](https://www.trailjournals.com/journals/)
+- [Trails](https://www.trailjournals.com/trails/)
+- [Photos](https://www.trailjournals.com/photos/2026)
+- [Gear](https://www.trailjournals.com/journal/entry/315603#)  - [Current Sales](https://www.trailjournals.com/gear/deals/onsale)
+  - [REI](https://www.trailjournals.com/gear/rei)
+  - [ULA](https://www.trailjournals.com/gear/ula)
+  - [Patagonia](https://www.trailjournals.com/gear/patagonia)
+  - [Cabela's](https://www.trailjournals.com/gear/cabela)
+- [Planning](https://www.trailjournals.com/journal/entry/315603#)  - [Plan Your Hike](https://www.trailjournals.com/planning/)
+  - [Gear](https://www.trailjournals.com/gear/)
+  - [Books](https://www.trailjournals.com/books/)
+  - [Links](https://www.trailjournals.com/links/)
+- [Search](https://www.trailjournals.com/search/)
+- [About](https://www.trailjournals.com/journal/entry/315603#)  - [About Trailjournals](https://www.trailjournals.com/about/)
+  - [Login](https://www.trailjournals.com/user/login)
+  - [Join](https://www.trailjournals.com/join)
+  - [Support Trailjournals](https://www.trailjournals.com/about/donate/)
+  - [Contact](https://www.trailjournals.com/about/contact)
+  - [Store](https://www.trailjournals.com/store/)
+
+Backpacking Journals and Photos from Long Distance Hikers
+
+1. [Home](https://www.trailjournals.com/)
+2. [Journals](https://www.trailjournals.com/journals)
+3. [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail)
+4. [2010](https://www.trailjournals.com/journals/appalachian_trail/2010)
+5. [Uncle Frank](https://www.trailjournals.com/journal/10467)
+6. [Entries](https://www.trailjournals.com/journal/entries/10467/uncle%20-frank)
+7. June 10, 2010
+
+Toggle navigation
+
+- [Journal](https://www.trailjournals.com/journal/10467)
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+- [My Journals](https://www.trailjournals.com/myjournals/10467)
+- [View Guest Book](https://www.trailjournals.com/journal/guestbook/10467)
+- [Sign Guest Book](https://www.trailjournals.com/journal/guestbook/sign/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/4a.gif)![](https://www.trailjournals.com/images/2a.gif)![](https://www.trailjournals.com/images/3a.gif)
+
+[Journal](https://www.trailjournals.com/journal/10467)
+
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+
+--Choose--01/21/1002/06/1002/07/1002/08/1002/09/1002/10/1002/11/1002/12/1002/13/1002/14/1002/15/1002/16/1002/17/1002/18/1002/19/1002/20/1002/21/1002/22/1002/23/1002/24/1002/25/1002/26/1002/27/1002/28/1003/01/1003/02/1003/03/1003/04/1003/05/1003/06/1003/07/1003/08/1003/09/1003/11/1003/12/1003/13/1003/14/1003/15/1003/16/1003/17/1003/18/1003/19/1003/20/1003/21/1003/24/1003/25/1003/26/1003/27/1003/28/1003/29/1003/30/1003/31/1004/01/1004/02/1004/03/1004/04/1004/05/1004/06/1004/07/1004/08/1004/09/1004/10/1004/11/1004/12/1004/13/1004/14/1004/15/1004/16/1004/17/1004/18/1004/19/1004/20/1004/21/1004/23/1004/24/1004/25/1004/26/1004/27/1004/28/1004/29/1004/30/1005/01/1005/02/1005/03/1005/04/1005/05/1005/06/1005/07/1005/08/1005/09/1005/10/1005/11/1005/12/1005/13/1005/14/1005/15/1005/16/1005/17/1005/18/1005/19/1005/20/1005/21/1005/22/1005/23/1005/24/1005/25/1005/26/1005/27/1005/28/1005/29/1005/30/1005/31/1006/01/1006/02/1006/03/1006/04/1006/05/1006/06/1006/07/1006/08/1006/09/1006/10/1006/11/1006/12/1006/13/1006/14/1006/15/1006/16/1006/17/1006/18/1006/19/1006/20/1006/21/10
+
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+
+Guest Book
+
+- [Sign](https://www.trailjournals.com/journal/guestbook/sign/10467)
+- [View](https://www.trailjournals.com/journal/guestbook/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/4a.gif)![](https://www.trailjournals.com/images/2a.gif)![](https://www.trailjournals.com/images/3a.gif)
+
+- [AT Journals](https://www.trailjournals.com/journals/appalachian_trail)
+- [AT Photos](https://www.trailjournals.com/photos/appalachian_trail)
+- [AT Books](https://www.trailjournals.com/books/appalachian_trail)
+- [Appalachian Trail](http://www.appalachiantrail.org/)
+
+[Join](https://www.trailjournals.com/join) [Login](https://www.trailjournals.com/user/login)
+
+[RSS](https://www.trailjournals.com/journal/rss/10467/xml)
+
+# Uncle Frank's 2010  Appalachian Trail Journal
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/315602) [Next](https://www.trailjournals.com/journal/entry/315604) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+Thursday, June 10, 2010
+
+Destination:Spaulding Mountain Lean-to
+
+Today's Miles:10.70
+
+Start Location:Bob's Hostel (Rangely, ME)
+
+Trip Miles:1969.50
+
+Destination:Spaulding Mountain Lean-to
+
+Start Location:Bob's Hostel (Rangely, ME)
+
+Today's Miles:10.70
+
+Trip Miles:1969.50
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/315602) [Next](https://www.trailjournals.com/journal/entry/315604) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+### Hiker Entries June 10, 2010
+
+|  | Journalist | Destination | Trail |
+| --- | --- | --- | --- |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DriveThruHikers_23038TN.jpg) | [Drive Thru Hikers](https://www.trailjournals.com/journal/about/23038) | [Hoosic River,Church St.](https://www.trailjournals.com/journal/entry/599738) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Deluxe](https://www.trailjournals.com/journal/about/21748) | [Lean To](https://www.trailjournals.com/journal/entry/566462) | [Northville-Placid Trail](https://www.trailjournals.com/journals/Northville-Placid%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2012FLTEndtoEnd_11316TN.jpg) | [FLT End to End](https://www.trailjournals.com/journal/about/11316) | [Perkins Pond Lean-to (Perkins Pond SF)](https://www.trailjournals.com/journal/entry/398915) | [Finger Lakes Trail](https://www.trailjournals.com/journals/Finger%20_Lakes%20_Trail) |
+|  | [Transient](https://www.trailjournals.com/journal/about/13775) | [Vidette Meadows](https://www.trailjournals.com/journal/entry/380600) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+|  | ["Dances with Wolfie"](https://www.trailjournals.com/journal/about/7342) | [Little Dam Lake](https://www.trailjournals.com/journal/entry/335964) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [FireBall](https://www.trailjournals.com/journal/about/9897) | [Still approaching Gunsight Pass](https://www.trailjournals.com/journal/entry/335133) | [Continental Divide Trail](https://www.trailjournals.com/journals/Continental%20_Divide%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010SilverSprings_10614TN.jpg) | [Silver Springs](https://www.trailjournals.com/journal/about/10614) | [\-\- View Entry --](https://www.trailjournals.com/journal/entry/332066) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Red Fox](https://www.trailjournals.com/journal/about/10662) | [Deep Gap](https://www.trailjournals.com/journal/entry/329863) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Trooper](https://www.trailjournals.com/journal/about/10644) | [1 Mile North of Mt. Baden-Powell Spur Trail](https://www.trailjournals.com/journal/entry/329384) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Peru_10969TN.jpg) | [Peru](https://www.trailjournals.com/journal/about/10969) | [Woods Hole Hostel](https://www.trailjournals.com/journal/entry/325466) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| [More...](https://www.trailjournals.com/entries/2010/06/10) [Grouped By Trail...](https://www.trailjournals.com/entries/2010/06/10/trail) |
+
+|     |
+| --- |
+| I have been helped by total strangers, some who speak a different dialect and/or language ... you know pilgrim when you see one, and I have gotten lost a few times even with a map ... but the locals always point me in the right direction ... it has taken away from my cynical nature towards humanity ... ... <br>[El Camino de Santiago](https://www.trailjournals.com/journal/entry/391229) —<br>[Camino de Santiago](https://www.trailjournals.com/journals/camino_de_santiago) [2012](https://www.trailjournals.com/journals/camino_de_santiago/2012) |
+
+[![Trailjournals](https://www.trailjournals.com/images/logo.png)](https://www.trailjournals.com/)
+
+#### Hiking
+
+- [Trails](https://www.trailjournals.com/trails/list)
+- [Journals](https://www.trailjournals.com/journals)
+- [Photos](https://www.trailjournals.com/photos)
+- [Calendar](https://www.trailjournals.com/calendar)
+- Gear
+- [Links](https://www.trailjournals.com/links)
+
+#### Partners
+
+- [ULA Equipment](https://ula-equipment.sjv.io/drN9K)
+- [REI](http://www.avantlink.com/click.php?tt=ml&ti=45265&pw=68025)
+- [Patagonia](http://www.avantlink.com/click.php?tt=ml&ti=45781&pw=68025)
+
+#### Network
+
+- [Trail Forums](http://www.trailforums.com/)
+- Trail News
+
+#### About Us
+
+- [Contact](https://www.trailjournals.com/about/contact)
+- [Donate](https://www.trailjournals.com/about/donate)
+- [Join](https://www.trailjournals.com/join)
+- [Login](https://www.trailjournals.com/user/login)
+- [Help](https://www.trailjournals.com/help)
+
+#### Follow Us
+
+- [Facebook](https://www.facebook.com/trailjournals)
+- [Instagram](https://instagram.com/trailjournals/)
+- [Twitter](https://twitter.com/trailjournals)
+- [Pinterest](https://www.pinterest.com/trailjournals/)
+- [Linkedin](https://www.linkedin.com/company/trailjournals-llc)
+
+Top Photo © Mathew Olsen - The Colorado Trail,
+06/22/2001 by
+[Leif](https://www.trailjournals.com/journal/97)
+
+Trailjournals LLC © 2026
+All Rights Reserved. [privacy policy](https://www.trailjournals.com/about/privacy)
+
+Newburyport, MA 01950
+
+[Terms under which this service is provided to you.](https://www.trailjournals.com/about/privacy)
+
+Build: 20210226:165913 [Manage Settings](https://www.trailjournals.com/about/settings)
+---
+---
+date: '2010-06-11'
+start: Spaulding Mountain Lean-to
+destination: Horns Pond Lean-to
+miles_today: 27.0
+trip_miles: 1996.5
+facts:
+  weather: High 64°F, low 43°F. Overcast.
+  trail_section: Trail section from Spaulding Mountain Lean-to to Horns Pond Lean-to.
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+---
+# Friday, June 11, 2010 — Horns Pond Lean-to
+**Start Location:** Spaulding Mountain Lean-to
+**Miles Today:** 27
+**Trip Miles:** 1996.50
+
+|     |
+| --- |
+| [![](https://www.trailjournals.com/images/photos/journals/10467/tj10467_061410_170842_541174.jpg)](https://www.trailjournals.com/journal/photos/10467/541174/315604)<br>**_An evening view by Horn Pond_** |
+---
+---
+date: '2010-06-12'
+start: Horns Pond Lean-to
+destination: A swamp near Pierce Pond Lean-to
+miles_today: 25.0
+trip_miles: 2021.5
+facts:
+  weather: High 61°F, low 44°F. Light drizzle.
+  trail_section: Trail section from Horns Pond Lean-to to A swamp near Pierce Pond
+    Lean-to.
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+---
+# Saturday, June 12, 2010 — A swamp near Pierce Pond Lean-to
+**Start Location:** Horns Pond Lean-to
+**Miles Today:** 25
+**Trip Miles:** 2021.50
+
+Toggle navigation[Trail Journals](https://www.trailjournals.com/)
+
+- [Journals](https://www.trailjournals.com/journal/entry/315605#)  - [Journals](https://www.trailjournals.com/journals)
+  - [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail/2026)
+  - [Pacific Crest Trail](https://www.trailjournals.com/journals/pacific_crest_trail/2026)
+  - [Colorado Trail](https://www.trailjournals.com/journals/colorado_trail/2026)
+  - [Continental Divide Trail](https://www.trailjournals.com/journals/continental_divide_trail/2026)
+  - [Long Trail - Vermont](https://www.trailjournals.com/journals/the_long_trail_-_vermont/2026)
+  - [Florida Trail](https://www.trailjournals.com/journals/the_florida_trail/2026)
+  - [Arizona Trail](https://www.trailjournals.com/journals/arizona_trail/2026)
+  - [John Muir Trail](https://www.trailjournals.com/journals/john_muir_trail/2026)
+  - [Camino de Santiago](https://www.trailjournals.com/journals/camino_de_santiago/2026)
+  - [American Discovery Trail](https://www.trailjournals.com/journals/american_discovery_trail/2026)
+  - [Coast to Coast Walk](https://www.trailjournals.com/journals/coast_to_coast_walk/2026)
+  - [More...](https://www.trailjournals.com/journals/)
+- [Trails](https://www.trailjournals.com/trails/)
+- [Photos](https://www.trailjournals.com/photos/2026)
+- [Gear](https://www.trailjournals.com/journal/entry/315605#)  - [Current Sales](https://www.trailjournals.com/gear/deals/onsale)
+  - [REI](https://www.trailjournals.com/gear/rei)
+  - [ULA](https://www.trailjournals.com/gear/ula)
+  - [Patagonia](https://www.trailjournals.com/gear/patagonia)
+  - [Cabela's](https://www.trailjournals.com/gear/cabela)
+- [Planning](https://www.trailjournals.com/journal/entry/315605#)  - [Plan Your Hike](https://www.trailjournals.com/planning/)
+  - [Gear](https://www.trailjournals.com/gear/)
+  - [Books](https://www.trailjournals.com/books/)
+  - [Links](https://www.trailjournals.com/links/)
+- [Search](https://www.trailjournals.com/search/)
+- [About](https://www.trailjournals.com/journal/entry/315605#)  - [About Trailjournals](https://www.trailjournals.com/about/)
+  - [Login](https://www.trailjournals.com/user/login)
+  - [Join](https://www.trailjournals.com/join)
+  - [Support Trailjournals](https://www.trailjournals.com/about/donate/)
+  - [Contact](https://www.trailjournals.com/about/contact)
+  - [Store](https://www.trailjournals.com/store/)
+
+Backpacking Journals and Photos from Long Distance Hikers
+
+1. [Home](https://www.trailjournals.com/)
+2. [Journals](https://www.trailjournals.com/journals)
+3. [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail)
+4. [2010](https://www.trailjournals.com/journals/appalachian_trail/2010)
+5. [Uncle Frank](https://www.trailjournals.com/journal/10467)
+6. [Entries](https://www.trailjournals.com/journal/entries/10467/uncle%20-frank)
+7. June 12, 2010
+
+Toggle navigation
+
+- [Journal](https://www.trailjournals.com/journal/10467)
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+- [My Journals](https://www.trailjournals.com/myjournals/10467)
+- [View Guest Book](https://www.trailjournals.com/journal/guestbook/10467)
+- [Sign Guest Book](https://www.trailjournals.com/journal/guestbook/sign/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/4a.gif)![](https://www.trailjournals.com/images/2a.gif)![](https://www.trailjournals.com/images/6a.gif)
+
+[Journal](https://www.trailjournals.com/journal/10467)
+
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+
+--Choose--01/21/1002/06/1002/07/1002/08/1002/09/1002/10/1002/11/1002/12/1002/13/1002/14/1002/15/1002/16/1002/17/1002/18/1002/19/1002/20/1002/21/1002/22/1002/23/1002/24/1002/25/1002/26/1002/27/1002/28/1003/01/1003/02/1003/03/1003/04/1003/05/1003/06/1003/07/1003/08/1003/09/1003/11/1003/12/1003/13/1003/14/1003/15/1003/16/1003/17/1003/18/1003/19/1003/20/1003/21/1003/24/1003/25/1003/26/1003/27/1003/28/1003/29/1003/30/1003/31/1004/01/1004/02/1004/03/1004/04/1004/05/1004/06/1004/07/1004/08/1004/09/1004/10/1004/11/1004/12/1004/13/1004/14/1004/15/1004/16/1004/17/1004/18/1004/19/1004/20/1004/21/1004/23/1004/24/1004/25/1004/26/1004/27/1004/28/1004/29/1004/30/1005/01/1005/02/1005/03/1005/04/1005/05/1005/06/1005/07/1005/08/1005/09/1005/10/1005/11/1005/12/1005/13/1005/14/1005/15/1005/16/1005/17/1005/18/1005/19/1005/20/1005/21/1005/22/1005/23/1005/24/1005/25/1005/26/1005/27/1005/28/1005/29/1005/30/1005/31/1006/01/1006/02/1006/03/1006/04/1006/05/1006/06/1006/07/1006/08/1006/09/1006/10/1006/11/1006/12/1006/13/1006/14/1006/15/1006/16/1006/17/1006/18/1006/19/1006/20/1006/21/10
+
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+
+Guest Book
+
+- [Sign](https://www.trailjournals.com/journal/guestbook/sign/10467)
+- [View](https://www.trailjournals.com/journal/guestbook/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/4a.gif)![](https://www.trailjournals.com/images/2a.gif)![](https://www.trailjournals.com/images/6a.gif)
+
+- [AT Journals](https://www.trailjournals.com/journals/appalachian_trail)
+- [AT Photos](https://www.trailjournals.com/photos/appalachian_trail)
+- [AT Books](https://www.trailjournals.com/books/appalachian_trail)
+- [Appalachian Trail](http://www.appalachiantrail.org/)
+
+[Join](https://www.trailjournals.com/join) [Login](https://www.trailjournals.com/user/login)
+
+[RSS](https://www.trailjournals.com/journal/rss/10467/xml)
+
+# Uncle Frank's 2010  Appalachian Trail Journal
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/315604) [Next](https://www.trailjournals.com/journal/entry/315608) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+Saturday, June 12, 2010
+
+Destination:A swamp near Pierce Pond Lean-to
+
+Today's Miles:25
+
+Start Location:Horns Pond Lean-to
+
+Trip Miles:2021.50
+
+Destination:A swamp near Pierce Pond Lean-to
+
+Start Location:Horns Pond Lean-to
+
+Today's Miles:25
+
+Trip Miles:2021.50
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/315604) [Next](https://www.trailjournals.com/journal/entry/315608) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+### Hiker Entries June 12, 2010
+
+|  | Journalist | Destination | Trail |
+| --- | --- | --- | --- |
+|  | [Deluxe](https://www.trailjournals.com/journal/about/21748) | [\-\- View Entry --](https://www.trailjournals.com/journal/entry/566465) | [Northville-Placid Trail](https://www.trailjournals.com/journals/Northville-Placid%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2012FLTEndtoEnd_11316TN.jpg) | [FLT End to End](https://www.trailjournals.com/journal/about/11316) | [Site 154 (Bowman Lake SP)](https://www.trailjournals.com/journal/entry/398917) | [Finger Lakes Trail](https://www.trailjournals.com/journals/Finger%20_Lakes%20_Trail) |
+|  | [Transient](https://www.trailjournals.com/journal/about/13775) | [Lone Pine](https://www.trailjournals.com/journal/entry/380602) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010seeksit_11881TN.jpg) | [seeksit](https://www.trailjournals.com/journal/about/11881) | [loop hike](https://www.trailjournals.com/journal/entry/337777) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | ["Dances with Wolfie"](https://www.trailjournals.com/journal/about/7342) | [Graymoor Friary](https://www.trailjournals.com/journal/entry/335987) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [FireBall](https://www.trailjournals.com/journal/about/9897) | [Wolf Pass near South Fork](https://www.trailjournals.com/journal/entry/335134) | [Continental Divide Trail](https://www.trailjournals.com/journals/Continental%20_Divide%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/1999beaker_6183TN.jpg) | [beaker](https://www.trailjournals.com/journal/about/6183) | [Birch Run Shelter](https://www.trailjournals.com/journal/entry/334998) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DidgeridudeandDoodlebug_9852TN.jpg) | [Didgeridude and Doodlebug](https://www.trailjournals.com/journal/about/9852) | [Birch Run Shelter](https://www.trailjournals.com/journal/entry/334681) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Red Fox](https://www.trailjournals.com/journal/about/10662) | [Clyde Smith shlter](https://www.trailjournals.com/journal/entry/329865) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Trooper](https://www.trailjournals.com/journal/about/10644) | [PCT detour - KOA Soledad Canyon Rd.](https://www.trailjournals.com/journal/entry/329388) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+| [More...](https://www.trailjournals.com/entries/2010/06/12) [Grouped By Trail...](https://www.trailjournals.com/entries/2010/06/12/trail) |
+
+|     |
+| --- |
+| I always hike better in the evening. The canyon opens up its impressive walls to a wide open space. It sprinkles on and off. Absolutely beautiful out here. ... <br>[Noworries](https://www.trailjournals.com/journal/entry/536312) —<br>[Continental Divide Trail](https://www.trailjournals.com/journals/continental_divide_trail) [2016](https://www.trailjournals.com/journals/continental_divide_trail/2016) |
+
+[![Trailjournals](https://www.trailjournals.com/images/logo.png)](https://www.trailjournals.com/)
+
+#### Hiking
+
+- [Trails](https://www.trailjournals.com/trails/list)
+- [Journals](https://www.trailjournals.com/journals)
+- [Photos](https://www.trailjournals.com/photos)
+- [Calendar](https://www.trailjournals.com/calendar)
+- Gear
+- [Links](https://www.trailjournals.com/links)
+
+#### Partners
+
+- [ULA Equipment](https://ula-equipment.sjv.io/drN9K)
+- [REI](http://www.avantlink.com/click.php?tt=ml&ti=45265&pw=68025)
+- [Patagonia](http://www.avantlink.com/click.php?tt=ml&ti=45781&pw=68025)
+
+#### Network
+
+- [Trail Forums](http://www.trailforums.com/)
+- Trail News
+
+#### About Us
+
+- [Contact](https://www.trailjournals.com/about/contact)
+- [Donate](https://www.trailjournals.com/about/donate)
+- [Join](https://www.trailjournals.com/join)
+- [Login](https://www.trailjournals.com/user/login)
+- [Help](https://www.trailjournals.com/help)
+
+#### Follow Us
+
+- [Facebook](https://www.facebook.com/trailjournals)
+- [Instagram](https://instagram.com/trailjournals/)
+- [Twitter](https://twitter.com/trailjournals)
+- [Pinterest](https://www.pinterest.com/trailjournals/)
+- [Linkedin](https://www.linkedin.com/company/trailjournals-llc)
+
+Top Photo © Mathew Olsen - The Colorado Trail,
+06/22/2001 by
+[Leif](https://www.trailjournals.com/journal/97)
+
+Trailjournals LLC © 2026
+All Rights Reserved. [privacy policy](https://www.trailjournals.com/about/privacy)
+
+Newburyport, MA 01950
+
+[Terms under which this service is provided to you.](https://www.trailjournals.com/about/privacy)
+
+Build: 20210226:165913 [Manage Settings](https://www.trailjournals.com/about/settings)
+---
+---
+date: '2010-06-13'
+start: A swamp near Pierce Pond Lean-to
+destination: Shaw's Boarding House
+miles_today: 40.0
+trip_miles: 2061.5
+facts:
+  trail_section: Trail section from A swamp near Pierce Pond Lean-to to Shaw's Boarding
+    House.
+  confidence: low
+---
+# Sunday, June 13, 2010 — Shaw's Boarding House
+**Start Location:** A swamp near Pierce Pond Lean-to
+**Miles Today:** 40
+**Trip Miles:** 2061.50
+
+|     |
+| --- |
+| [![](https://www.trailjournals.com/images/photos/journals/10467/tj10467_061410_173417_541176.jpg)](https://www.trailjournals.com/journal/photos/10467/541176/315608)<br>**_The ferry over the Kennebec_** |
+
+What a day! It was only 4 o'clock, and it was dim out. But the morning summer light was growing as it does these days, permitting an early start on the trail. Out here, I've never seen the sun so wild. It sets later and rises earlier than it does living inside, and this morning I noticed its faint glow lighting up the sky well before my 4 o'clock departure. I guess I know the sun better than I used to.
+At 5:45 I arrived at the Pierce Pond Shelter and took a 5-minute blue-blaze trail to Harrison’s Camp, home to Harrison’s infamous 12-pancake breakfast. It was still dim and the place was silent, so I walked inside and passed out on a couch. I would’ve marched on for sake of time, but I needed this breakfast—those 12 pancakes would get me 40 miles to Monson by that night. By 9:30 I was, at last, stuffed with sausage, eggs, and twelve blueberry, apple, and cranberry pancakes (honestly, I was surprised at the feat). I moved swiftly on to the ferry at the Kennebec River.
+At the river bank, loons cooed and disappeared underwater. I made a “skalooo” sound, and heard a “skaloo” back from the woods across the river. A man with a straw hat pulled a canoe from the tree-line and paddled across. “Hillbilly Joe” was his name, owing perhaps to his missing teeth. “Thanks for the ferry, man!” I exclaimed enthusiastically. “That’s what I’m here for,” he replied. Across the river, I kept walking.
+The day passed by under sunny skies. Yeah, it hurt, but I was in the mood to hike. Also, the terrain was mild at last. Nervous that darkness would fall before I arrived in Monson (I had no headlamp), the whole day I kept checking my coordinates, counting my mileage and calculating my pace.
+Near sunset, I stopped in a shelter to ask for a headlamp. Perhaps, I figured, I could buy one off a hiker with an extra (a fat chance, right?). Unfortunately, none of the 4 hikers had one. As I went to leave, I heard “wait a minute…I might actually have one.” Believe it or not, he did! I almost kissed the guy. Back on the trail, I found two little boxes of raisins! Then a spring to fill my bottle! I knew it was just good luck but, deep down, God was looking out for me.
+Into the night I hiked. At mile 34, five outside Monson, I hit my limit and crashed at a shelter to rest.
+---
+---
+date: '2010-06-14'
+start: Shaw's Boarding House
+destination: Shaw's Boarding House
+miles_today: 0.0
+trip_miles: 2061.5
+facts:
+  trail_section: Trail section from Shaw's Boarding House to Shaw's Boarding House.
+  confidence: low
+---
+# Monday, June 14, 2010 — Shaw's Boarding House
+**Start Location:** Shaw's Boarding House
+**Miles Today:** 0
+**Trip Miles:** 2061.50
+
+Toggle navigation[Trail Journals](https://www.trailjournals.com/)
+
+- [Journals](https://www.trailjournals.com/journal/entry/316907#)  - [Journals](https://www.trailjournals.com/journals)
+  - [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail/2026)
+  - [Pacific Crest Trail](https://www.trailjournals.com/journals/pacific_crest_trail/2026)
+  - [Colorado Trail](https://www.trailjournals.com/journals/colorado_trail/2026)
+  - [Continental Divide Trail](https://www.trailjournals.com/journals/continental_divide_trail/2026)
+  - [Long Trail - Vermont](https://www.trailjournals.com/journals/the_long_trail_-_vermont/2026)
+  - [Florida Trail](https://www.trailjournals.com/journals/the_florida_trail/2026)
+  - [Arizona Trail](https://www.trailjournals.com/journals/arizona_trail/2026)
+  - [John Muir Trail](https://www.trailjournals.com/journals/john_muir_trail/2026)
+  - [Camino de Santiago](https://www.trailjournals.com/journals/camino_de_santiago/2026)
+  - [American Discovery Trail](https://www.trailjournals.com/journals/american_discovery_trail/2026)
+  - [Coast to Coast Walk](https://www.trailjournals.com/journals/coast_to_coast_walk/2026)
+  - [More...](https://www.trailjournals.com/journals/)
+- [Trails](https://www.trailjournals.com/trails/)
+- [Photos](https://www.trailjournals.com/photos/2026)
+- [Gear](https://www.trailjournals.com/journal/entry/316907#)  - [Current Sales](https://www.trailjournals.com/gear/deals/onsale)
+  - [REI](https://www.trailjournals.com/gear/rei)
+  - [ULA](https://www.trailjournals.com/gear/ula)
+  - [Patagonia](https://www.trailjournals.com/gear/patagonia)
+  - [Cabela's](https://www.trailjournals.com/gear/cabela)
+- [Planning](https://www.trailjournals.com/journal/entry/316907#)  - [Plan Your Hike](https://www.trailjournals.com/planning/)
+  - [Gear](https://www.trailjournals.com/gear/)
+  - [Books](https://www.trailjournals.com/books/)
+  - [Links](https://www.trailjournals.com/links/)
+- [Search](https://www.trailjournals.com/search/)
+- [About](https://www.trailjournals.com/journal/entry/316907#)  - [About Trailjournals](https://www.trailjournals.com/about/)
+  - [Login](https://www.trailjournals.com/user/login)
+  - [Join](https://www.trailjournals.com/join)
+  - [Support Trailjournals](https://www.trailjournals.com/about/donate/)
+  - [Contact](https://www.trailjournals.com/about/contact)
+  - [Store](https://www.trailjournals.com/store/)
+
+Backpacking Journals and Photos from Long Distance Hikers
+
+1. [Home](https://www.trailjournals.com/)
+2. [Journals](https://www.trailjournals.com/journals)
+3. [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail)
+4. [2010](https://www.trailjournals.com/journals/appalachian_trail/2010)
+5. [Uncle Frank](https://www.trailjournals.com/journal/10467)
+6. [Entries](https://www.trailjournals.com/journal/entries/10467/uncle%20-frank)
+7. June 14, 2010
+
+Toggle navigation
+
+- [Journal](https://www.trailjournals.com/journal/10467)
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+- [My Journals](https://www.trailjournals.com/myjournals/10467)
+- [View Guest Book](https://www.trailjournals.com/journal/guestbook/10467)
+- [Sign Guest Book](https://www.trailjournals.com/journal/guestbook/sign/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/4a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/0a.gif)
+
+[Journal](https://www.trailjournals.com/journal/10467)
+
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+
+--Choose--01/21/1002/06/1002/07/1002/08/1002/09/1002/10/1002/11/1002/12/1002/13/1002/14/1002/15/1002/16/1002/17/1002/18/1002/19/1002/20/1002/21/1002/22/1002/23/1002/24/1002/25/1002/26/1002/27/1002/28/1003/01/1003/02/1003/03/1003/04/1003/05/1003/06/1003/07/1003/08/1003/09/1003/11/1003/12/1003/13/1003/14/1003/15/1003/16/1003/17/1003/18/1003/19/1003/20/1003/21/1003/24/1003/25/1003/26/1003/27/1003/28/1003/29/1003/30/1003/31/1004/01/1004/02/1004/03/1004/04/1004/05/1004/06/1004/07/1004/08/1004/09/1004/10/1004/11/1004/12/1004/13/1004/14/1004/15/1004/16/1004/17/1004/18/1004/19/1004/20/1004/21/1004/23/1004/24/1004/25/1004/26/1004/27/1004/28/1004/29/1004/30/1005/01/1005/02/1005/03/1005/04/1005/05/1005/06/1005/07/1005/08/1005/09/1005/10/1005/11/1005/12/1005/13/1005/14/1005/15/1005/16/1005/17/1005/18/1005/19/1005/20/1005/21/1005/22/1005/23/1005/24/1005/25/1005/26/1005/27/1005/28/1005/29/1005/30/1005/31/1006/01/1006/02/1006/03/1006/04/1006/05/1006/06/1006/07/1006/08/1006/09/1006/10/1006/11/1006/12/1006/13/1006/14/1006/15/1006/16/1006/17/1006/18/1006/19/1006/20/1006/21/10
+
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+
+Guest Book
+
+- [Sign](https://www.trailjournals.com/journal/guestbook/sign/10467)
+- [View](https://www.trailjournals.com/journal/guestbook/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/4a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/0a.gif)
+
+- [AT Journals](https://www.trailjournals.com/journals/appalachian_trail)
+- [AT Photos](https://www.trailjournals.com/photos/appalachian_trail)
+- [AT Books](https://www.trailjournals.com/books/appalachian_trail)
+- [Appalachian Trail](http://www.appalachiantrail.org/)
+
+[Join](https://www.trailjournals.com/join) [Login](https://www.trailjournals.com/user/login)
+
+[RSS](https://www.trailjournals.com/journal/rss/10467/xml)
+
+# Uncle Frank's 2010  Appalachian Trail Journal
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/315608) [Next](https://www.trailjournals.com/journal/entry/316908) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+Monday, June 14, 2010
+
+Destination:Shaw's Boarding House
+
+Today's Miles:0
+
+Start Location:Shaw's Boarding House
+
+Trip Miles:2061.50
+
+Destination:Shaw's Boarding House
+
+Start Location:Shaw's Boarding House
+
+Today's Miles:0
+
+Trip Miles:2061.50
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/315608) [Next](https://www.trailjournals.com/journal/entry/316908) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+### Hiker Entries June 14, 2010
+
+|  | Journalist | Destination | Trail |
+| --- | --- | --- | --- |
+|  | [RuhRoh](https://www.trailjournals.com/journal/about/13023) | [Peck's Corner Shelter](https://www.trailjournals.com/journal/entry/366124) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010seeksit_11881TN.jpg) | [seeksit](https://www.trailjournals.com/journal/about/11881) | [Soldier's Delight Natural Area](https://www.trailjournals.com/journal/entry/338075) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | ["Dances with Wolfie"](https://www.trailjournals.com/journal/about/7342) | [RPH Shelter](https://www.trailjournals.com/journal/entry/335991) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/1999beaker_6183TN.jpg) | [beaker](https://www.trailjournals.com/journal/about/6183) | [Boiling Springs](https://www.trailjournals.com/journal/entry/335000) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DidgeridudeandDoodlebug_9852TN.jpg) | [Didgeridude and Doodlebug](https://www.trailjournals.com/journal/about/9852) | [stream](https://www.trailjournals.com/journal/entry/334683) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010LittleFootTheLandBeforeTime_10864TN.jpg) | [Little Foot (The Land Before Time)](https://www.trailjournals.com/journal/about/10864) | [Nowheeeere](https://www.trailjournals.com/journal/entry/331374) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [bone lady](https://www.trailjournals.com/journal/about/11245) | [Norwich, CT](https://www.trailjournals.com/journal/entry/330816) | [The Long Trail - Vermont](https://www.trailjournals.com/journals/The%20_Long%20_Trail%20_-%20_Vermont) |
+|  | [Red Fox](https://www.trailjournals.com/journal/about/10662) | [19E](https://www.trailjournals.com/journal/entry/329868) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Trooper](https://www.trailjournals.com/journal/about/10644) | [San Francisquito Road](https://www.trailjournals.com/journal/entry/329331) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Peru_10969TN.jpg) | [Peru](https://www.trailjournals.com/journal/about/10969) | [War Spur Shelter](https://www.trailjournals.com/journal/entry/325470) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| [More...](https://www.trailjournals.com/entries/2010/06/14) [Grouped By Trail...](https://www.trailjournals.com/entries/2010/06/14/trail) |
+
+|     |
+| --- |
+| ...we hadn't planned a zero so soon, but it feels wonderful now and I am really looking forward to hiking out tomorrow. "Plans are worthless, but planning is everything". Dwight Eisenhower... <br>[Katwalk](https://www.trailjournals.com/journal/entry/485503) —<br>[Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail) [2015](https://www.trailjournals.com/journals/appalachian_trail/2015) |
+
+[![Trailjournals](https://www.trailjournals.com/images/logo.png)](https://www.trailjournals.com/)
+
+#### Hiking
+
+- [Trails](https://www.trailjournals.com/trails/list)
+- [Journals](https://www.trailjournals.com/journals)
+- [Photos](https://www.trailjournals.com/photos)
+- [Calendar](https://www.trailjournals.com/calendar)
+- Gear
+- [Links](https://www.trailjournals.com/links)
+
+#### Partners
+
+- [ULA Equipment](https://ula-equipment.sjv.io/drN9K)
+- [REI](http://www.avantlink.com/click.php?tt=ml&ti=45265&pw=68025)
+- [Patagonia](http://www.avantlink.com/click.php?tt=ml&ti=45781&pw=68025)
+
+#### Network
+
+- [Trail Forums](http://www.trailforums.com/)
+- Trail News
+
+#### About Us
+
+- [Contact](https://www.trailjournals.com/about/contact)
+- [Donate](https://www.trailjournals.com/about/donate)
+- [Join](https://www.trailjournals.com/join)
+- [Login](https://www.trailjournals.com/user/login)
+- [Help](https://www.trailjournals.com/help)
+
+#### Follow Us
+
+- [Facebook](https://www.facebook.com/trailjournals)
+- [Instagram](https://instagram.com/trailjournals/)
+- [Twitter](https://twitter.com/trailjournals)
+- [Pinterest](https://www.pinterest.com/trailjournals/)
+- [Linkedin](https://www.linkedin.com/company/trailjournals-llc)
+
+Top Photo © Mathew Olsen - The Colorado Trail,
+06/22/2001 by
+[Leif](https://www.trailjournals.com/journal/97)
+
+Trailjournals LLC © 2026
+All Rights Reserved. [privacy policy](https://www.trailjournals.com/about/privacy)
+
+Newburyport, MA 01950
+
+[Terms under which this service is provided to you.](https://www.trailjournals.com/about/privacy)
+
+Build: 20210226:165913 [Manage Settings](https://www.trailjournals.com/about/settings)
+---
+---
+date: '2010-06-15'
+start: Shaw's Boarding House
+destination: Wilson Valley Lean-to
+miles_today: 13.7
+trip_miles: 2075.2
+facts:
+  weather: High 66°F, low 50°F. Clear sky.
+  trail_section: Trail section from Shaw's Boarding House to Wilson Valley Lean-to.
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+---
+# Tuesday, June 15, 2010 — Wilson Valley Lean-to
+**Start Location:** Shaw's Boarding House
+**Miles Today:** 13.70
+**Trip Miles:** 2075.20
+
+Toggle navigation[Trail Journals](https://www.trailjournals.com/)
+
+- [Journals](https://www.trailjournals.com/journal/entry/316908#)  - [Journals](https://www.trailjournals.com/journals)
+  - [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail/2026)
+  - [Pacific Crest Trail](https://www.trailjournals.com/journals/pacific_crest_trail/2026)
+  - [Colorado Trail](https://www.trailjournals.com/journals/colorado_trail/2026)
+  - [Continental Divide Trail](https://www.trailjournals.com/journals/continental_divide_trail/2026)
+  - [Long Trail - Vermont](https://www.trailjournals.com/journals/the_long_trail_-_vermont/2026)
+  - [Florida Trail](https://www.trailjournals.com/journals/the_florida_trail/2026)
+  - [Arizona Trail](https://www.trailjournals.com/journals/arizona_trail/2026)
+  - [John Muir Trail](https://www.trailjournals.com/journals/john_muir_trail/2026)
+  - [Camino de Santiago](https://www.trailjournals.com/journals/camino_de_santiago/2026)
+  - [American Discovery Trail](https://www.trailjournals.com/journals/american_discovery_trail/2026)
+  - [Coast to Coast Walk](https://www.trailjournals.com/journals/coast_to_coast_walk/2026)
+  - [More...](https://www.trailjournals.com/journals/)
+- [Trails](https://www.trailjournals.com/trails/)
+- [Photos](https://www.trailjournals.com/photos/2026)
+- [Gear](https://www.trailjournals.com/journal/entry/316908#)  - [Current Sales](https://www.trailjournals.com/gear/deals/onsale)
+  - [REI](https://www.trailjournals.com/gear/rei)
+  - [ULA](https://www.trailjournals.com/gear/ula)
+  - [Patagonia](https://www.trailjournals.com/gear/patagonia)
+  - [Cabela's](https://www.trailjournals.com/gear/cabela)
+- [Planning](https://www.trailjournals.com/journal/entry/316908#)  - [Plan Your Hike](https://www.trailjournals.com/planning/)
+  - [Gear](https://www.trailjournals.com/gear/)
+  - [Books](https://www.trailjournals.com/books/)
+  - [Links](https://www.trailjournals.com/links/)
+- [Search](https://www.trailjournals.com/search/)
+- [About](https://www.trailjournals.com/journal/entry/316908#)  - [About Trailjournals](https://www.trailjournals.com/about/)
+  - [Login](https://www.trailjournals.com/user/login)
+  - [Join](https://www.trailjournals.com/join)
+  - [Support Trailjournals](https://www.trailjournals.com/about/donate/)
+  - [Contact](https://www.trailjournals.com/about/contact)
+  - [Store](https://www.trailjournals.com/store/)
+
+Backpacking Journals and Photos from Long Distance Hikers
+
+1. [Home](https://www.trailjournals.com/)
+2. [Journals](https://www.trailjournals.com/journals)
+3. [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail)
+4. [2010](https://www.trailjournals.com/journals/appalachian_trail/2010)
+5. [Uncle Frank](https://www.trailjournals.com/journal/10467)
+6. [Entries](https://www.trailjournals.com/journal/entries/10467/uncle%20-frank)
+7. June 15, 2010
+
+Toggle navigation
+
+- [Journal](https://www.trailjournals.com/journal/10467)
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+- [My Journals](https://www.trailjournals.com/myjournals/10467)
+- [View Guest Book](https://www.trailjournals.com/journal/guestbook/10467)
+- [Sign Guest Book](https://www.trailjournals.com/journal/guestbook/sign/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/4a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/2a.gif)
+
+[Journal](https://www.trailjournals.com/journal/10467)
+
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+
+--Choose--01/21/1002/06/1002/07/1002/08/1002/09/1002/10/1002/11/1002/12/1002/13/1002/14/1002/15/1002/16/1002/17/1002/18/1002/19/1002/20/1002/21/1002/22/1002/23/1002/24/1002/25/1002/26/1002/27/1002/28/1003/01/1003/02/1003/03/1003/04/1003/05/1003/06/1003/07/1003/08/1003/09/1003/11/1003/12/1003/13/1003/14/1003/15/1003/16/1003/17/1003/18/1003/19/1003/20/1003/21/1003/24/1003/25/1003/26/1003/27/1003/28/1003/29/1003/30/1003/31/1004/01/1004/02/1004/03/1004/04/1004/05/1004/06/1004/07/1004/08/1004/09/1004/10/1004/11/1004/12/1004/13/1004/14/1004/15/1004/16/1004/17/1004/18/1004/19/1004/20/1004/21/1004/23/1004/24/1004/25/1004/26/1004/27/1004/28/1004/29/1004/30/1005/01/1005/02/1005/03/1005/04/1005/05/1005/06/1005/07/1005/08/1005/09/1005/10/1005/11/1005/12/1005/13/1005/14/1005/15/1005/16/1005/17/1005/18/1005/19/1005/20/1005/21/1005/22/1005/23/1005/24/1005/25/1005/26/1005/27/1005/28/1005/29/1005/30/1005/31/1006/01/1006/02/1006/03/1006/04/1006/05/1006/06/1006/07/1006/08/1006/09/1006/10/1006/11/1006/12/1006/13/1006/14/1006/15/1006/16/1006/17/1006/18/1006/19/1006/20/1006/21/10
+
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+
+Guest Book
+
+- [Sign](https://www.trailjournals.com/journal/guestbook/sign/10467)
+- [View](https://www.trailjournals.com/journal/guestbook/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/4a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/2a.gif)
+
+- [AT Journals](https://www.trailjournals.com/journals/appalachian_trail)
+- [AT Photos](https://www.trailjournals.com/photos/appalachian_trail)
+- [AT Books](https://www.trailjournals.com/books/appalachian_trail)
+- [Appalachian Trail](http://www.appalachiantrail.org/)
+
+[Join](https://www.trailjournals.com/join) [Login](https://www.trailjournals.com/user/login)
+
+[RSS](https://www.trailjournals.com/journal/rss/10467/xml)
+
+# Uncle Frank's 2010  Appalachian Trail Journal
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/316907) [Next](https://www.trailjournals.com/journal/entry/316909) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+Tuesday, June 15, 2010
+
+Destination:Wilson Valley Lean-to
+
+Today's Miles:13.70
+
+Start Location:Shaw's Boarding House
+
+Trip Miles:2075.20
+
+Destination:Wilson Valley Lean-to
+
+Start Location:Shaw's Boarding House
+
+Today's Miles:13.70
+
+Trip Miles:2075.20
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/316907) [Next](https://www.trailjournals.com/journal/entry/316909) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+### Hiker Entries June 15, 2010
+
+|  | Journalist | Destination | Trail |
+| --- | --- | --- | --- |
+|  | [RuhRoh](https://www.trailjournals.com/journal/about/13023) | [Newfound Gap](https://www.trailjournals.com/journal/entry/366125) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Rough Cut](https://www.trailjournals.com/journal/about/11734) | [RPH Shelter](https://www.trailjournals.com/journal/entry/336856) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | ["Dances with Wolfie"](https://www.trailjournals.com/journal/about/7342) | [NY55/Hotel](https://www.trailjournals.com/journal/entry/335993) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/1999beaker_6183TN.jpg) | [beaker](https://www.trailjournals.com/journal/about/6183) | [Boiling Springs](https://www.trailjournals.com/journal/entry/335001) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DidgeridudeandDoodlebug_9852TN.jpg) | [Didgeridude and Doodlebug](https://www.trailjournals.com/journal/about/9852) | [Allenberry Boiling Springs](https://www.trailjournals.com/journal/entry/334684) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [58Starter](https://www.trailjournals.com/journal/about/11488) | [Dicks Creek Gap Rd](https://www.trailjournals.com/journal/entry/334555) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [trackz man and sscblaze](https://www.trailjournals.com/journal/about/11275) | [East side of Black Butte](https://www.trailjournals.com/journal/entry/331528) | [Tahoe Rim Trail](https://www.trailjournals.com/journals/Tahoe%20_Rim%20_Trail) |
+|  | [bone lady](https://www.trailjournals.com/journal/about/11245) | [Dalton, Mass](https://www.trailjournals.com/journal/entry/330817) | [The Long Trail - Vermont](https://www.trailjournals.com/journals/The%20_Long%20_Trail%20_-%20_Vermont) |
+|  | [Red Fox](https://www.trailjournals.com/journal/about/10662) | [Kincora Hiking hostel](https://www.trailjournals.com/journal/entry/329869) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Trooper](https://www.trailjournals.com/journal/about/10644) | [Mile 500](https://www.trailjournals.com/journal/entry/329336) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+| [More...](https://www.trailjournals.com/entries/2010/06/15) [Grouped By Trail...](https://www.trailjournals.com/entries/2010/06/15/trail) |
+
+|     |
+| --- |
+| I was caught in a downpour. Lightning flashed and thunder cracked right after. Raindrops pelted at me sideways. The trail turned into a river as rainwater gushed downhill, soaking my boots. I felt like Dorothy in the twister, trying to keep my umbrella from blowing inside-out, trying not to slip on the smooth, wet rocks, trying to see the white blazes through the rain.... <br>[Red Panda](https://www.trailjournals.com/journal/entry/502313) —<br>[Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail) [2015](https://www.trailjournals.com/journals/appalachian_trail/2015) |
+
+[![Trailjournals](https://www.trailjournals.com/images/logo.png)](https://www.trailjournals.com/)
+
+#### Hiking
+
+- [Trails](https://www.trailjournals.com/trails/list)
+- [Journals](https://www.trailjournals.com/journals)
+- [Photos](https://www.trailjournals.com/photos)
+- [Calendar](https://www.trailjournals.com/calendar)
+- Gear
+- [Links](https://www.trailjournals.com/links)
+
+#### Partners
+
+- [ULA Equipment](https://ula-equipment.sjv.io/drN9K)
+- [REI](http://www.avantlink.com/click.php?tt=ml&ti=45265&pw=68025)
+- [Patagonia](http://www.avantlink.com/click.php?tt=ml&ti=45781&pw=68025)
+
+#### Network
+
+- [Trail Forums](http://www.trailforums.com/)
+- Trail News
+
+#### About Us
+
+- [Contact](https://www.trailjournals.com/about/contact)
+- [Donate](https://www.trailjournals.com/about/donate)
+- [Join](https://www.trailjournals.com/join)
+- [Login](https://www.trailjournals.com/user/login)
+- [Help](https://www.trailjournals.com/help)
+
+#### Follow Us
+
+- [Facebook](https://www.facebook.com/trailjournals)
+- [Instagram](https://instagram.com/trailjournals/)
+- [Twitter](https://twitter.com/trailjournals)
+- [Pinterest](https://www.pinterest.com/trailjournals/)
+- [Linkedin](https://www.linkedin.com/company/trailjournals-llc)
+
+Top Photo © Comer and Jean - Appalachian Trail,
+07/01/2001 by
+[Comer and Jean](https://www.trailjournals.com/journal/129)
+
+Trailjournals LLC © 2026
+All Rights Reserved. [privacy policy](https://www.trailjournals.com/about/privacy)
+
+Newburyport, MA 01950
+
+[Terms under which this service is provided to you.](https://www.trailjournals.com/about/privacy)
+
+Build: 20210226:165913 [Manage Settings](https://www.trailjournals.com/about/settings)
+---
+---
+date: '2010-06-16'
+start: Wilson Valley Lean-to
+destination: Chairback Gap Lean-to
+miles_today: 15.6
+trip_miles: 2090.8
+facts:
+  weather: High 69°F, low 47°F. Overcast.
+  trail_section: Trail section from Wilson Valley Lean-to to Chairback Gap Lean-to.
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+---
+# Wednesday, June 16, 2010 — Chairback Gap Lean-to
+**Start Location:** Wilson Valley Lean-to
+**Miles Today:** 15.60
+**Trip Miles:** 2090.80
+
+Toggle navigation[Trail Journals](https://www.trailjournals.com/)
+
+- [Journals](https://www.trailjournals.com/journal/entry/316909#)  - [Journals](https://www.trailjournals.com/journals)
+  - [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail/2026)
+  - [Pacific Crest Trail](https://www.trailjournals.com/journals/pacific_crest_trail/2026)
+  - [Colorado Trail](https://www.trailjournals.com/journals/colorado_trail/2026)
+  - [Continental Divide Trail](https://www.trailjournals.com/journals/continental_divide_trail/2026)
+  - [Long Trail - Vermont](https://www.trailjournals.com/journals/the_long_trail_-_vermont/2026)
+  - [Florida Trail](https://www.trailjournals.com/journals/the_florida_trail/2026)
+  - [Arizona Trail](https://www.trailjournals.com/journals/arizona_trail/2026)
+  - [John Muir Trail](https://www.trailjournals.com/journals/john_muir_trail/2026)
+  - [Camino de Santiago](https://www.trailjournals.com/journals/camino_de_santiago/2026)
+  - [American Discovery Trail](https://www.trailjournals.com/journals/american_discovery_trail/2026)
+  - [Coast to Coast Walk](https://www.trailjournals.com/journals/coast_to_coast_walk/2026)
+  - [More...](https://www.trailjournals.com/journals/)
+- [Trails](https://www.trailjournals.com/trails/)
+- [Photos](https://www.trailjournals.com/photos/2026)
+- [Gear](https://www.trailjournals.com/journal/entry/316909#)  - [Current Sales](https://www.trailjournals.com/gear/deals/onsale)
+  - [REI](https://www.trailjournals.com/gear/rei)
+  - [ULA](https://www.trailjournals.com/gear/ula)
+  - [Patagonia](https://www.trailjournals.com/gear/patagonia)
+  - [Cabela's](https://www.trailjournals.com/gear/cabela)
+- [Planning](https://www.trailjournals.com/journal/entry/316909#)  - [Plan Your Hike](https://www.trailjournals.com/planning/)
+  - [Gear](https://www.trailjournals.com/gear/)
+  - [Books](https://www.trailjournals.com/books/)
+  - [Links](https://www.trailjournals.com/links/)
+- [Search](https://www.trailjournals.com/search/)
+- [About](https://www.trailjournals.com/journal/entry/316909#)  - [About Trailjournals](https://www.trailjournals.com/about/)
+  - [Login](https://www.trailjournals.com/user/login)
+  - [Join](https://www.trailjournals.com/join)
+  - [Support Trailjournals](https://www.trailjournals.com/about/donate/)
+  - [Contact](https://www.trailjournals.com/about/contact)
+  - [Store](https://www.trailjournals.com/store/)
+
+Backpacking Journals and Photos from Long Distance Hikers
+
+1. [Home](https://www.trailjournals.com/)
+2. [Journals](https://www.trailjournals.com/journals)
+3. [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail)
+4. [2010](https://www.trailjournals.com/journals/appalachian_trail/2010)
+5. [Uncle Frank](https://www.trailjournals.com/journal/10467)
+6. [Entries](https://www.trailjournals.com/journal/entries/10467/uncle%20-frank)
+7. June 16, 2010
+
+Toggle navigation
+
+- [Journal](https://www.trailjournals.com/journal/10467)
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+- [My Journals](https://www.trailjournals.com/myjournals/10467)
+- [View Guest Book](https://www.trailjournals.com/journal/guestbook/10467)
+- [Sign Guest Book](https://www.trailjournals.com/journal/guestbook/sign/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/4a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/5a.gif)
+
+[Journal](https://www.trailjournals.com/journal/10467)
+
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+
+--Choose--01/21/1002/06/1002/07/1002/08/1002/09/1002/10/1002/11/1002/12/1002/13/1002/14/1002/15/1002/16/1002/17/1002/18/1002/19/1002/20/1002/21/1002/22/1002/23/1002/24/1002/25/1002/26/1002/27/1002/28/1003/01/1003/02/1003/03/1003/04/1003/05/1003/06/1003/07/1003/08/1003/09/1003/11/1003/12/1003/13/1003/14/1003/15/1003/16/1003/17/1003/18/1003/19/1003/20/1003/21/1003/24/1003/25/1003/26/1003/27/1003/28/1003/29/1003/30/1003/31/1004/01/1004/02/1004/03/1004/04/1004/05/1004/06/1004/07/1004/08/1004/09/1004/10/1004/11/1004/12/1004/13/1004/14/1004/15/1004/16/1004/17/1004/18/1004/19/1004/20/1004/21/1004/23/1004/24/1004/25/1004/26/1004/27/1004/28/1004/29/1004/30/1005/01/1005/02/1005/03/1005/04/1005/05/1005/06/1005/07/1005/08/1005/09/1005/10/1005/11/1005/12/1005/13/1005/14/1005/15/1005/16/1005/17/1005/18/1005/19/1005/20/1005/21/1005/22/1005/23/1005/24/1005/25/1005/26/1005/27/1005/28/1005/29/1005/30/1005/31/1006/01/1006/02/1006/03/1006/04/1006/05/1006/06/1006/07/1006/08/1006/09/1006/10/1006/11/1006/12/1006/13/1006/14/1006/15/1006/16/1006/17/1006/18/1006/19/1006/20/1006/21/10
+
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+
+Guest Book
+
+- [Sign](https://www.trailjournals.com/journal/guestbook/sign/10467)
+- [View](https://www.trailjournals.com/journal/guestbook/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/4a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/5a.gif)
+
+- [AT Journals](https://www.trailjournals.com/journals/appalachian_trail)
+- [AT Photos](https://www.trailjournals.com/photos/appalachian_trail)
+- [AT Books](https://www.trailjournals.com/books/appalachian_trail)
+- [Appalachian Trail](http://www.appalachiantrail.org/)
+
+[Join](https://www.trailjournals.com/join) [Login](https://www.trailjournals.com/user/login)
+
+[RSS](https://www.trailjournals.com/journal/rss/10467/xml)
+
+# Uncle Frank's 2010  Appalachian Trail Journal
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/316908) [Next](https://www.trailjournals.com/journal/entry/316910) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+Wednesday, June 16, 2010
+
+Destination:Chairback Gap Lean-to
+
+Today's Miles:15.60
+
+Start Location:Wilson Valley Lean-to
+
+Trip Miles:2090.80
+
+Destination:Chairback Gap Lean-to
+
+Start Location:Wilson Valley Lean-to
+
+Today's Miles:15.60
+
+Trip Miles:2090.80
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/316908) [Next](https://www.trailjournals.com/journal/entry/316910) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+### Hiker Entries June 16, 2010
+
+|  | Journalist | Destination | Trail |
+| --- | --- | --- | --- |
+|  | [Deluxe](https://www.trailjournals.com/journal/about/21748) | [\-\- View Entry --](https://www.trailjournals.com/journal/entry/566469) | [Northville-Placid Trail](https://www.trailjournals.com/journals/Northville-Placid%20_Trail) |
+|  | [Deluxe](https://www.trailjournals.com/journal/about/21748) | [\-\- View Entry --](https://www.trailjournals.com/journal/entry/566467) | [Northville-Placid Trail](https://www.trailjournals.com/journals/Northville-Placid%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010seeksit_11881TN.jpg) | [seeksit](https://www.trailjournals.com/journal/about/11881) | [End of Bollinger Mill Road, Liberty Reservoir](https://www.trailjournals.com/journal/entry/338076) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Rough Cut](https://www.trailjournals.com/journal/about/11734) | [Morgan Stewart Shelter](https://www.trailjournals.com/journal/entry/336857) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | ["Dances with Wolfie"](https://www.trailjournals.com/journal/about/7342) | [Hoyt Rd NY/CT Line](https://www.trailjournals.com/journal/entry/335994) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/1999beaker_6183TN.jpg) | [beaker](https://www.trailjournals.com/journal/about/6183) | [Darlington Shelter](https://www.trailjournals.com/journal/entry/335006) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DidgeridudeandDoodlebug_9852TN.jpg) | [Didgeridude and Doodlebug](https://www.trailjournals.com/journal/about/9852) | [Allenberry](https://www.trailjournals.com/journal/entry/334685) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [trackz man and sscblaze](https://www.trailjournals.com/journal/about/11275) | [South ridge above Squaw Creek](https://www.trailjournals.com/journal/entry/331529) | [Tahoe Rim Trail](https://www.trailjournals.com/journals/Tahoe%20_Rim%20_Trail) |
+|  | [bone lady](https://www.trailjournals.com/journal/about/11245) | [Congdon Shelter](https://www.trailjournals.com/journal/entry/330818) | [The Long Trail - Vermont](https://www.trailjournals.com/journals/The%20_Long%20_Trail%20_-%20_Vermont) |
+|  | [Red Fox](https://www.trailjournals.com/journal/about/10662) | [Watuga Lake](https://www.trailjournals.com/journal/entry/329870) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| [More...](https://www.trailjournals.com/entries/2010/06/16) [Grouped By Trail...](https://www.trailjournals.com/entries/2010/06/16/trail) |
+
+|     |
+| --- |
+| The weather relaxed, and to our left the valley opened up in a soft light with soft ethereal edges. It looked like heaven.... <br>[Whirled Peas](https://www.trailjournals.com/journal/entry/434924) —<br>[Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail) [2013](https://www.trailjournals.com/journals/appalachian_trail/2013) |
+
+[![Trailjournals](https://www.trailjournals.com/images/logo.png)](https://www.trailjournals.com/)
+
+#### Hiking
+
+- [Trails](https://www.trailjournals.com/trails/list)
+- [Journals](https://www.trailjournals.com/journals)
+- [Photos](https://www.trailjournals.com/photos)
+- [Calendar](https://www.trailjournals.com/calendar)
+- Gear
+- [Links](https://www.trailjournals.com/links)
+
+#### Partners
+
+- [ULA Equipment](https://ula-equipment.sjv.io/drN9K)
+- [REI](http://www.avantlink.com/click.php?tt=ml&ti=45265&pw=68025)
+- [Patagonia](http://www.avantlink.com/click.php?tt=ml&ti=45781&pw=68025)
+
+#### Network
+
+- [Trail Forums](http://www.trailforums.com/)
+- Trail News
+
+#### About Us
+
+- [Contact](https://www.trailjournals.com/about/contact)
+- [Donate](https://www.trailjournals.com/about/donate)
+- [Join](https://www.trailjournals.com/join)
+- [Login](https://www.trailjournals.com/user/login)
+- [Help](https://www.trailjournals.com/help)
+
+#### Follow Us
+
+- [Facebook](https://www.facebook.com/trailjournals)
+- [Instagram](https://instagram.com/trailjournals/)
+- [Twitter](https://twitter.com/trailjournals)
+- [Pinterest](https://www.pinterest.com/trailjournals/)
+- [Linkedin](https://www.linkedin.com/company/trailjournals-llc)
+
+Top Photo © Comer and Jean - Appalachian Trail,
+07/01/2001 by
+[Comer and Jean](https://www.trailjournals.com/journal/129)
+
+Trailjournals LLC © 2026
+All Rights Reserved. [privacy policy](https://www.trailjournals.com/about/privacy)
+
+Newburyport, MA 01950
+
+[Terms under which this service is provided to you.](https://www.trailjournals.com/about/privacy)
+
+Build: 20210226:165913 [Manage Settings](https://www.trailjournals.com/about/settings)
+---
+---
+date: '2010-06-17'
+start: Chairback Gap Lean-to
+destination: Cooper Brook Falls Lean-to
+miles_today: 29.0
+trip_miles: 2119.8
+facts:
+  weather: High 67°F, low 49°F. Slight rain.
+  trail_section: Trail section from Chairback Gap Lean-to to Cooper Brook Falls Lean-to.
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+---
+# Thursday, June 17, 2010 — Cooper Brook Falls Lean-to
+**Start Location:** Chairback Gap Lean-to
+**Miles Today:** 29
+**Trip Miles:** 2119.80
+
+Toggle navigation[Trail Journals](https://www.trailjournals.com/)
+
+- [Journals](https://www.trailjournals.com/journal/entry/316910#)  - [Journals](https://www.trailjournals.com/journals)
+  - [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail/2026)
+  - [Pacific Crest Trail](https://www.trailjournals.com/journals/pacific_crest_trail/2026)
+  - [Colorado Trail](https://www.trailjournals.com/journals/colorado_trail/2026)
+  - [Continental Divide Trail](https://www.trailjournals.com/journals/continental_divide_trail/2026)
+  - [Long Trail - Vermont](https://www.trailjournals.com/journals/the_long_trail_-_vermont/2026)
+  - [Florida Trail](https://www.trailjournals.com/journals/the_florida_trail/2026)
+  - [Arizona Trail](https://www.trailjournals.com/journals/arizona_trail/2026)
+  - [John Muir Trail](https://www.trailjournals.com/journals/john_muir_trail/2026)
+  - [Camino de Santiago](https://www.trailjournals.com/journals/camino_de_santiago/2026)
+  - [American Discovery Trail](https://www.trailjournals.com/journals/american_discovery_trail/2026)
+  - [Coast to Coast Walk](https://www.trailjournals.com/journals/coast_to_coast_walk/2026)
+  - [More...](https://www.trailjournals.com/journals/)
+- [Trails](https://www.trailjournals.com/trails/)
+- [Photos](https://www.trailjournals.com/photos/2026)
+- [Gear](https://www.trailjournals.com/journal/entry/316910#)  - [Current Sales](https://www.trailjournals.com/gear/deals/onsale)
+  - [REI](https://www.trailjournals.com/gear/rei)
+  - [ULA](https://www.trailjournals.com/gear/ula)
+  - [Patagonia](https://www.trailjournals.com/gear/patagonia)
+  - [Cabela's](https://www.trailjournals.com/gear/cabela)
+- [Planning](https://www.trailjournals.com/journal/entry/316910#)  - [Plan Your Hike](https://www.trailjournals.com/planning/)
+  - [Gear](https://www.trailjournals.com/gear/)
+  - [Books](https://www.trailjournals.com/books/)
+  - [Links](https://www.trailjournals.com/links/)
+- [Search](https://www.trailjournals.com/search/)
+- [About](https://www.trailjournals.com/journal/entry/316910#)  - [About Trailjournals](https://www.trailjournals.com/about/)
+  - [Login](https://www.trailjournals.com/user/login)
+  - [Join](https://www.trailjournals.com/join)
+  - [Support Trailjournals](https://www.trailjournals.com/about/donate/)
+  - [Contact](https://www.trailjournals.com/about/contact)
+  - [Store](https://www.trailjournals.com/store/)
+
+Backpacking Journals and Photos from Long Distance Hikers
+
+1. [Home](https://www.trailjournals.com/)
+2. [Journals](https://www.trailjournals.com/journals)
+3. [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail)
+4. [2010](https://www.trailjournals.com/journals/appalachian_trail/2010)
+5. [Uncle Frank](https://www.trailjournals.com/journal/10467)
+6. [Entries](https://www.trailjournals.com/journal/entries/10467/uncle%20-frank)
+7. June 17, 2010
+
+Toggle navigation
+
+- [Journal](https://www.trailjournals.com/journal/10467)
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+- [My Journals](https://www.trailjournals.com/myjournals/10467)
+- [View Guest Book](https://www.trailjournals.com/journal/guestbook/10467)
+- [Sign Guest Book](https://www.trailjournals.com/journal/guestbook/sign/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/4a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/2a.gif)
+
+[Journal](https://www.trailjournals.com/journal/10467)
+
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+
+--Choose--01/21/1002/06/1002/07/1002/08/1002/09/1002/10/1002/11/1002/12/1002/13/1002/14/1002/15/1002/16/1002/17/1002/18/1002/19/1002/20/1002/21/1002/22/1002/23/1002/24/1002/25/1002/26/1002/27/1002/28/1003/01/1003/02/1003/03/1003/04/1003/05/1003/06/1003/07/1003/08/1003/09/1003/11/1003/12/1003/13/1003/14/1003/15/1003/16/1003/17/1003/18/1003/19/1003/20/1003/21/1003/24/1003/25/1003/26/1003/27/1003/28/1003/29/1003/30/1003/31/1004/01/1004/02/1004/03/1004/04/1004/05/1004/06/1004/07/1004/08/1004/09/1004/10/1004/11/1004/12/1004/13/1004/14/1004/15/1004/16/1004/17/1004/18/1004/19/1004/20/1004/21/1004/23/1004/24/1004/25/1004/26/1004/27/1004/28/1004/29/1004/30/1005/01/1005/02/1005/03/1005/04/1005/05/1005/06/1005/07/1005/08/1005/09/1005/10/1005/11/1005/12/1005/13/1005/14/1005/15/1005/16/1005/17/1005/18/1005/19/1005/20/1005/21/1005/22/1005/23/1005/24/1005/25/1005/26/1005/27/1005/28/1005/29/1005/30/1005/31/1006/01/1006/02/1006/03/1006/04/1006/05/1006/06/1006/07/1006/08/1006/09/1006/10/1006/11/1006/12/1006/13/1006/14/1006/15/1006/16/1006/17/1006/18/1006/19/1006/20/1006/21/10
+
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+
+Guest Book
+
+- [Sign](https://www.trailjournals.com/journal/guestbook/sign/10467)
+- [View](https://www.trailjournals.com/journal/guestbook/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/4a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/2a.gif)
+
+- [AT Journals](https://www.trailjournals.com/journals/appalachian_trail)
+- [AT Photos](https://www.trailjournals.com/photos/appalachian_trail)
+- [AT Books](https://www.trailjournals.com/books/appalachian_trail)
+- [Appalachian Trail](http://www.appalachiantrail.org/)
+
+[Join](https://www.trailjournals.com/join) [Login](https://www.trailjournals.com/user/login)
+
+[RSS](https://www.trailjournals.com/journal/rss/10467/xml)
+
+# Uncle Frank's 2010  Appalachian Trail Journal
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/316909) [Next](https://www.trailjournals.com/journal/entry/316911) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+Thursday, June 17, 2010
+
+Destination:Cooper Brook Falls Lean-to
+
+Today's Miles:29
+
+Start Location:Chairback Gap Lean-to
+
+Trip Miles:2119.80
+
+Destination:Cooper Brook Falls Lean-to
+
+Start Location:Chairback Gap Lean-to
+
+Today's Miles:29
+
+Trip Miles:2119.80
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/316909) [Next](https://www.trailjournals.com/journal/entry/316911) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+### Hiker Entries June 17, 2010
+
+|  | Journalist | Destination | Trail |
+| --- | --- | --- | --- |
+|  | [Transient](https://www.trailjournals.com/journal/about/13775) | [Dragon Lake Trail](https://www.trailjournals.com/journal/entry/380603) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010seeksit_11881TN.jpg) | [seeksit](https://www.trailjournals.com/journal/about/11881) | [Cat Rock, Cunningham Falls State Park](https://www.trailjournals.com/journal/entry/338077) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Rough Cut](https://www.trailjournals.com/journal/about/11734) | [Telephone Pioneer Shelter](https://www.trailjournals.com/journal/entry/336858) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/1999beaker_6183TN.jpg) | [beaker](https://www.trailjournals.com/journal/about/6183) | [Doyle Hotel](https://www.trailjournals.com/journal/entry/335007) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DidgeridudeandDoodlebug_9852TN.jpg) | [Didgeridude and Doodlebug](https://www.trailjournals.com/journal/about/9852) | [Darlington Shelter](https://www.trailjournals.com/journal/entry/334686) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DavidandBecky_11425TN.jpg) |  | [Our 2010 CDT Hike: An Intro](https://www.trailjournals.com/journal/entry/333887) | [Continental Divide Trail](https://www.trailjournals.com/journals/Continental%20_Divide%20_Trail) |
+|  | [trackz man and sscblaze](https://www.trailjournals.com/journal/about/11275) | [Myrazek Trail-above Tumalo Falls](https://www.trailjournals.com/journal/entry/331530) | [Tahoe Rim Trail](https://www.trailjournals.com/journals/Tahoe%20_Rim%20_Trail) |
+|  | [bone lady](https://www.trailjournals.com/journal/about/11245) | [Goddard Shelter](https://www.trailjournals.com/journal/entry/330819) | [The Long Trail - Vermont](https://www.trailjournals.com/journals/The%20_Long%20_Trail%20_-%20_Vermont) |
+|  | [Red Fox](https://www.trailjournals.com/journal/about/10662) | [Handicapped AT trail](https://www.trailjournals.com/journal/entry/329871) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Trooper](https://www.trailjournals.com/journal/about/10644) | [Tehachapi-Willow Springs Rd](https://www.trailjournals.com/journal/entry/329339) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+| [More...](https://www.trailjournals.com/entries/2010/06/17) [Grouped By Trail...](https://www.trailjournals.com/entries/2010/06/17/trail) |
+
+|     |
+| --- |
+| What is better than two cokes, four hard boiled eggs, a Klondike Ice Cream Bar, two cookies, and hand picked blueberries? Nothing.... <br>[Three By Five](https://www.trailjournals.com/journal/entry/469659) —<br>[Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail) [2014](https://www.trailjournals.com/journals/appalachian_trail/2014) |
+
+[![Trailjournals](https://www.trailjournals.com/images/logo.png)](https://www.trailjournals.com/)
+
+#### Hiking
+
+- [Trails](https://www.trailjournals.com/trails/list)
+- [Journals](https://www.trailjournals.com/journals)
+- [Photos](https://www.trailjournals.com/photos)
+- [Calendar](https://www.trailjournals.com/calendar)
+- Gear
+- [Links](https://www.trailjournals.com/links)
+
+#### Partners
+
+- [ULA Equipment](https://ula-equipment.sjv.io/drN9K)
+- [REI](http://www.avantlink.com/click.php?tt=ml&ti=45265&pw=68025)
+- [Patagonia](http://www.avantlink.com/click.php?tt=ml&ti=45781&pw=68025)
+
+#### Network
+
+- [Trail Forums](http://www.trailforums.com/)
+- Trail News
+
+#### About Us
+
+- [Contact](https://www.trailjournals.com/about/contact)
+- [Donate](https://www.trailjournals.com/about/donate)
+- [Join](https://www.trailjournals.com/join)
+- [Login](https://www.trailjournals.com/user/login)
+- [Help](https://www.trailjournals.com/help)
+
+#### Follow Us
+
+- [Facebook](https://www.facebook.com/trailjournals)
+- [Instagram](https://instagram.com/trailjournals/)
+- [Twitter](https://twitter.com/trailjournals)
+- [Pinterest](https://www.pinterest.com/trailjournals/)
+- [Linkedin](https://www.linkedin.com/company/trailjournals-llc)
+
+Top Photo © Mathew Olsen - The Colorado Trail,
+06/22/2001 by
+[Leif](https://www.trailjournals.com/journal/97)
+
+Trailjournals LLC © 2026
+All Rights Reserved. [privacy policy](https://www.trailjournals.com/about/privacy)
+
+Newburyport, MA 01950
+
+[Terms under which this service is provided to you.](https://www.trailjournals.com/about/privacy)
+
+Build: 20210226:165913 [Manage Settings](https://www.trailjournals.com/about/settings)
+---
+---
+date: '2010-06-18'
+start: Cooper Brook Falls Lean-to
+destination: Wadleigh Stream Lean-to
+miles_today: 21.5
+trip_miles: 2141.3
+facts:
+  weather: High 79°F, low 58°F. Overcast.
+  trail_section: Trail section from Cooper Brook Falls Lean-to to Wadleigh Stream
+    Lean-to.
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+---
+# Friday, June 18, 2010 — Wadleigh Stream Lean-to
+**Start Location:** Cooper Brook Falls Lean-to
+**Miles Today:** 21.50
+**Trip Miles:** 2141.30
+
+Toggle navigation[Trail Journals](https://www.trailjournals.com/)
+
+- [Journals](https://www.trailjournals.com/journal/entry/316911#)  - [Journals](https://www.trailjournals.com/journals)
+  - [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail/2026)
+  - [Pacific Crest Trail](https://www.trailjournals.com/journals/pacific_crest_trail/2026)
+  - [Colorado Trail](https://www.trailjournals.com/journals/colorado_trail/2026)
+  - [Continental Divide Trail](https://www.trailjournals.com/journals/continental_divide_trail/2026)
+  - [Long Trail - Vermont](https://www.trailjournals.com/journals/the_long_trail_-_vermont/2026)
+  - [Florida Trail](https://www.trailjournals.com/journals/the_florida_trail/2026)
+  - [Arizona Trail](https://www.trailjournals.com/journals/arizona_trail/2026)
+  - [John Muir Trail](https://www.trailjournals.com/journals/john_muir_trail/2026)
+  - [Camino de Santiago](https://www.trailjournals.com/journals/camino_de_santiago/2026)
+  - [American Discovery Trail](https://www.trailjournals.com/journals/american_discovery_trail/2026)
+  - [Coast to Coast Walk](https://www.trailjournals.com/journals/coast_to_coast_walk/2026)
+  - [More...](https://www.trailjournals.com/journals/)
+- [Trails](https://www.trailjournals.com/trails/)
+- [Photos](https://www.trailjournals.com/photos/2026)
+- [Gear](https://www.trailjournals.com/journal/entry/316911#)  - [Current Sales](https://www.trailjournals.com/gear/deals/onsale)
+  - [REI](https://www.trailjournals.com/gear/rei)
+  - [ULA](https://www.trailjournals.com/gear/ula)
+  - [Patagonia](https://www.trailjournals.com/gear/patagonia)
+  - [Cabela's](https://www.trailjournals.com/gear/cabela)
+- [Planning](https://www.trailjournals.com/journal/entry/316911#)  - [Plan Your Hike](https://www.trailjournals.com/planning/)
+  - [Gear](https://www.trailjournals.com/gear/)
+  - [Books](https://www.trailjournals.com/books/)
+  - [Links](https://www.trailjournals.com/links/)
+- [Search](https://www.trailjournals.com/search/)
+- [About](https://www.trailjournals.com/journal/entry/316911#)  - [About Trailjournals](https://www.trailjournals.com/about/)
+  - [Login](https://www.trailjournals.com/user/login)
+  - [Join](https://www.trailjournals.com/join)
+  - [Support Trailjournals](https://www.trailjournals.com/about/donate/)
+  - [Contact](https://www.trailjournals.com/about/contact)
+  - [Store](https://www.trailjournals.com/store/)
+
+Backpacking Journals and Photos from Long Distance Hikers
+
+1. [Home](https://www.trailjournals.com/)
+2. [Journals](https://www.trailjournals.com/journals)
+3. [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail)
+4. [2010](https://www.trailjournals.com/journals/appalachian_trail/2010)
+5. [Uncle Frank](https://www.trailjournals.com/journal/10467)
+6. [Entries](https://www.trailjournals.com/journal/entries/10467/uncle%20-frank)
+7. June 18, 2010
+
+Toggle navigation
+
+- [Journal](https://www.trailjournals.com/journal/10467)
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+- [My Journals](https://www.trailjournals.com/myjournals/10467)
+- [View Guest Book](https://www.trailjournals.com/journal/guestbook/10467)
+- [Sign Guest Book](https://www.trailjournals.com/journal/guestbook/sign/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/4a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/8a.gif)
+
+[Journal](https://www.trailjournals.com/journal/10467)
+
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+
+--Choose--01/21/1002/06/1002/07/1002/08/1002/09/1002/10/1002/11/1002/12/1002/13/1002/14/1002/15/1002/16/1002/17/1002/18/1002/19/1002/20/1002/21/1002/22/1002/23/1002/24/1002/25/1002/26/1002/27/1002/28/1003/01/1003/02/1003/03/1003/04/1003/05/1003/06/1003/07/1003/08/1003/09/1003/11/1003/12/1003/13/1003/14/1003/15/1003/16/1003/17/1003/18/1003/19/1003/20/1003/21/1003/24/1003/25/1003/26/1003/27/1003/28/1003/29/1003/30/1003/31/1004/01/1004/02/1004/03/1004/04/1004/05/1004/06/1004/07/1004/08/1004/09/1004/10/1004/11/1004/12/1004/13/1004/14/1004/15/1004/16/1004/17/1004/18/1004/19/1004/20/1004/21/1004/23/1004/24/1004/25/1004/26/1004/27/1004/28/1004/29/1004/30/1005/01/1005/02/1005/03/1005/04/1005/05/1005/06/1005/07/1005/08/1005/09/1005/10/1005/11/1005/12/1005/13/1005/14/1005/15/1005/16/1005/17/1005/18/1005/19/1005/20/1005/21/1005/22/1005/23/1005/24/1005/25/1005/26/1005/27/1005/28/1005/29/1005/30/1005/31/1006/01/1006/02/1006/03/1006/04/1006/05/1006/06/1006/07/1006/08/1006/09/1006/10/1006/11/1006/12/1006/13/1006/14/1006/15/1006/16/1006/17/1006/18/1006/19/1006/20/1006/21/10
+
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+
+Guest Book
+
+- [Sign](https://www.trailjournals.com/journal/guestbook/sign/10467)
+- [View](https://www.trailjournals.com/journal/guestbook/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/4a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/8a.gif)
+
+- [AT Journals](https://www.trailjournals.com/journals/appalachian_trail)
+- [AT Photos](https://www.trailjournals.com/photos/appalachian_trail)
+- [AT Books](https://www.trailjournals.com/books/appalachian_trail)
+- [Appalachian Trail](http://www.appalachiantrail.org/)
+
+[Join](https://www.trailjournals.com/join) [Login](https://www.trailjournals.com/user/login)
+
+[RSS](https://www.trailjournals.com/journal/rss/10467/xml)
+
+# Uncle Frank's 2010  Appalachian Trail Journal
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/316910) [Next](https://www.trailjournals.com/journal/entry/316912) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+Friday, June 18, 2010
+
+Destination:Wadleigh Stream Lean-to
+
+Today's Miles:21.50
+
+Start Location:Cooper Brook Falls Lean-to
+
+Trip Miles:2141.30
+
+Destination:Wadleigh Stream Lean-to
+
+Start Location:Cooper Brook Falls Lean-to
+
+Today's Miles:21.50
+
+Trip Miles:2141.30
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/316910) [Next](https://www.trailjournals.com/journal/entry/316912) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+### Hiker Entries June 18, 2010
+
+|  | Journalist | Destination | Trail |
+| --- | --- | --- | --- |
+|  | [Transient](https://www.trailjournals.com/journal/about/13775) | [Pinchot Pass](https://www.trailjournals.com/journal/entry/380604) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+|  | [RuhRoh](https://www.trailjournals.com/journal/about/13023) | [Siler Bald Shelter](https://www.trailjournals.com/journal/entry/366126) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Troll_3506TN.jpg) | [Troll](https://www.trailjournals.com/journal/about/3506) | [Hightop Hut](https://www.trailjournals.com/journal/entry/355113) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010seeksit_11881TN.jpg) | [seeksit](https://www.trailjournals.com/journal/about/11881) | [Liberty Reservoir](https://www.trailjournals.com/journal/entry/339202) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Rough Cut](https://www.trailjournals.com/journal/about/11734) | [Ten mile river lean too](https://www.trailjournals.com/journal/entry/336859) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DidgeridudeandDoodlebug_9852TN.jpg) | [Didgeridude and Doodlebug](https://www.trailjournals.com/journal/about/9852) | [Duncannon PA](https://www.trailjournals.com/journal/entry/334687) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [trackz man and sscblaze](https://www.trailjournals.com/journal/about/11275) | [Shevlin Park](https://www.trailjournals.com/journal/entry/331531) | [Tahoe Rim Trail](https://www.trailjournals.com/journals/Tahoe%20_Rim%20_Trail) |
+|  | [bone lady](https://www.trailjournals.com/journal/about/11245) | [Story Spring Shelter](https://www.trailjournals.com/journal/entry/330820) | [The Long Trail - Vermont](https://www.trailjournals.com/journals/The%20_Long%20_Trail%20_-%20_Vermont) |
+|  | [Red Fox](https://www.trailjournals.com/journal/about/10662) | [Damascus, VA](https://www.trailjournals.com/journal/entry/329872) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Trooper](https://www.trailjournals.com/journal/about/10644) | [\-\- View Entry --](https://www.trailjournals.com/journal/entry/329341) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+| [More...](https://www.trailjournals.com/entries/2010/06/18) [Grouped By Trail...](https://www.trailjournals.com/entries/2010/06/18/trail) |
+
+|     |
+| --- |
+| I've never seen anything like this place, a large canyon connecting lakes with snow fed streams originating at a snow pack high up on a mountain.... <br>[Fitty Shrimp](https://www.trailjournals.com/journal/entry/519076) —<br>[Pacific Northwest Trail](https://www.trailjournals.com/journals/pacific_northwest_trail) [2015](https://www.trailjournals.com/journals/pacific_northwest_trail/2015) |
+
+[![Trailjournals](https://www.trailjournals.com/images/logo.png)](https://www.trailjournals.com/)
+
+#### Hiking
+
+- [Trails](https://www.trailjournals.com/trails/list)
+- [Journals](https://www.trailjournals.com/journals)
+- [Photos](https://www.trailjournals.com/photos)
+- [Calendar](https://www.trailjournals.com/calendar)
+- Gear
+- [Links](https://www.trailjournals.com/links)
+
+#### Partners
+
+- [ULA Equipment](https://ula-equipment.sjv.io/drN9K)
+- [REI](http://www.avantlink.com/click.php?tt=ml&ti=45265&pw=68025)
+- [Patagonia](http://www.avantlink.com/click.php?tt=ml&ti=45781&pw=68025)
+
+#### Network
+
+- [Trail Forums](http://www.trailforums.com/)
+- Trail News
+
+#### About Us
+
+- [Contact](https://www.trailjournals.com/about/contact)
+- [Donate](https://www.trailjournals.com/about/donate)
+- [Join](https://www.trailjournals.com/join)
+- [Login](https://www.trailjournals.com/user/login)
+- [Help](https://www.trailjournals.com/help)
+
+#### Follow Us
+
+- [Facebook](https://www.facebook.com/trailjournals)
+- [Instagram](https://instagram.com/trailjournals/)
+- [Twitter](https://twitter.com/trailjournals)
+- [Pinterest](https://www.pinterest.com/trailjournals/)
+- [Linkedin](https://www.linkedin.com/company/trailjournals-llc)
+
+Top Photo © Comer and Jean - Appalachian Trail,
+07/01/2001 by
+[Comer and Jean](https://www.trailjournals.com/journal/129)
+
+Trailjournals LLC © 2026
+All Rights Reserved. [privacy policy](https://www.trailjournals.com/about/privacy)
+
+Newburyport, MA 01950
+
+[Terms under which this service is provided to you.](https://www.trailjournals.com/about/privacy)
+
+Build: 20210226:165913 [Manage Settings](https://www.trailjournals.com/about/settings)
+---
+---
+date: '2010-06-19'
+start: Wadleigh Stream Lean-to
+destination: The Birches Lean-tos
+miles_today: 33.0
+trip_miles: 2174.3
+facts:
+  weather: High 84°F, low 60°F. Overcast.
+  trail_section: Trail section from Wadleigh Stream Lean-to to The Birches Lean-tos.
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+---
+# Saturday, June 19, 2010 — The Birches Lean-tos
+**Start Location:** Wadleigh Stream Lean-to
+**Miles Today:** 33
+**Trip Miles:** 2174.30
+
+Toggle navigation[Trail Journals](https://www.trailjournals.com/)
+
+- [Journals](https://www.trailjournals.com/journal/entry/316912#)  - [Journals](https://www.trailjournals.com/journals)
+  - [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail/2026)
+  - [Pacific Crest Trail](https://www.trailjournals.com/journals/pacific_crest_trail/2026)
+  - [Colorado Trail](https://www.trailjournals.com/journals/colorado_trail/2026)
+  - [Continental Divide Trail](https://www.trailjournals.com/journals/continental_divide_trail/2026)
+  - [Long Trail - Vermont](https://www.trailjournals.com/journals/the_long_trail_-_vermont/2026)
+  - [Florida Trail](https://www.trailjournals.com/journals/the_florida_trail/2026)
+  - [Arizona Trail](https://www.trailjournals.com/journals/arizona_trail/2026)
+  - [John Muir Trail](https://www.trailjournals.com/journals/john_muir_trail/2026)
+  - [Camino de Santiago](https://www.trailjournals.com/journals/camino_de_santiago/2026)
+  - [American Discovery Trail](https://www.trailjournals.com/journals/american_discovery_trail/2026)
+  - [Coast to Coast Walk](https://www.trailjournals.com/journals/coast_to_coast_walk/2026)
+  - [More...](https://www.trailjournals.com/journals/)
+- [Trails](https://www.trailjournals.com/trails/)
+- [Photos](https://www.trailjournals.com/photos/2026)
+- [Gear](https://www.trailjournals.com/journal/entry/316912#)  - [Current Sales](https://www.trailjournals.com/gear/deals/onsale)
+  - [REI](https://www.trailjournals.com/gear/rei)
+  - [ULA](https://www.trailjournals.com/gear/ula)
+  - [Patagonia](https://www.trailjournals.com/gear/patagonia)
+  - [Cabela's](https://www.trailjournals.com/gear/cabela)
+- [Planning](https://www.trailjournals.com/journal/entry/316912#)  - [Plan Your Hike](https://www.trailjournals.com/planning/)
+  - [Gear](https://www.trailjournals.com/gear/)
+  - [Books](https://www.trailjournals.com/books/)
+  - [Links](https://www.trailjournals.com/links/)
+- [Search](https://www.trailjournals.com/search/)
+- [About](https://www.trailjournals.com/journal/entry/316912#)  - [About Trailjournals](https://www.trailjournals.com/about/)
+  - [Login](https://www.trailjournals.com/user/login)
+  - [Join](https://www.trailjournals.com/join)
+  - [Support Trailjournals](https://www.trailjournals.com/about/donate/)
+  - [Contact](https://www.trailjournals.com/about/contact)
+  - [Store](https://www.trailjournals.com/store/)
+
+Backpacking Journals and Photos from Long Distance Hikers
+
+1. [Home](https://www.trailjournals.com/)
+2. [Journals](https://www.trailjournals.com/journals)
+3. [Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail)
+4. [2010](https://www.trailjournals.com/journals/appalachian_trail/2010)
+5. [Uncle Frank](https://www.trailjournals.com/journal/10467)
+6. [Entries](https://www.trailjournals.com/journal/entries/10467/uncle%20-frank)
+7. June 19, 2010
+
+Toggle navigation
+
+- [Journal](https://www.trailjournals.com/journal/10467)
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+- [My Journals](https://www.trailjournals.com/myjournals/10467)
+- [View Guest Book](https://www.trailjournals.com/journal/guestbook/10467)
+- [Sign Guest Book](https://www.trailjournals.com/journal/guestbook/sign/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/4a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/6a.gif)
+
+[Journal](https://www.trailjournals.com/journal/10467)
+
+- [Entries](https://www.trailjournals.com/journal/entries/10467)
+- [by Date](https://www.trailjournals.com/journal/calendar/10467)
+
+--Choose--01/21/1002/06/1002/07/1002/08/1002/09/1002/10/1002/11/1002/12/1002/13/1002/14/1002/15/1002/16/1002/17/1002/18/1002/19/1002/20/1002/21/1002/22/1002/23/1002/24/1002/25/1002/26/1002/27/1002/28/1003/01/1003/02/1003/03/1003/04/1003/05/1003/06/1003/07/1003/08/1003/09/1003/11/1003/12/1003/13/1003/14/1003/15/1003/16/1003/17/1003/18/1003/19/1003/20/1003/21/1003/24/1003/25/1003/26/1003/27/1003/28/1003/29/1003/30/1003/31/1004/01/1004/02/1004/03/1004/04/1004/05/1004/06/1004/07/1004/08/1004/09/1004/10/1004/11/1004/12/1004/13/1004/14/1004/15/1004/16/1004/17/1004/18/1004/19/1004/20/1004/21/1004/23/1004/24/1004/25/1004/26/1004/27/1004/28/1004/29/1004/30/1005/01/1005/02/1005/03/1005/04/1005/05/1005/06/1005/07/1005/08/1005/09/1005/10/1005/11/1005/12/1005/13/1005/14/1005/15/1005/16/1005/17/1005/18/1005/19/1005/20/1005/21/1005/22/1005/23/1005/24/1005/25/1005/26/1005/27/1005/28/1005/29/1005/30/1005/31/1006/01/1006/02/1006/03/1006/04/1006/05/1006/06/1006/07/1006/08/1006/09/1006/10/1006/11/1006/12/1006/13/1006/14/1006/15/1006/16/1006/17/1006/18/1006/19/1006/20/1006/21/10
+
+- [Gear](https://www.trailjournals.com/journal/gear/10467)
+- [Photos](https://www.trailjournals.com/journal/photos/10467)
+- [About](https://www.trailjournals.com/journal/about/10467)
+- [Trail Name](https://www.trailjournals.com/journal/trailname/3000)
+- [Stats](https://www.trailjournals.com/journal/stats/10467)
+
+Guest Book
+
+- [Sign](https://www.trailjournals.com/journal/guestbook/sign/10467)
+- [View](https://www.trailjournals.com/journal/guestbook/10467)
+
+![](https://www.trailjournals.com/images/6a.gif)![](https://www.trailjournals.com/images/7a.gif)![](https://www.trailjournals.com/images/4a.gif)![](https://www.trailjournals.com/images/3a.gif)![](https://www.trailjournals.com/images/6a.gif)
+
+- [AT Journals](https://www.trailjournals.com/journals/appalachian_trail)
+- [AT Photos](https://www.trailjournals.com/photos/appalachian_trail)
+- [AT Books](https://www.trailjournals.com/books/appalachian_trail)
+- [Appalachian Trail](http://www.appalachiantrail.org/)
+
+[Join](https://www.trailjournals.com/join) [Login](https://www.trailjournals.com/user/login)
+
+[RSS](https://www.trailjournals.com/journal/rss/10467/xml)
+
+# Uncle Frank's 2010  Appalachian Trail Journal
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/316911) [Next](https://www.trailjournals.com/journal/entry/316913) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+Saturday, June 19, 2010
+
+Destination:The Birches Lean-tos
+
+Today's Miles:33
+
+Start Location:Wadleigh Stream Lean-to
+
+Trip Miles:2174.30
+
+Destination:The Birches Lean-tos
+
+Start Location:Wadleigh Stream Lean-to
+
+Today's Miles:33
+
+Trip Miles:2174.30
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/316911) [Next](https://www.trailjournals.com/journal/entry/316913) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+### Hiker Entries June 19, 2010
+
+|  | Journalist | Destination | Trail |
+| --- | --- | --- | --- |
+|  | [Transient](https://www.trailjournals.com/journal/about/13775) | [Upper Palisade Lake](https://www.trailjournals.com/journal/entry/380606) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+|  | [RuhRoh](https://www.trailjournals.com/journal/about/13023) | [Tyre Top](https://www.trailjournals.com/journal/entry/366127) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Troll_3506TN.jpg) | [Troll](https://www.trailjournals.com/journal/about/3506) | [Rock Spring Hut](https://www.trailjournals.com/journal/entry/355114) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010seeksit_11881TN.jpg) | [seeksit](https://www.trailjournals.com/journal/about/11881) | [Bollinger Mill Road trailhead](https://www.trailjournals.com/journal/entry/339204) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010DidgeridudeandDoodlebug_9852TN.jpg) | [Didgeridude and Doodlebug](https://www.trailjournals.com/journal/about/9852) | [Clarks Ferry Shelter](https://www.trailjournals.com/journal/entry/334688) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [bone lady](https://www.trailjournals.com/journal/about/11245) | [North Shore Tenting Area, Stratton Pond](https://www.trailjournals.com/journal/entry/330821) | [The Long Trail - Vermont](https://www.trailjournals.com/journals/The%20_Long%20_Trail%20_-%20_Vermont) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010lastonthebus_10176TN.jpg) | [lastonthebus "LB"](https://www.trailjournals.com/journal/about/10176) | [\-\- View Entry --](https://www.trailjournals.com/journal/entry/329352) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+|  | [Trooper](https://www.trailjournals.com/journal/about/10644) | [\-\- View Entry --](https://www.trailjournals.com/journal/entry/329342) | [Pacific Crest Trail](https://www.trailjournals.com/journals/Pacific%20_Crest%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010Peru_10969TN.jpg) | [Peru](https://www.trailjournals.com/journal/about/10969) | [Daleville](https://www.trailjournals.com/journal/entry/325475) | [Appalachian Trail](https://www.trailjournals.com/journals/Appalachian%20_Trail) |
+| ![](https://www.trailjournals.com/images/thumbnail/30/2010SlowWalker_10376TN.jpg) | [Slow Walker](https://www.trailjournals.com/journal/about/10376) | [Alresford](https://www.trailjournals.com/journal/entry/324725) | [Other Trails](https://www.trailjournals.com/journals/Other%20_Trails) |
+| [More...](https://www.trailjournals.com/entries/2010/06/19) [Grouped By Trail...](https://www.trailjournals.com/entries/2010/06/19/trail) |
+
+|     |
+| --- |
+| Last nights choice of a campsite by a stream turned out great for I was able to lie in my tent and listen to the lullaby of the water over the rocks. ... <br>[Short Stop](https://www.trailjournals.com/journal/entry/473502) —<br>[Appalachian Trail](https://www.trailjournals.com/journals/appalachian_trail) [2014](https://www.trailjournals.com/journals/appalachian_trail/2014) |
+
+[![Trailjournals](https://www.trailjournals.com/images/logo.png)](https://www.trailjournals.com/)
+
+#### Hiking
+
+- [Trails](https://www.trailjournals.com/trails/list)
+- [Journals](https://www.trailjournals.com/journals)
+- [Photos](https://www.trailjournals.com/photos)
+- [Calendar](https://www.trailjournals.com/calendar)
+- Gear
+- [Links](https://www.trailjournals.com/links)
+
+#### Partners
+
+- [ULA Equipment](https://ula-equipment.sjv.io/drN9K)
+- [REI](http://www.avantlink.com/click.php?tt=ml&ti=45265&pw=68025)
+- [Patagonia](http://www.avantlink.com/click.php?tt=ml&ti=45781&pw=68025)
+
+#### Network
+
+- [Trail Forums](http://www.trailforums.com/)
+- Trail News
+
+#### About Us
+
+- [Contact](https://www.trailjournals.com/about/contact)
+- [Donate](https://www.trailjournals.com/about/donate)
+- [Join](https://www.trailjournals.com/join)
+- [Login](https://www.trailjournals.com/user/login)
+- [Help](https://www.trailjournals.com/help)
+
+#### Follow Us
+
+- [Facebook](https://www.facebook.com/trailjournals)
+- [Instagram](https://instagram.com/trailjournals/)
+- [Twitter](https://twitter.com/trailjournals)
+- [Pinterest](https://www.pinterest.com/trailjournals/)
+- [Linkedin](https://www.linkedin.com/company/trailjournals-llc)
+
+Top Photo © Comer and Jean - Appalachian Trail,
+07/01/2001 by
+[Comer and Jean](https://www.trailjournals.com/journal/129)
+
+Trailjournals LLC © 2026
+All Rights Reserved. [privacy policy](https://www.trailjournals.com/about/privacy)
+
+Newburyport, MA 01950
+
+[Terms under which this service is provided to you.](https://www.trailjournals.com/about/privacy)
+
+Build: 20210226:165913 [Manage Settings](https://www.trailjournals.com/about/settings)
+---
+---
+date: '2010-06-20'
+start: The Birches Lean-tos
+destination: Baxter Peak, Mount Katahdin
+miles_today: 5.2
+trip_miles: 2179.5
+facts:
+  trail_section: Mount Katahdin (5,267 ft) in Baxter State Park, Maine, is the northern
+    terminus of the Appalachian Trail.
+  confidence: low
+---
+# Sunday, June 20, 2010 — Baxter Peak, Mount Katahdin
+**Start Location:** The Birches Lean-tos
+**Miles Today:** 5.20
+**Trip Miles:** 2179.50
+
+The night had been a long one, buzzing relentlessly with the sound of mosquitos. I was up all night, thanks to a new sting on my face or neck every five minutes, but by 3:00 the cold and rain arrived and suppressed the mosquitos. So, for an hour, I slept.
+
+At 4 o'clock I was up and packing my things. "This is it," I repeated in my head. "Don't get scared now" (that's a line from Home Alone). I hit the trail by 4:37, moving swiftly up and up and up into the end of this horrible trek. The terrain was as difficult as I expected (Katahdin is widely believed to be THE hardest peak on the entire AT), but to be honest I made quick work of the 5.2 miles to the summit. My stomach cramped with hunger and my legs burned with lactic build-up. I felt like Edmond Hillary ascending up the final cornice, the "Hillary Step," but like Hillary it went quickly. "A push and a shove and Tenezig and I were on the top of the world," Hillary wrote later.
+
+So there I was, standing at that godforsaken sign, wind whipping and white cloud shrouding the peak. I showed little emotion--in fact, I showed none. I just stood there, looking at the sign. I didn't feel like anything important was going on, nor that I'd accomplished any sort of feat. I nodded to myself and walked down the mountain. At the bottom, a day hiker asked me my name. "Uncle Fra-," I began to say. But it was all over--the trail had expired and my trail name with it--so I smiled and said, "Ford. Ford Prior."
+---
+---
+date: '2010-06-21'
+start: Baxter Peak, Mount Katahdin
+destination: HOME
+miles_today: 0.0
+trip_miles: 2179.5
+facts:
+  trail_section: Mount Katahdin (5,267 ft) in Baxter State Park, Maine, is the northern
+    terminus of the Appalachian Trail.
+  confidence: low
+---
+# Monday, June 21, 2010 — HOME
+**Start Location:** Baxter Peak, Mount Katahdin
+**Miles Today:** 0
+**Trip Miles:** 2179.50
+
+Hey everyone. It's been over for a couple weeks now and I'm getting comfy back at home. Just letting you know that I'll be continuing to write on my website, www.fordprior.weebly.com, so check it out if you ever get bored. I did kind of a trail recap. Thanks for following.

--- a/examples/uncle-frank/journal_facts.txt
+++ b/examples/uncle-frank/journal_facts.txt
@@ -107,20 +107,23 @@ miles_today: 0.0
 trip_miles: 0.0
 facts:
   weather: High 39°F, low 34°F. Slight snow.
-  trail_section: Amicalola Falls State Park is the traditional starting gateway for
-    northbound AT thru-hikers. The 8.5-mile Approach Trail from Amicalola Falls gains
-    substantial elevation to reach Springer Mountain. Amicalola Falls at 729 feet
-    is one of the tallest cascading waterfalls in the eastern United States. The Hike
-    Inn is a backcountry eco-lodge accessible only on foot via a 5-mile trail near
-    Amicalola Falls. The Hike Inn sits within sight of the AT approach corridor through
-    classic Blue Ridge hardwood forest. The Georgia AT traverses the southern Blue
-    Ridge Mountains, crossing several 4,000-foot summits in ~76 miles. Georgia's AT
-    features rocky ridgelines alternating with dense hardwood forest typical of the
-    southern Appalachians.
+  trail_section: 'Springer Mountain approach (AT miles -9–-5): The southernmost AT
+    miles climb from Amicalola Falls through the Approach Trail to Springer Mountain,
+    often in late-winter snow and ice. Steep approach-trail climbing, icy hardwood
+    forest, and the emotional start of a northbound thru-hike. Notable points along
+    this leg include Amicalola Falls State Park, Hike Inn. Amicalola Falls State Park
+    is the traditional gateway to Springer Mountain for northbound thru-hikers. The
+    Hike Inn is a backcountry eco-lodge accessible only by a 5-mile trail near Amicalola
+    Falls.'
   confidence: high
   sources:
+  - AT segment guide
   - AT location database
   - Open-Meteo archive
+  segment: Springer Mountain approach
+  at_mile_start: -8.8
+  at_mile_end: -5.0
+  region: Georgia
 ---
 # Saturday, February 06, 2010 — Hike Inn
 **Start Location:** Amicalola Falls State Park
@@ -143,18 +146,23 @@ miles_today: 9.0
 trip_miles: 9.0
 facts:
   weather: High 40°F, low 23°F. Slight snow.
-  trail_section: The Hike Inn is a backcountry eco-lodge accessible only on foot via
-    a 5-mile trail near Amicalola Falls. The Hike Inn sits within sight of the AT
-    approach corridor through classic Blue Ridge hardwood forest. Hawk Mountain Shelter
-    sits at roughly AT mile 8 from Springer Mountain in the Georgia Blue Ridge. The
-    trail between Springer Mountain and Hawk Mountain traverses rocky ridgeline sections
-    through hardwood forest. The Georgia AT traverses the southern Blue Ridge Mountains,
-    crossing several 4,000-foot summits in ~76 miles. Georgia's AT features rocky
-    ridgelines alternating with dense hardwood forest typical of the southern Appalachians.
+  trail_section: 'Springer Mountain approach (AT miles -5–8): The southernmost AT
+    miles climb from Amicalola Falls through the Approach Trail to Springer Mountain,
+    often in late-winter snow and ice. Steep approach-trail climbing, icy hardwood
+    forest, and the emotional start of a northbound thru-hike. Notable points along
+    this leg include Hike Inn, Springer Mountain, Springer Mountain Shelter, Three
+    Forks. The Hike Inn is a backcountry eco-lodge accessible only by a 5-mile trail
+    near Amicalola Falls. Hawk Mountain Shelter (AT mile ~8) is an early overnight
+    stop in Georgia''s Blue Ridge.'
   confidence: high
   sources:
+  - AT segment guide
   - AT location database
   - Open-Meteo archive
+  segment: Springer Mountain approach
+  at_mile_start: -5.0
+  at_mile_end: 8.1
+  region: Georgia
 ---
 # Sunday, February 07, 2010 — Hawk Mountain Shelter
 **Start Location:** Hike Inn
@@ -177,20 +185,23 @@ miles_today: 14.0
 trip_miles: 23.0
 facts:
   weather: High 44°F, low 27°F. Overcast.
-  trail_section: Hawk Mountain Shelter sits at roughly AT mile 8 from Springer Mountain
-    in the Georgia Blue Ridge. The trail between Springer Mountain and Hawk Mountain
-    traverses rocky ridgeline sections through hardwood forest. Gooch Mountain Shelter
-    near AT mile 16 is a popular first multi-night destination for northbound thru-hikers.
-    The trail from Hawk Mountain to Gooch Mountain crosses Justus Creek and climbs
-    through mixed hardwood forest. The Gooch Mountain area receives heavy hiker traffic
-    in early spring during thru-hiking season. The Georgia AT traverses the southern
-    Blue Ridge Mountains, crossing several 4,000-foot summits in ~76 miles. Georgia's
-    AT features rocky ridgelines alternating with dense hardwood forest typical of
-    the southern Appalachians.
+  trail_section: 'Georgia Blue Ridge — early ridges (AT miles 8–16): Rolling Blue
+    Ridge ridgelines with frequent shelters, creek crossings, and the first sustained
+    mountain walking of the hike. Rocky tread, rhododendron tunnels, and climbs toward
+    Blood Mountain — Georgia''s highest AT peak. Notable points along this leg include
+    Hawk Mountain Shelter, Cooper Gap, Gooch Mountain Shelter. Hawk Mountain Shelter
+    (AT mile ~8) is an early overnight stop in Georgia''s Blue Ridge. Gooch Mountain
+    Shelter (AT mile ~16) is a popular early multi-day destination for northbound
+    hikers.'
   confidence: high
   sources:
+  - AT segment guide
   - AT location database
   - Open-Meteo archive
+  segment: Georgia Blue Ridge — early ridges
+  at_mile_start: 8.1
+  at_mile_end: 15.8
+  region: Georgia
 ---
 # Monday, February 08, 2010 — Gooch Mountain Shelter
 **Start Location:** Hawk Mountain Shelter
@@ -213,17 +224,22 @@ miles_today: 15.5
 trip_miles: 38.5
 facts:
   weather: High 40°F, low 34°F. Slight rain.
-  trail_section: Gooch Mountain Shelter near AT mile 16 is a popular first multi-night
-    destination for northbound thru-hikers. The trail from Hawk Mountain to Gooch
-    Mountain crosses Justus Creek and climbs through mixed hardwood forest. The Gooch
-    Mountain area receives heavy hiker traffic in early spring during thru-hiking
-    season. The Georgia AT traverses the southern Blue Ridge Mountains, crossing several
-    4,000-foot summits in ~76 miles. Georgia's AT features rocky ridgelines alternating
-    with dense hardwood forest typical of the southern Appalachians.
+  trail_section: 'Georgia Blue Ridge — early ridges (AT miles 16–32): Rolling Blue
+    Ridge ridgelines with frequent shelters, creek crossings, and the first sustained
+    mountain walking of the hike. Rocky tread, rhododendron tunnels, and climbs toward
+    Blood Mountain — Georgia''s highest AT peak. Notable points along this leg include
+    Gooch Mountain Shelter, Woody Gap, Lance Creek Campsite, Blood Mountain Shelter.
+    Gooch Mountain Shelter (AT mile ~16) is a popular early multi-day destination
+    for northbound hikers.'
   confidence: high
   sources:
+  - AT segment guide
   - AT location database
   - Open-Meteo archive
+  segment: Georgia Blue Ridge — early ridges
+  at_mile_start: 15.8
+  at_mile_end: 31.7
+  region: Georgia
 ---
 # Tuesday, February 09, 2010 — Neel Gap Hostel
 **Start Location:** Gooch Mountain Shelter
@@ -250,10 +266,20 @@ miles_today: 11.0
 trip_miles: 49.5
 facts:
   weather: High 38°F, low 20°F. Light drizzle.
-  trail_section: Trail section from Neel Gap Hostel to Low Gap Shelter.
-  confidence: medium
+  trail_section: 'Georgia Blue Ridge — early ridges (AT miles 32–38): Rolling Blue
+    Ridge ridgelines with frequent shelters, creek crossings, and the first sustained
+    mountain walking of the hike. Rocky tread, rhododendron tunnels, and climbs toward
+    Blood Mountain — Georgia''s highest AT peak. Notable points along this leg include
+    Neel Gap, Neel Gap Hostel, Walasi-Yi Center, Whitley Gap Shelter.'
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
+  segment: Georgia Blue Ridge — early ridges
+  at_mile_start: 31.7
+  at_mile_end: 38.5
+  region: Georgia
 ---
 # Wednesday, February 10, 2010 — Low Gap Shelter
 **Start Location:** Neel Gap Hostel
@@ -274,12 +300,22 @@ miles_today: 13.5
 trip_miles: 63.0
 facts:
   weather: High 42°F, low 24°F. Overcast.
-  trail_section: Trail section from Low Gap Shelter to EconoLodge Motel (Helen, GA).
+  trail_section: 'Georgia — Blood Mountain to Bly Gap (AT miles 38–63): Classic Georgia
+    AT: long climbs, mountain laurel, and trail-town access near Helen and Hiawassee
+    before the NC border. Sustained ups and downs along the Blue Ridge; often muddy
+    in spring; famous steep pitches leaving NOC later. Notable points along this leg
+    include Low Gap Shelter, Unicoi Gap, Blue Mountain Shelter, Tray Mountain Shelter.'
   town_events: Franklin named first Appalachian Trail Community in 2010 - Facebook
-  confidence: medium
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
   - https://www.facebook.com/groups/159729421133853/posts/877502402689881/
+  segment: Georgia — Blood Mountain to Bly Gap
+  at_mile_start: 38.5
+  at_mile_end: 63.0
+  region: Georgia
 ---
 # Thursday, February 11, 2010 — EconoLodge Motel (Helen, GA)
 **Start Location:** Low Gap Shelter
@@ -299,12 +335,21 @@ destination: Mull's Motel (Hiawasee, GA)
 miles_today: 15.0
 trip_miles: 78.0
 facts:
-  trail_section: Trail section from EconoLodge Motel (Helen, GA) to Mull's Motel (Hiawasee,
-    GA).
+  trail_section: 'Georgia — Blood Mountain to Bly Gap (AT miles 63–78): Classic Georgia
+    AT: long climbs, mountain laurel, and trail-town access near Helen and Hiawassee
+    before the NC border. Sustained ups and downs along the Blue Ridge; often muddy
+    in spring; famous steep pitches leaving NOC later. Notable points along this leg
+    include Bly Gap, Standing Indian Shelter, Carter Gap Shelter.'
   town_events: Hiawassee/Towns County, GA
   confidence: low
   sources:
+  - AT segment guide
+  - firecrawl web search
   - https://appalachiantrail.org/protect/conservation/at-community-program/hiawassee-towns-county-ga/
+  segment: Georgia — Blood Mountain to Bly Gap
+  at_mile_start: 63.0
+  at_mile_end: 78.0
+  region: Georgia
 ---
 # Friday, February 12, 2010 — Mull's Motel (Hiawasee, GA)
 **Start Location:** EconoLodge Motel (Helen, GA)
@@ -330,12 +375,21 @@ destination: Mull's Motel (Hiawasee, GA)
 miles_today: 0.0
 trip_miles: 78.0
 facts:
-  trail_section: Trail section from Mull's Motel (Hiawasee, GA) to Mull's Motel (Hiawasee,
-    GA).
+  trail_section: 'Georgia — Blood Mountain to Bly Gap (AT miles 77–78): Classic Georgia
+    AT: long climbs, mountain laurel, and trail-town access near Helen and Hiawassee
+    before the NC border. Sustained ups and downs along the Blue Ridge; often muddy
+    in spring; famous steep pitches leaving NOC later. Landmarks in this corridor
+    include Neels Gap, Unicoi Gap, Tray Mountain, Bly Gap.'
   town_events: 2013 Appalachian Trail Events
   confidence: low
   sources:
+  - AT segment guide
+  - firecrawl web search
   - https://appalachiantrail.com/2013-appalachian-trail-events/
+  segment: Georgia — Blood Mountain to Bly Gap
+  at_mile_start: 77.0
+  at_mile_end: 78.0
+  region: Georgia
 ---
 # Saturday, February 13, 2010 — Mull's Motel (Hiawasee, GA)
 **Start Location:** Mull's Motel (Hiawasee, GA)
@@ -361,12 +415,21 @@ destination: Blueberry Patch Hostel
 miles_today: 0.0
 trip_miles: 78.0
 facts:
-  trail_section: Trail section from Mull's Motel (Hiawasee, GA) to Blueberry Patch
-    Hostel.
+  trail_section: 'Georgia — Blood Mountain to Bly Gap (AT miles 77–78): Classic Georgia
+    AT: long climbs, mountain laurel, and trail-town access near Helen and Hiawassee
+    before the NC border. Sustained ups and downs along the Blue Ridge; often muddy
+    in spring; famous steep pitches leaving NOC later. Landmarks in this corridor
+    include Neels Gap, Unicoi Gap, Tray Mountain, Bly Gap.'
   town_events: Hiawassee/Towns County, GA - Appalachian Trail Conservancy
   confidence: low
   sources:
+  - AT segment guide
+  - firecrawl web search
   - https://appalachiantrail.org/protect/conservation/at-community-program/hiawassee-towns-county-ga/
+  segment: Georgia — Blood Mountain to Bly Gap
+  at_mile_start: 77.0
+  at_mile_end: 78.0
+  region: Georgia
 ---
 # Sunday, February 14, 2010 — Blueberry Patch Hostel
 **Start Location:** Mull's Motel (Hiawasee, GA)
@@ -391,10 +454,20 @@ miles_today: 15.0
 trip_miles: 93.0
 facts:
   weather: High 27°F, low 19°F. Heavy snow.
-  trail_section: Trail section from Blueberry Patch Hostel to Muskrat Creek Shelter.
-  confidence: medium
+  trail_section: 'Southern North Carolina high country (AT miles 78–93): High southern
+    Appalachians with Standing Indian, Franklin resupply, and the long climb toward
+    the Nantahala gorge. Big elevation change, open balds, and remote ridge walking
+    south of the Smokies. Notable points along this leg include Rock Gap Shelter,
+    Winding Stair Gap, Cold Spring Shelter, Wayah Bald Shelter.'
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
+  segment: Southern North Carolina high country
+  at_mile_start: 78.0
+  at_mile_end: 93.0
+  region: North Carolina
 ---
 # Monday, February 15, 2010 — Muskrat Creek Shelter
 **Start Location:** Blueberry Patch Hostel
@@ -415,14 +488,21 @@ miles_today: 5.3
 trip_miles: 98.3
 facts:
   weather: High 24°F, low 12°F. Overcast.
-  trail_section: Standing Indian Mountain at 5,498 feet is the highest peak south
-    of the Great Smokies on the AT. The Standing Indian area is known for its high
-    balds and sweeping views of the southern Appalachians. The North Carolina AT includes
-    some of the highest peaks east of the Mississippi outside the Rockies.
+  trail_section: 'Georgia — Blood Mountain to Bly Gap (AT miles 65–70): Classic Georgia
+    AT: long climbs, mountain laurel, and trail-town access near Helen and Hiawassee
+    before the NC border. Sustained ups and downs along the Blue Ridge; often muddy
+    in spring; famous steep pitches leaving NOC later. Notable points along this leg
+    include Bly Gap, Standing Indian Shelter. Standing Indian Mountain (5,498 ft)
+    is the highest peak south of the Smokies on the AT.'
   confidence: high
   sources:
+  - AT segment guide
   - AT location database
   - Open-Meteo archive
+  segment: Georgia — Blood Mountain to Bly Gap
+  at_mile_start: 64.9
+  at_mile_end: 70.2
+  region: Georgia
 ---
 # Tuesday, February 16, 2010 — Standing Indian Shelter
 **Start Location:** Muskrat Creek Shelter
@@ -443,14 +523,21 @@ miles_today: 7.6
 trip_miles: 105.9
 facts:
   weather: High 28°F, low 8°F. Overcast.
-  trail_section: Standing Indian Mountain at 5,498 feet is the highest peak south
-    of the Great Smokies on the AT. The Standing Indian area is known for its high
-    balds and sweeping views of the southern Appalachians. The North Carolina AT includes
-    some of the highest peaks east of the Mississippi outside the Rockies.
+  trail_section: 'Georgia — Blood Mountain to Bly Gap (AT miles 70–75): Classic Georgia
+    AT: long climbs, mountain laurel, and trail-town access near Helen and Hiawassee
+    before the NC border. Sustained ups and downs along the Blue Ridge; often muddy
+    in spring; famous steep pitches leaving NOC later. Notable points along this leg
+    include Standing Indian Shelter, Carter Gap Shelter. Standing Indian Mountain
+    (5,498 ft) is the highest peak south of the Smokies on the AT.'
   confidence: high
   sources:
+  - AT segment guide
   - AT location database
   - Open-Meteo archive
+  segment: Georgia — Blood Mountain to Bly Gap
+  at_mile_start: 70.2
+  at_mile_end: 75.2
+  region: Georgia
 ---
 # Wednesday, February 17, 2010 — Carter Gap Shelter
 **Start Location:** Standing Indian Shelter
@@ -471,13 +558,22 @@ miles_today: 15.9
 trip_miles: 121.8
 facts:
   weather: High 38°F, low 27°F. Slight snow.
-  trail_section: Trail section from Carter Gap Shelter to Sapphire Inn (Franklin,
-    NC).
+  trail_section: 'Southern North Carolina high country (AT miles 75–122): High southern
+    Appalachians with Standing Indian, Franklin resupply, and the long climb toward
+    the Nantahala gorge. Big elevation change, open balds, and remote ridge walking
+    south of the Smokies. Notable points along this leg include Carter Gap Shelter,
+    Rock Gap Shelter, Winding Stair Gap, Cold Spring Shelter.'
   town_events: Franklin named first Appalachian Trail Community in 2010 - Facebook
-  confidence: medium
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
   - https://www.facebook.com/groups/159729421133853/posts/877502402689881/
+  segment: Southern North Carolina high country
+  at_mile_start: 75.2
+  at_mile_end: 121.8
+  region: North Carolina
 ---
 # Thursday, February 18, 2010 — Sapphire Inn (Franklin, NC)
 **Start Location:** Carter Gap Shelter
@@ -506,12 +602,21 @@ miles_today: 6.0
 trip_miles: 127.8
 facts:
   weather: High 39°F, low 29°F. Overcast.
-  trail_section: Trail section from Sapphire Inn (Franklin, NC) to Siler Bald Shelter.
+  trail_section: 'Southern North Carolina high country (AT miles 93–99): High southern
+    Appalachians with Standing Indian, Franklin resupply, and the long climb toward
+    the Nantahala gorge. Big elevation change, open balds, and remote ridge walking
+    south of the Smokies. Notable points along this leg include Siler Bald Shelter.'
   town_events: Franklin named first Appalachian Trail Community in 2010
-  confidence: medium
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
   - https://www.facebook.com/groups/159729421133853/posts/877502402689881/
+  segment: Southern North Carolina high country
+  at_mile_start: 92.6
+  at_mile_end: 98.6
+  region: North Carolina
 ---
 # Friday, February 19, 2010 — Siler Bald Shelter
 **Start Location:** Sapphire Inn (Franklin, NC)
@@ -530,10 +635,20 @@ miles_today: 12.6
 trip_miles: 140.4
 facts:
   weather: High 45°F, low 23°F. Mainly clear.
-  trail_section: Trail section from Siler Bald Shelter to Cold Spring Shelter.
-  confidence: medium
+  trail_section: 'Southern North Carolina high country (AT miles 99–88): High southern
+    Appalachians with Standing Indian, Franklin resupply, and the long climb toward
+    the Nantahala gorge. Big elevation change, open balds, and remote ridge walking
+    south of the Smokies. Notable points along this leg include Cold Spring Shelter,
+    Wayah Bald Shelter, Siler Bald Shelter.'
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
+  segment: Southern North Carolina high country
+  at_mile_start: 98.6
+  at_mile_end: 88.4
+  region: North Carolina
 ---
 # Saturday, February 20, 2010 — Cold Spring Shelter
 **Start Location:** Siler Bald Shelter
@@ -552,12 +667,22 @@ miles_today: 12.0
 trip_miles: 152.4
 facts:
   weather: High 44°F, low 23°F. Overcast.
-  trail_section: Trail section from Cold Spring Shelter to A cabin (NOC).
+  trail_section: 'Southern North Carolina high country (AT miles 88–152): High southern
+    Appalachians with Standing Indian, Franklin resupply, and the long climb toward
+    the Nantahala gorge. Big elevation change, open balds, and remote ridge walking
+    south of the Smokies. Notable points along this leg include Cold Spring Shelter,
+    Wayah Bald Shelter, Siler Bald Shelter, Wesser NOC.'
   town_events: Events
-  confidence: medium
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
   - https://appalachiantrail.org/events/
+  segment: Southern North Carolina high country
+  at_mile_start: 88.4
+  at_mile_end: 152.4
+  region: North Carolina
 ---
 # Sunday, February 21, 2010 — A cabin (NOC)
 **Start Location:** Cold Spring Shelter
@@ -580,12 +705,22 @@ miles_today: 7.5
 trip_miles: 159.9
 facts:
   weather: High 53°F, low 38°F. Slight rain.
-  trail_section: Trail section from A cabin (NOC) to Sassafras Gap Shelter.
+  trail_section: 'Nantahala gorge to Fontana Dam (AT miles 152–160): One of the steepest
+    climbs on the entire trail leaves the NOC river gorge; hikers then traverse the
+    Smokies approach to Fontana. Brutal climb out of the gorge (3,000+ ft), then ridge
+    walking toward the ''Fontana Hilton'' shelter at the dam. Landmarks in this corridor
+    include NOC, Fontana Dam, Fontana Dam Shelter.'
   town_events: Franklin named first Appalachian Trail Community in 2010 - Facebook
-  confidence: medium
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
   - https://www.facebook.com/groups/159729421133853/posts/877502402689881/
+  segment: Nantahala gorge to Fontana Dam
+  at_mile_start: 152.4
+  at_mile_end: 159.9
+  region: North Carolina
 ---
 # Monday, February 22, 2010 — Sassafras Gap Shelter
 **Start Location:** A cabin (NOC)
@@ -606,10 +741,20 @@ miles_today: 9.1
 trip_miles: 169.0
 facts:
   weather: High 41°F, low 31°F. Light drizzle.
-  trail_section: Trail section from Sassafras Gap Shelter to Brown Fork Gap Shelter.
-  confidence: medium
+  trail_section: 'Nantahala gorge to Fontana Dam (AT miles 160–169): One of the steepest
+    climbs on the entire trail leaves the NOC river gorge; hikers then traverse the
+    Smokies approach to Fontana. Brutal climb out of the gorge (3,000+ ft), then ridge
+    walking toward the ''Fontana Hilton'' shelter at the dam. Landmarks in this corridor
+    include NOC, Fontana Dam, Fontana Dam Shelter.'
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
+  segment: Nantahala gorge to Fontana Dam
+  at_mile_start: 159.9
+  at_mile_end: 169.0
+  region: North Carolina
 ---
 # Tuesday, February 23, 2010 — Brown Fork Gap Shelter
 **Start Location:** Sassafras Gap Shelter
@@ -636,13 +781,22 @@ miles_today: 12.0
 trip_miles: 181.0
 facts:
   weather: High 32°F, low 24°F. Slight snow.
-  trail_section: Trail section from Brown Fork Gap Shelter to Fontana Lodge (Fontana
-    Village).
+  trail_section: 'Great Smoky Mountains National Park (south) (AT miles 169–181):
+    Inside GSMNP: sustained climbing, crowded shelters, bear cables, and mandatory
+    backcountry permits define this iconic section. Dense spruce-fir near treeline,
+    icy spring conditions, and some of the highest elevations on the entire AT. Landmarks
+    in this corridor include Clingmans Dome, Mollies Ridge, Icewater Spring.'
   town_events: Appalachian Trail thru-hikers enjoy trail magic at Fontana Village
-  confidence: medium
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
   - https://www.facebook.com/groups/1070154271134761/posts/1533014594848724/
+  segment: Great Smoky Mountains National Park (south)
+  at_mile_start: 169.0
+  at_mile_end: 181.0
+  region: Tennessee / Great Smoky Mountains
 ---
 # Wednesday, February 24, 2010 — Fontana Lodge (Fontana Village)
 **Start Location:** Brown Fork Gap Shelter
@@ -663,14 +817,22 @@ miles_today: 1.0
 trip_miles: 182.0
 facts:
   weather: High 34°F, low 24°F. Moderate snow.
-  trail_section: Fontana Dam at 480 feet is the tallest dam east of the Mississippi
-    River; the AT crosses it entering GSMNP. Fontana Dam Shelter is nicknamed the
-    'Fontana Hilton' for its spacious shower and laundry facilities. The North Carolina
-    AT includes some of the highest peaks east of the Mississippi outside the Rockies.
+  trail_section: 'Great Smoky Mountains National Park (south) (AT miles 181–182):
+    Inside GSMNP: sustained climbing, crowded shelters, bear cables, and mandatory
+    backcountry permits define this iconic section. Dense spruce-fir near treeline,
+    icy spring conditions, and some of the highest elevations on the entire AT. Landmarks
+    in this corridor include Clingmans Dome, Mollies Ridge, Icewater Spring. Fontana
+    Dam (480 ft tall) is crossed by the AT entering Great Smoky Mountains National
+    Park.'
   confidence: high
   sources:
+  - AT segment guide
   - AT location database
   - Open-Meteo archive
+  segment: Great Smoky Mountains National Park (south)
+  at_mile_start: 181.0
+  at_mile_end: 182.0
+  region: Tennessee / Great Smoky Mountains
 ---
 # Thursday, February 25, 2010 — Fontana Dam Shelter
 **Start Location:** Fontana Lodge (Fontana Village)
@@ -687,14 +849,22 @@ miles_today: 11.3
 trip_miles: 193.3
 facts:
   weather: High 39°F, low 21°F. Mainly clear.
-  trail_section: Fontana Dam at 480 feet is the tallest dam east of the Mississippi
-    River; the AT crosses it entering GSMNP. Fontana Dam Shelter is nicknamed the
-    'Fontana Hilton' for its spacious shower and laundry facilities. The North Carolina
-    AT includes some of the highest peaks east of the Mississippi outside the Rockies.
+  trail_section: 'Great Smoky Mountains National Park (south) (AT miles 182–193):
+    Inside GSMNP: sustained climbing, crowded shelters, bear cables, and mandatory
+    backcountry permits define this iconic section. Dense spruce-fir near treeline,
+    icy spring conditions, and some of the highest elevations on the entire AT. Landmarks
+    in this corridor include Clingmans Dome, Mollies Ridge, Icewater Spring. Fontana
+    Dam (480 ft tall) is crossed by the AT entering Great Smoky Mountains National
+    Park.'
   confidence: high
   sources:
+  - AT segment guide
   - AT location database
   - Open-Meteo archive
+  segment: Great Smoky Mountains National Park (south)
+  at_mile_start: 182.0
+  at_mile_end: 193.3
+  region: Tennessee / Great Smoky Mountains
 ---
 # Friday, February 26, 2010 — Mollie's Ridge Shelter
 **Start Location:** Fontana Dam Shelter
@@ -711,10 +881,20 @@ miles_today: 12.0
 trip_miles: 205.3
 facts:
   weather: High 30°F, low 11°F. Overcast.
-  trail_section: Trail section from Mollie's Ridge Shelter to Derrick Knob Shelter.
-  confidence: medium
+  trail_section: 'Great Smoky Mountains National Park (south) (AT miles 193–205):
+    Inside GSMNP: sustained climbing, crowded shelters, bear cables, and mandatory
+    backcountry permits define this iconic section. Dense spruce-fir near treeline,
+    icy spring conditions, and some of the highest elevations on the entire AT. Landmarks
+    in this corridor include Clingmans Dome, Mollies Ridge, Icewater Spring.'
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
+  segment: Great Smoky Mountains National Park (south)
+  at_mile_start: 193.3
+  at_mile_end: 205.3
+  region: Tennessee / Great Smoky Mountains
 ---
 # Saturday, February 27, 2010 — Derrick Knob Shelter
 **Start Location:** Mollie's Ridge Shelter
@@ -733,13 +913,22 @@ miles_today: 15.0
 trip_miles: 220.3
 facts:
   weather: High 57°F, low 35°F. Partly cloudy.
-  trail_section: Trail section from Derrick Knob Shelter to On the side of the road
-    (U.S. 442).
+  trail_section: 'Great Smoky Mountains National Park (south) (AT miles 205–220):
+    Inside GSMNP: sustained climbing, crowded shelters, bear cables, and mandatory
+    backcountry permits define this iconic section. Dense spruce-fir near treeline,
+    icy spring conditions, and some of the highest elevations on the entire AT. Landmarks
+    in this corridor include Clingmans Dome, Mollies Ridge, Icewater Spring.'
   town_events: Franklin named first Appalachian Trail Community in 2010
-  confidence: medium
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
   - https://www.facebook.com/groups/159729421133853/posts/877502402689881/
+  segment: Great Smoky Mountains National Park (south)
+  at_mile_start: 205.3
+  at_mile_end: 220.3
+  region: Tennessee / Great Smoky Mountains
 ---
 # Sunday, February 28, 2010 — On the side of the road (U.S. 442)
 **Start Location:** Derrick Knob Shelter
@@ -758,13 +947,22 @@ miles_today: 0.0
 trip_miles: 220.3
 facts:
   weather: High 51°F, low 40°F. Moderate drizzle.
-  trail_section: Trail section from On the side of the road (U.S. 442) to A cabin
-    (Gatlinburg, TN).
+  trail_section: 'Smokies exit to Hot Springs (AT miles 219–220): Northbound hikers
+    leave the Smokies at Davenport Gap and cross into the balds-and-river country
+    around Hot Springs. Post-Smokies fatigue is common; Max Patch bald offers huge
+    views; trail softens into pastoral TN/NC border country. Landmarks in this corridor
+    include Davenport Gap, Max Patch, Hot Springs.'
   town_events: The Appalachian Trail | Great Smoky Mountains National Park
-  confidence: medium
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
   - https://www.gatlinburg.com/great-smoky-mountains/hiking-trails/appalachian-trail/
+  segment: Smokies exit to Hot Springs
+  at_mile_start: 219.3
+  at_mile_end: 220.3
+  region: Tennessee / North Carolina
 ---
 # Monday, March 01, 2010 — A cabin (Gatlinburg, TN)
 **Start Location:** On the side of the road (U.S. 442)
@@ -787,12 +985,22 @@ miles_today: 3.0
 trip_miles: 223.3
 facts:
   weather: High 40°F, low 33°F. Moderate snow.
-  trail_section: Trail section from A cabin (Gatlinburg, TN) to Icewater Spring Shelter.
+  trail_section: 'Smokies exit to Hot Springs (AT miles 220–223): Northbound hikers
+    leave the Smokies at Davenport Gap and cross into the balds-and-river country
+    around Hot Springs. Post-Smokies fatigue is common; Max Patch bald offers huge
+    views; trail softens into pastoral TN/NC border country. Landmarks in this corridor
+    include Davenport Gap, Max Patch, Hot Springs.'
   town_events: Franklin named first Appalachian Trail Community in 2010
-  confidence: medium
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
   - https://www.facebook.com/groups/159729421133853/posts/877502402689881/
+  segment: Smokies exit to Hot Springs
+  at_mile_start: 220.3
+  at_mile_end: 223.3
+  region: Tennessee / North Carolina
 ---
 # Tuesday, March 02, 2010 — Icewater Spring Shelter
 **Start Location:** A cabin (Gatlinburg, TN)
@@ -809,10 +1017,20 @@ miles_today: 8.0
 trip_miles: 231.3
 facts:
   weather: High 22°F, low 16°F. Moderate snow.
-  trail_section: Trail section from Icewater Spring Shelter to Pecks Corner Shelter.
-  confidence: medium
+  trail_section: 'Smokies exit to Hot Springs (AT miles 223–231): Northbound hikers
+    leave the Smokies at Davenport Gap and cross into the balds-and-river country
+    around Hot Springs. Post-Smokies fatigue is common; Max Patch bald offers huge
+    views; trail softens into pastoral TN/NC border country. Landmarks in this corridor
+    include Davenport Gap, Max Patch, Hot Springs.'
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
+  segment: Smokies exit to Hot Springs
+  at_mile_start: 223.3
+  at_mile_end: 231.3
+  region: Tennessee / North Carolina
 ---
 # Wednesday, March 03, 2010 — Pecks Corner Shelter
 **Start Location:** Icewater Spring Shelter
@@ -829,10 +1047,20 @@ miles_today: 14.0
 trip_miles: 245.3
 facts:
   weather: High 29°F, low 18°F. Slight snow.
-  trail_section: Trail section from Pecks Corner Shelter to Cosby Knob Shelter.
-  confidence: medium
+  trail_section: 'Smokies exit to Hot Springs (AT miles 231–245): Northbound hikers
+    leave the Smokies at Davenport Gap and cross into the balds-and-river country
+    around Hot Springs. Post-Smokies fatigue is common; Max Patch bald offers huge
+    views; trail softens into pastoral TN/NC border country. Landmarks in this corridor
+    include Davenport Gap, Max Patch, Hot Springs.'
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
+  segment: Smokies exit to Hot Springs
+  at_mile_start: 231.3
+  at_mile_end: 245.3
+  region: Tennessee / North Carolina
 ---
 # Thursday, March 04, 2010 — Cosby Knob Shelter
 **Start Location:** Pecks Corner Shelter
@@ -849,10 +1077,20 @@ miles_today: 10.0
 trip_miles: 255.3
 facts:
   weather: High 30°F, low 18°F. Clear sky.
-  trail_section: Trail section from Cosby Knob Shelter to Standing Bear Farm Hostel.
-  confidence: medium
+  trail_section: 'Smokies exit to Hot Springs (AT miles 245–255): Northbound hikers
+    leave the Smokies at Davenport Gap and cross into the balds-and-river country
+    around Hot Springs. Post-Smokies fatigue is common; Max Patch bald offers huge
+    views; trail softens into pastoral TN/NC border country. Landmarks in this corridor
+    include Davenport Gap, Max Patch, Hot Springs.'
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
+  segment: Smokies exit to Hot Springs
+  at_mile_start: 245.3
+  at_mile_end: 255.3
+  region: Tennessee / North Carolina
 ---
 # Friday, March 05, 2010 — Standing Bear Farm Hostel
 **Start Location:** Cosby Knob Shelter
@@ -878,8 +1116,18 @@ destination: Groundhog Creek Shelter
 miles_today: 8.0
 trip_miles: 263.3
 facts:
-  trail_section: Trail section from Standing Bear Farm Hostel to Groundhog Creek Shelter.
+  trail_section: 'Smokies exit to Hot Springs (AT miles 255–263): Northbound hikers
+    leave the Smokies at Davenport Gap and cross into the balds-and-river country
+    around Hot Springs. Post-Smokies fatigue is common; Max Patch bald offers huge
+    views; trail softens into pastoral TN/NC border country. Landmarks in this corridor
+    include Davenport Gap, Max Patch, Hot Springs.'
   confidence: low
+  sources:
+  - AT segment guide
+  segment: Smokies exit to Hot Springs
+  at_mile_start: 255.3
+  at_mile_end: 263.3
+  region: Tennessee / North Carolina
 ---
 # Saturday, March 06, 2010 — Groundhog Creek Shelter
 **Start Location:** Standing Bear Farm Hostel
@@ -908,10 +1156,20 @@ miles_today: 11.5
 trip_miles: 274.8
 facts:
   weather: High 44°F, low 23°F. Overcast.
-  trail_section: Trail section from Groundhog Creek Shelter to Roaring Fork Shelter.
-  confidence: medium
+  trail_section: 'Smokies exit to Hot Springs (AT miles 263–275): Northbound hikers
+    leave the Smokies at Davenport Gap and cross into the balds-and-river country
+    around Hot Springs. Post-Smokies fatigue is common; Max Patch bald offers huge
+    views; trail softens into pastoral TN/NC border country. Landmarks in this corridor
+    include Davenport Gap, Max Patch, Hot Springs.'
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
+  segment: Smokies exit to Hot Springs
+  at_mile_start: 263.3
+  at_mile_end: 274.8
+  region: Tennessee / North Carolina
 ---
 # Sunday, March 07, 2010 — Roaring Fork Shelter
 **Start Location:** Groundhog Creek Shelter
@@ -934,10 +1192,20 @@ miles_today: 15.0
 trip_miles: 289.8
 facts:
   weather: High 48°F, low 25°F. Overcast.
-  trail_section: Trail section from Roaring Fork Shelter to Deer Park Shelter.
-  confidence: medium
+  trail_section: 'Cherokee National Forest balds (AT miles 275–290): Ridge walking
+    through grassy balds and forested gaps between Hot Springs and the Roan Highlands
+    approach. Exposed ridges, spring snow squalls, and increasing trail community
+    as hikers settle into mileage. Landmarks in this corridor include Roaring Fork,
+    Groundhog Creek, Big Bald.'
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
+  segment: Cherokee National Forest balds
+  at_mile_start: 274.8
+  at_mile_end: 289.8
+  region: North Carolina / Tennessee
 ---
 # Monday, March 08, 2010 — Deer Park Shelter
 **Start Location:** Roaring Fork Shelter
@@ -954,12 +1222,22 @@ miles_today: 3.2
 trip_miles: 293.0
 facts:
   weather: High 67°F, low 34°F. Overcast.
-  trail_section: Trail section from Deer Park Shelter to A cabin (Hot Springs, NC).
+  trail_section: 'Cherokee National Forest balds (AT miles 290–293): Ridge walking
+    through grassy balds and forested gaps between Hot Springs and the Roan Highlands
+    approach. Exposed ridges, spring snow squalls, and increasing trail community
+    as hikers settle into mileage. Landmarks in this corridor include Roaring Fork,
+    Groundhog Creek, Big Bald.'
   town_events: Hot Springs Town & Trail Festival
-  confidence: medium
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
   - https://appalachiantrail.org/event/hot-springs-town-trail-2026/
+  segment: Cherokee National Forest balds
+  at_mile_start: 289.8
+  at_mile_end: 293.0
+  region: North Carolina / Tennessee
 ---
 # Tuesday, March 09, 2010 — A cabin (Hot Springs, NC)
 **Start Location:** Deer Park Shelter
@@ -984,12 +1262,22 @@ miles_today: 11.0
 trip_miles: 304.0
 facts:
   weather: High 55°F, low 42°F. Dense drizzle.
-  trail_section: Trail section from A cabin (Hot Springs, NC) to Spring Mountain Shelter.
+  trail_section: 'Cherokee National Forest balds (AT miles 293–304): Ridge walking
+    through grassy balds and forested gaps between Hot Springs and the Roan Highlands
+    approach. Exposed ridges, spring snow squalls, and increasing trail community
+    as hikers settle into mileage. Landmarks in this corridor include Roaring Fork,
+    Groundhog Creek, Big Bald.'
   town_events: Hot Springs Town & Trail Festival - Appalachian Trail Conservancy
-  confidence: medium
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
   - https://appalachiantrail.org/event/hot-springs-town-trail-2026/
+  segment: Cherokee National Forest balds
+  at_mile_start: 293.0
+  at_mile_end: 304.0
+  region: North Carolina / Tennessee
 ---
 # Thursday, March 11, 2010 — Spring Mountain Shelter
 **Start Location:** A cabin (Hot Springs, NC)
@@ -1012,10 +1300,20 @@ miles_today: 15.4
 trip_miles: 319.4
 facts:
   weather: High 60°F, low 43°F. Slight rain.
-  trail_section: Trail section from Spring Mountain Shelter to Jerry Cabin Shelter.
-  confidence: medium
+  trail_section: 'Cherokee National Forest balds (AT miles 304–319): Ridge walking
+    through grassy balds and forested gaps between Hot Springs and the Roan Highlands
+    approach. Exposed ridges, spring snow squalls, and increasing trail community
+    as hikers settle into mileage. Landmarks in this corridor include Roaring Fork,
+    Groundhog Creek, Big Bald.'
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
+  segment: Cherokee National Forest balds
+  at_mile_start: 304.0
+  at_mile_end: 319.4
+  region: North Carolina / Tennessee
 ---
 # Friday, March 12, 2010 — Jerry Cabin Shelter
 **Start Location:** Spring Mountain Shelter
@@ -1036,10 +1334,20 @@ miles_today: 14.7
 trip_miles: 334.1
 facts:
   weather: High 47°F, low 36°F. Moderate rain.
-  trail_section: Trail section from Jerry Cabin Shelter to Hogback Ridge Shelter.
-  confidence: medium
+  trail_section: 'Cherokee National Forest balds (AT miles 319–334): Ridge walking
+    through grassy balds and forested gaps between Hot Springs and the Roan Highlands
+    approach. Exposed ridges, spring snow squalls, and increasing trail community
+    as hikers settle into mileage. Landmarks in this corridor include Roaring Fork,
+    Groundhog Creek, Big Bald.'
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
+  segment: Cherokee National Forest balds
+  at_mile_start: 319.4
+  at_mile_end: 334.1
+  region: North Carolina / Tennessee
 ---
 # Saturday, March 13, 2010 — Hogback Ridge Shelter
 **Start Location:** Jerry Cabin Shelter
@@ -1056,10 +1364,20 @@ miles_today: 20.7
 trip_miles: 354.8
 facts:
   weather: High 43°F, low 32°F. Moderate drizzle.
-  trail_section: Trail section from Hogback Ridge Shelter to No Business Knob Shelter.
-  confidence: medium
+  trail_section: 'Cherokee National Forest balds (AT miles 334–355): Ridge walking
+    through grassy balds and forested gaps between Hot Springs and the Roan Highlands
+    approach. Exposed ridges, spring snow squalls, and increasing trail community
+    as hikers settle into mileage. Landmarks in this corridor include Roaring Fork,
+    Groundhog Creek, Big Bald.'
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
+  segment: Cherokee National Forest balds
+  at_mile_start: 334.1
+  at_mile_end: 354.8
+  region: North Carolina / Tennessee
 ---
 # Sunday, March 14, 2010 — No Business Knob Shelter
 **Start Location:** Hogback Ridge Shelter
@@ -1076,10 +1394,20 @@ miles_today: 10.5
 trip_miles: 365.3
 facts:
   weather: High 44°F, low 37°F. Moderate drizzle.
-  trail_section: Trail section from No Business Knob Shelter to Curley Maple Gap Shelter.
-  confidence: medium
+  trail_section: 'Roan Highlands (AT miles 355–365): The Roan Highlands feature treeless
+    6,000-foot balds, rhododendron gardens, and some of the most scenic ridge walking
+    on the AT. Wide-open balds with punishing winds; spectacular views when clouds
+    lift; very exposed in storms. Landmarks in this corridor include Roan High Knob,
+    Carvers Gap, Overmountain Shelter.'
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
+  segment: Roan Highlands
+  at_mile_start: 354.8
+  at_mile_end: 365.3
+  region: Tennessee / North Carolina
 ---
 # Monday, March 15, 2010 — Curley Maple Gap Shelter
 **Start Location:** No Business Knob Shelter
@@ -1096,10 +1424,20 @@ miles_today: 22.0
 trip_miles: 387.3
 facts:
   weather: High 42°F, low 30°F. Light drizzle.
-  trail_section: Trail section from Curley Maple Gap Shelter to Clyde Smith Shelter.
-  confidence: medium
+  trail_section: 'Roan Highlands (AT miles 365–387): The Roan Highlands feature treeless
+    6,000-foot balds, rhododendron gardens, and some of the most scenic ridge walking
+    on the AT. Wide-open balds with punishing winds; spectacular views when clouds
+    lift; very exposed in storms. Landmarks in this corridor include Roan High Knob,
+    Carvers Gap, Overmountain Shelter.'
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
+  segment: Roan Highlands
+  at_mile_start: 365.3
+  at_mile_end: 387.3
+  region: Tennessee / North Carolina
 ---
 # Tuesday, March 16, 2010 — Clyde Smith Shelter
 **Start Location:** Curley Maple Gap Shelter
@@ -1116,11 +1454,20 @@ miles_today: 13.1
 trip_miles: 400.4
 facts:
   weather: High 49°F, low 37°F. Light drizzle.
-  trail_section: Trail section from Clyde Smith Shelter to A cabin (near Overmountain
-    Shelter?).
-  confidence: medium
+  trail_section: 'Roan Highlands (AT miles 387–400): The Roan Highlands feature treeless
+    6,000-foot balds, rhododendron gardens, and some of the most scenic ridge walking
+    on the AT. Wide-open balds with punishing winds; spectacular views when clouds
+    lift; very exposed in storms. Landmarks in this corridor include Roan High Knob,
+    Carvers Gap, Overmountain Shelter.'
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
+  segment: Roan Highlands
+  at_mile_start: 387.3
+  at_mile_end: 400.4
+  region: Tennessee / North Carolina
 ---
 # Wednesday, March 17, 2010 — A cabin (near Overmountain Shelter?)
 **Start Location:** Clyde Smith Shelter
@@ -1145,13 +1492,22 @@ miles_today: 9.0
 trip_miles: 409.4
 facts:
   weather: High 60°F, low 40°F. Overcast.
-  trail_section: Trail section from A cabin (near Overmountain Shelter?) to Mountain
-    Harbour Hostel (Elk Park, TN).
+  trail_section: 'Roan Highlands (AT miles 400–409): The Roan Highlands feature treeless
+    6,000-foot balds, rhododendron gardens, and some of the most scenic ridge walking
+    on the AT. Wide-open balds with punishing winds; spectacular views when clouds
+    lift; very exposed in storms. Landmarks in this corridor include Roan High Knob,
+    Carvers Gap, Overmountain Shelter.'
   town_events: 'Appalachian Trail Conservancy: Home'
-  confidence: medium
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
   - https://appalachiantrail.org/
+  segment: Roan Highlands
+  at_mile_start: 400.4
+  at_mile_end: 409.4
+  region: Tennessee / North Carolina
 ---
 # Thursday, March 18, 2010 — Mountain Harbour Hostel (Elk Park, TN)
 **Start Location:** A cabin (near Overmountain Shelter?)
@@ -1168,13 +1524,22 @@ miles_today: 16.7
 trip_miles: 426.1
 facts:
   weather: High 57°F, low 34°F. Mainly clear.
-  trail_section: Trail section from Mountain Harbour Hostel (Elk Park, TN) to Moreland
-    Gap Shelter.
+  trail_section: 'TN–VA high country to Damascus (AT miles 409–426): Crossing into
+    Virginia, hikers descend toward the Holston River and the legendary trail town
+    of Damascus. Long ridge traverses giving way to river valleys; spring green tunnels
+    and increasing horse/equestrian trail overlap in places. Landmarks in this corridor
+    include Damascus, The Place, Kincora Hostel.'
   town_events: 'Erwin, TN to US 19 E. at Elk Park, NC : r/AppalachianTrail - Reddit'
-  confidence: medium
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
   - https://www.reddit.com/r/AppalachianTrail/comments/1plxo5/the_appalachian_trail_in_30_days_530_erwin_tn_to/
+  segment: TN–VA high country to Damascus
+  at_mile_start: 409.4
+  at_mile_end: 426.1
+  region: Tennessee / Virginia
 ---
 # Friday, March 19, 2010 — Moreland Gap Shelter
 **Start Location:** Mountain Harbour Hostel (Elk Park, TN)
@@ -1194,12 +1559,20 @@ destination: Kincora (Dennis Cove, TN)
 miles_today: 6.0
 trip_miles: 432.1
 facts:
-  trail_section: Trail section from Holiday Inn Express (Abingdon, VA) to Kincora
-    (Dennis Cove, TN).
+  trail_section: 'TN–VA high country to Damascus (AT miles 426–432): Crossing into
+    Virginia, hikers descend toward the Holston River and the legendary trail town
+    of Damascus. Long ridge traverses giving way to river valleys; spring green tunnels
+    and increasing horse/equestrian trail overlap in places. Landmarks in this corridor
+    include Damascus, The Place, Kincora Hostel.'
   town_events: Hiking Laurel Falls from Hampton trailhead - Facebook
   confidence: low
   sources:
+  - AT segment guide
   - https://www.facebook.com/groups/tennesseehiking/posts/783378817687401/
+  segment: TN–VA high country to Damascus
+  at_mile_start: 426.1
+  at_mile_end: 432.1
+  region: Tennessee / Virginia
 ---
 # Saturday, March 20, 2010 — Kincora (Dennis Cove, TN)
 **Start Location:** Holiday Inn Express (Abingdon, VA)
@@ -1221,12 +1594,21 @@ destination: Kincora (Dennis Cove, TN)
 miles_today: 0.0
 trip_miles: 432.1
 facts:
-  trail_section: Trail section from Kincora (Dennis Cove, TN) to Kincora (Dennis Cove,
-    TN).
+  trail_section: 'TN–VA high country to Damascus (AT miles 431–432): Crossing into
+    Virginia, hikers descend toward the Holston River and the legendary trail town
+    of Damascus. Long ridge traverses giving way to river valleys; spring green tunnels
+    and increasing horse/equestrian trail overlap in places. Landmarks in this corridor
+    include Damascus, The Place, Kincora Hostel.'
   town_events: 10.1 mile Appalachian Trail hike from Dennis Cove to ...
   confidence: low
   sources:
+  - AT segment guide
+  - firecrawl web search
   - https://www.facebook.com/groups/theweekendadventurer/posts/1389047798518663/
+  segment: TN–VA high country to Damascus
+  at_mile_start: 431.1
+  at_mile_end: 432.1
+  region: Tennessee / Virginia
 ---
 # Sunday, March 21, 2010 — Kincora (Dennis Cove, TN)
 **Start Location:** Kincora (Dennis Cove, TN)
@@ -1243,11 +1625,20 @@ miles_today: 18.0
 trip_miles: 450.1
 facts:
   weather: High 65°F, low 36°F. Overcast.
-  trail_section: Trail section from Double Spring Shelter to The Place (Damascus,
-    VA).
-  confidence: medium
+  trail_section: 'TN–VA high country to Damascus (AT miles 432–450): Crossing into
+    Virginia, hikers descend toward the Holston River and the legendary trail town
+    of Damascus. Long ridge traverses giving way to river valleys; spring green tunnels
+    and increasing horse/equestrian trail overlap in places. Landmarks in this corridor
+    include Damascus, The Place, Kincora Hostel.'
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
+  segment: TN–VA high country to Damascus
+  at_mile_start: 432.1
+  at_mile_end: 450.1
+  region: Tennessee / Virginia
 ---
 # Wednesday, March 24, 2010 — The Place (Damascus, VA)
 **Start Location:** Double Spring Shelter
@@ -1268,13 +1659,22 @@ miles_today: 0.0
 trip_miles: 450.1
 facts:
   weather: High 62°F, low 42°F. Moderate drizzle.
-  trail_section: Trail section from The Place (Damascus, VA) to The Place (Damascus,
-    VA).
+  trail_section: 'TN–VA high country to Damascus (AT miles 449–450): Crossing into
+    Virginia, hikers descend toward the Holston River and the legendary trail town
+    of Damascus. Long ridge traverses giving way to river valleys; spring green tunnels
+    and increasing horse/equestrian trail overlap in places. Landmarks in this corridor
+    include Damascus, The Place, Kincora Hostel.'
   town_events: Appalachian Trail Days Festival - Visit Damascus
-  confidence: medium
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
   - https://visitdamascus.org/traildays/
+  segment: TN–VA high country to Damascus
+  at_mile_start: 449.1
+  at_mile_end: 450.1
+  region: Tennessee / Virginia
 ---
 # Thursday, March 25, 2010 — The Place (Damascus, VA)
 **Start Location:** The Place (Damascus, VA)
@@ -1291,13 +1691,22 @@ miles_today: 18.0
 trip_miles: 468.1
 facts:
   weather: High 52°F, low 42°F. Dense drizzle.
-  trail_section: Trail section from The Place (Damascus, VA) to Augusta's Appalachian
-    Inn (Damascus, VA).
+  trail_section: 'TN–VA high country to Damascus (AT miles 450–468): Crossing into
+    Virginia, hikers descend toward the Holston River and the legendary trail town
+    of Damascus. Long ridge traverses giving way to river valleys; spring green tunnels
+    and increasing horse/equestrian trail overlap in places. Landmarks in this corridor
+    include Damascus, The Place, Kincora Hostel.'
   town_events: Appalachian Trail Days Festival
-  confidence: medium
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
   - https://visitdamascus.org/traildays/
+  segment: TN–VA high country to Damascus
+  at_mile_start: 450.1
+  at_mile_end: 468.1
+  region: Tennessee / Virginia
 ---
 # Friday, March 26, 2010 — Augusta's Appalachian Inn (Damascus, VA)
 **Start Location:** The Place (Damascus, VA)
@@ -1329,13 +1738,22 @@ miles_today: 0.0
 trip_miles: 468.1
 facts:
   weather: High 58°F, low 31°F. Partly cloudy.
-  trail_section: Trail section from Augusta's Appalachian Inn (Damascus, VA) to Holiday
-    Inn Express (Abingdon, VA).
+  trail_section: 'TN–VA high country to Damascus (AT miles 467–468): Crossing into
+    Virginia, hikers descend toward the Holston River and the legendary trail town
+    of Damascus. Long ridge traverses giving way to river valleys; spring green tunnels
+    and increasing horse/equestrian trail overlap in places. Landmarks in this corridor
+    include Damascus, The Place, Kincora Hostel.'
   town_events: Abingdon, VA - Appalachian Trail Conservancy
-  confidence: medium
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
   - https://appalachiantrail.org/protect/conservation/at-community-program/abingdon-va/
+  segment: TN–VA high country to Damascus
+  at_mile_start: 467.1
+  at_mile_end: 468.1
+  region: Tennessee / Virginia
 ---
 # Saturday, March 27, 2010 — Holiday Inn Express (Abingdon, VA)
 **Start Location:** Augusta's Appalachian Inn (Damascus, VA)
@@ -1354,10 +1772,20 @@ miles_today: 20.0
 trip_miles: 488.1
 facts:
   weather: High 52°F, low 36°F. Slight rain.
-  trail_section: Trail section from U.S. 58 to Wise Shelter.
-  confidence: medium
+  trail_section: 'Southwest Virginia — Grayson Highlands (AT miles 468–488): Virginia''s
+    high country: wild ponies at Grayson Highlands, open balds, and the rhythm of
+    20-mile days many hikers adopt. Frequent 4,000-foot knobs, meadow walking, and
+    reliable spring water; notorious spring mud in gaps. Landmarks in this corridor
+    include Grayson Highlands, Mount Rogers, Partnership Shelter.'
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
+  segment: Southwest Virginia — Grayson Highlands
+  at_mile_start: 468.1
+  at_mile_end: 488.1
+  region: Virginia
 ---
 # Sunday, March 28, 2010 — Wise Shelter
 **Start Location:** U.S. 58
@@ -1380,10 +1808,20 @@ miles_today: 20.0
 trip_miles: 508.1
 facts:
   weather: High 48°F, low 37°F. Slight rain.
-  trail_section: Trail section from Wise Shelter to Trimpi Shelter.
-  confidence: medium
+  trail_section: 'Southwest Virginia — Grayson Highlands (AT miles 488–508): Virginia''s
+    high country: wild ponies at Grayson Highlands, open balds, and the rhythm of
+    20-mile days many hikers adopt. Frequent 4,000-foot knobs, meadow walking, and
+    reliable spring water; notorious spring mud in gaps. Landmarks in this corridor
+    include Grayson Highlands, Mount Rogers, Partnership Shelter.'
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
+  segment: Southwest Virginia — Grayson Highlands
+  at_mile_start: 488.1
+  at_mile_end: 508.1
+  region: Virginia
 ---
 # Monday, March 29, 2010 — Trimpi Shelter
 **Start Location:** Wise Shelter
@@ -1401,8 +1839,19 @@ destination: north of Atkins
 miles_today: 27.0
 trip_miles: 535.1
 facts:
-  trail_section: Trail section from Trimpi Shelter to north of Atkins.
+  trail_section: 'Southwest Virginia — Grayson Highlands (AT miles 508–535): Virginia''s
+    high country: wild ponies at Grayson Highlands, open balds, and the rhythm of
+    20-mile days many hikers adopt. Frequent 4,000-foot knobs, meadow walking, and
+    reliable spring water; notorious spring mud in gaps. Landmarks in this corridor
+    include Grayson Highlands, Mount Rogers, Partnership Shelter.'
   confidence: low
+  sources:
+  - AT segment guide
+  - firecrawl web search
+  segment: Southwest Virginia — Grayson Highlands
+  at_mile_start: 508.1
+  at_mile_end: 535.1
+  region: Virginia
 ---
 # Tuesday, March 30, 2010 — north of Atkins
 **Start Location:** Trimpi Shelter
@@ -1423,10 +1872,20 @@ miles_today: 30.0
 trip_miles: 565.1
 facts:
   weather: High 66°F, low 37°F. Overcast.
-  trail_section: Trail section from north of Atkins to Jenkins Shelter.
-  confidence: medium
+  trail_section: 'Southwest Virginia — Grayson Highlands (AT miles 535–565): Virginia''s
+    high country: wild ponies at Grayson Highlands, open balds, and the rhythm of
+    20-mile days many hikers adopt. Frequent 4,000-foot knobs, meadow walking, and
+    reliable spring water; notorious spring mud in gaps. Landmarks in this corridor
+    include Grayson Highlands, Mount Rogers, Partnership Shelter.'
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
+  segment: Southwest Virginia — Grayson Highlands
+  at_mile_start: 535.1
+  at_mile_end: 565.1
+  region: Virginia
 ---
 # Wednesday, March 31, 2010 — Jenkins Shelter
 **Start Location:** north of Atkins
@@ -1445,10 +1904,20 @@ miles_today: 23.8
 trip_miles: 588.9
 facts:
   weather: High 78°F, low 42°F. Overcast.
-  trail_section: Trail section from Jenkins Shelter to Jenny's Knob Shelter.
-  confidence: medium
+  trail_section: 'Central Virginia Blue Ridge (AT miles 565–589): The long Virginia
+    grind begins in earnest — hundreds of miles of Blue Ridge walking with road crossings
+    and small towns. Pine forest, PUDs (pointless ups and downs), and creek valleys;
+    psychologically challenging monotony. Landmarks in this corridor include Pearisburg,
+    Dragon''s Tooth, McAfee Knob.'
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
+  segment: Central Virginia Blue Ridge
+  at_mile_start: 565.1
+  at_mile_end: 588.9
+  region: Virginia
 ---
 # Thursday, April 01, 2010 — Jenny's Knob Shelter
 **Start Location:** Jenkins Shelter
@@ -1466,8 +1935,19 @@ destination: Woods Hole Hostel
 miles_today: 21.0
 trip_miles: 609.9
 facts:
-  trail_section: Trail section from Jenny's Knob Shelter to Woods Hole Hostel.
+  trail_section: 'Central Virginia Blue Ridge (AT miles 589–610): The long Virginia
+    grind begins in earnest — hundreds of miles of Blue Ridge walking with road crossings
+    and small towns. Pine forest, PUDs (pointless ups and downs), and creek valleys;
+    psychologically challenging monotony. Landmarks in this corridor include Pearisburg,
+    Dragon''s Tooth, McAfee Knob.'
   confidence: low
+  sources:
+  - AT segment guide
+  - firecrawl web search
+  segment: Central Virginia Blue Ridge
+  at_mile_start: 588.9
+  at_mile_end: 609.9
+  region: Virginia
 ---
 # Friday, April 02, 2010 — Woods Hole Hostel
 **Start Location:** Jenny's Knob Shelter
@@ -1487,12 +1967,22 @@ miles_today: 10.0
 trip_miles: 619.9
 facts:
   weather: High 77°F, low 57°F. Overcast.
-  trail_section: Trail section from Woods Hole Hostel to A cabin (Pearisburg, VA).
+  trail_section: 'Central Virginia Blue Ridge (AT miles 610–620): The long Virginia
+    grind begins in earnest — hundreds of miles of Blue Ridge walking with road crossings
+    and small towns. Pine forest, PUDs (pointless ups and downs), and creek valleys;
+    psychologically challenging monotony. Landmarks in this corridor include Pearisburg,
+    Dragon''s Tooth, McAfee Knob.'
   town_events: Pearisburg, VA - Appalachian Trail Conservancy
-  confidence: medium
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
   - https://appalachiantrail.org/protect/conservation/at-community-program/pearisburg-va/
+  segment: Central Virginia Blue Ridge
+  at_mile_start: 609.9
+  at_mile_end: 619.9
+  region: Virginia
 ---
 # Saturday, April 03, 2010 — A cabin (Pearisburg, VA)
 **Start Location:** Woods Hole Hostel
@@ -1513,13 +2003,22 @@ miles_today: 0.0
 trip_miles: 619.9
 facts:
   weather: High 73°F, low 49°F. Overcast.
-  trail_section: Trail section from A cabin (Pearisburg, VA) to Rendezevous Motel
-    (Pearisburg, VA).
+  trail_section: 'Central Virginia Blue Ridge (AT miles 619–620): The long Virginia
+    grind begins in earnest — hundreds of miles of Blue Ridge walking with road crossings
+    and small towns. Pine forest, PUDs (pointless ups and downs), and creek valleys;
+    psychologically challenging monotony. Landmarks in this corridor include Pearisburg,
+    Dragon''s Tooth, McAfee Knob.'
   town_events: Pearisburg, VA - Appalachian Trail Conservancy
-  confidence: medium
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
   - https://appalachiantrail.org/protect/conservation/at-community-program/pearisburg-va/
+  segment: Central Virginia Blue Ridge
+  at_mile_start: 618.9
+  at_mile_end: 619.9
+  region: Virginia
 ---
 # Sunday, April 04, 2010 — Rendezevous Motel (Pearisburg, VA)
 **Start Location:** A cabin (Pearisburg, VA)
@@ -1538,13 +2037,22 @@ miles_today: 23.2
 trip_miles: 643.1
 facts:
   weather: High 77°F, low 50°F. Light drizzle.
-  trail_section: Trail section from Rendezevous Motel (Pearisburg, VA) to Bailey Gap
-    Shelter.
+  trail_section: 'Central Virginia Blue Ridge (AT miles 620–643): The long Virginia
+    grind begins in earnest — hundreds of miles of Blue Ridge walking with road crossings
+    and small towns. Pine forest, PUDs (pointless ups and downs), and creek valleys;
+    psychologically challenging monotony. Landmarks in this corridor include Pearisburg,
+    Dragon''s Tooth, McAfee Knob.'
   town_events: Pearisburg, VA
-  confidence: medium
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
   - https://appalachiantrail.org/protect/conservation/at-community-program/pearisburg-va/
+  segment: Central Virginia Blue Ridge
+  at_mile_start: 619.9
+  at_mile_end: 643.1
+  region: Virginia
 ---
 # Monday, April 05, 2010 — Bailey Gap Shelter
 **Start Location:** Rendezevous Motel (Pearisburg, VA)
@@ -1563,10 +2071,20 @@ miles_today: 26.2
 trip_miles: 669.3
 facts:
   weather: High 83°F, low 55°F. Overcast.
-  trail_section: Trail section from Bailey Gap Shelter to Niday Shelter.
-  confidence: medium
+  trail_section: 'Central Virginia — McAfee Knob and Tye River (AT miles 643–669):
+    Home to McAfee Knob and Dragon''s Tooth — two of the most iconic photo ops on
+    the entire trail. Rocky scrambles, knife-edge overlooks, and steep descents into
+    the James River gorge. Landmarks in this corridor include McAfee Knob, Dragon''s
+    Tooth, James River Foot Bridge.'
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
+  segment: Central Virginia — McAfee Knob and Tye River
+  at_mile_start: 643.1
+  at_mile_end: 669.3
+  region: Virginia
 ---
 # Tuesday, April 06, 2010 — Niday Shelter
 **Start Location:** Bailey Gap Shelter
@@ -1765,10 +2283,20 @@ miles_today: 27.1
 trip_miles: 696.4
 facts:
   weather: High 82°F, low 54°F. Overcast.
-  trail_section: Trail section from Niday Shelter to Campbell Shelter.
-  confidence: medium
+  trail_section: 'Central Virginia — McAfee Knob and Tye River (AT miles 669–696):
+    Home to McAfee Knob and Dragon''s Tooth — two of the most iconic photo ops on
+    the entire trail. Rocky scrambles, knife-edge overlooks, and steep descents into
+    the James River gorge. Landmarks in this corridor include McAfee Knob, Dragon''s
+    Tooth, James River Foot Bridge.'
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
+  segment: Central Virginia — McAfee Knob and Tye River
+  at_mile_start: 669.3
+  at_mile_end: 696.4
+  region: Virginia
 ---
 # Wednesday, April 07, 2010 — Campbell Shelter
 **Start Location:** Niday Shelter
@@ -1787,13 +2315,22 @@ miles_today: 17.0
 trip_miles: 713.4
 facts:
   weather: High 73°F, low 57°F. Slight rain.
-  trail_section: Trail section from Campbell Shelter to Travelodge Motel (Daleville,
-    VA).
+  trail_section: 'Central Virginia — McAfee Knob and Tye River (AT miles 696–713):
+    Home to McAfee Knob and Dragon''s Tooth — two of the most iconic photo ops on
+    the entire trail. Rocky scrambles, knife-edge overlooks, and steep descents into
+    the James River gorge. Landmarks in this corridor include McAfee Knob, Dragon''s
+    Tooth, James River Foot Bridge.'
   town_events: 'Day 48: Arriving in Daleville, Redux'
-  confidence: medium
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
   - https://thetrek.co/appalachian-trail/daleville-va/
+  segment: Central Virginia — McAfee Knob and Tye River
+  at_mile_start: 696.4
+  at_mile_end: 713.4
+  region: Virginia
 ---
 # Thursday, April 08, 2010 — Travelodge Motel (Daleville, VA)
 **Start Location:** Campbell Shelter
@@ -1812,13 +2349,22 @@ miles_today: 4.9
 trip_miles: 718.3
 facts:
   weather: High 58°F, low 43°F. Moderate rain.
-  trail_section: Trail section from Travelodge Motel (Daleville, VA) to Fullhardt
-    Knob Shelter.
+  trail_section: 'Central Virginia — McAfee Knob and Tye River (AT miles 713–718):
+    Home to McAfee Knob and Dragon''s Tooth — two of the most iconic photo ops on
+    the entire trail. Rocky scrambles, knife-edge overlooks, and steep descents into
+    the James River gorge. Landmarks in this corridor include McAfee Knob, Dragon''s
+    Tooth, James River Foot Bridge.'
   town_events: 'Day 48: Arriving in Daleville, Redux - The Trek'
-  confidence: medium
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
   - https://thetrek.co/appalachian-trail/daleville-va/
+  segment: Central Virginia — McAfee Knob and Tye River
+  at_mile_start: 713.4
+  at_mile_end: 718.3
+  region: Virginia
 ---
 # Friday, April 09, 2010 — Fullhardt Knob Shelter
 **Start Location:** Travelodge Motel (Daleville, VA)
@@ -1837,10 +2383,20 @@ miles_today: 20.0
 trip_miles: 738.3
 facts:
   weather: High 66°F, low 38°F. Clear sky.
-  trail_section: Trail section from Fullhardt Knob Shelter to Cove Mountain Shelter.
-  confidence: medium
+  trail_section: 'Central Virginia — McAfee Knob and Tye River (AT miles 718–738):
+    Home to McAfee Knob and Dragon''s Tooth — two of the most iconic photo ops on
+    the entire trail. Rocky scrambles, knife-edge overlooks, and steep descents into
+    the James River gorge. Landmarks in this corridor include McAfee Knob, Dragon''s
+    Tooth, James River Foot Bridge.'
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
+  segment: Central Virginia — McAfee Knob and Tye River
+  at_mile_start: 718.3
+  at_mile_end: 738.3
+  region: Virginia
 ---
 # Saturday, April 10, 2010 — Cove Mountain Shelter
 **Start Location:** Fullhardt Knob Shelter
@@ -1861,10 +2417,20 @@ miles_today: 17.2
 trip_miles: 755.5
 facts:
   weather: High 71°F, low 38°F. Clear sky.
-  trail_section: Trail section from Cove Mountain Shelter to Thunder Hill Shelter.
-  confidence: medium
+  trail_section: 'Central Virginia — McAfee Knob and Tye River (AT miles 738–756):
+    Home to McAfee Knob and Dragon''s Tooth — two of the most iconic photo ops on
+    the entire trail. Rocky scrambles, knife-edge overlooks, and steep descents into
+    the James River gorge. Landmarks in this corridor include McAfee Knob, Dragon''s
+    Tooth, James River Foot Bridge.'
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
+  segment: Central Virginia — McAfee Knob and Tye River
+  at_mile_start: 738.3
+  at_mile_end: 755.5
+  region: Virginia
 ---
 # Sunday, April 11, 2010 — Thunder Hill Shelter
 **Start Location:** Cove Mountain Shelter
@@ -1880,8 +2446,19 @@ destination: Punchbowl Shelter
 miles_today: 25.1
 trip_miles: 780.6
 facts:
-  trail_section: Trail section from Thunder Hill Shelter to Punchbowl Shelter.
+  trail_section: 'Virginia — Blue Ridge to Shenandoah approach (AT miles 756–781):
+    Approaching Shenandoah National Park through rolling Blue Ridge country and Civil
+    War-era landscape. Gradual climbs, horse trails, and increasing signs of proximity
+    to the DC metro exurbs. Landmarks in this corridor include Blacksburg area, Bluff
+    City, Shenandoah south entrance.'
   confidence: low
+  sources:
+  - AT segment guide
+  - firecrawl web search
+  segment: Virginia — Blue Ridge to Shenandoah approach
+  at_mile_start: 755.5
+  at_mile_end: 780.6
+  region: Virginia
 ---
 # Monday, April 12, 2010 — Punchbowl Shelter
 **Start Location:** Thunder Hill Shelter
@@ -1903,8 +2480,19 @@ destination: Seely-Woodworth Shelter
 miles_today: 25.3
 trip_miles: 805.9
 facts:
-  trail_section: Trail section from Punchbowl Shelter to Seely-Woodworth Shelter.
+  trail_section: 'Virginia — Blue Ridge to Shenandoah approach (AT miles 781–806):
+    Approaching Shenandoah National Park through rolling Blue Ridge country and Civil
+    War-era landscape. Gradual climbs, horse trails, and increasing signs of proximity
+    to the DC metro exurbs. Landmarks in this corridor include Blacksburg area, Bluff
+    City, Shenandoah south entrance.'
   confidence: low
+  sources:
+  - AT segment guide
+  - firecrawl web search
+  segment: Virginia — Blue Ridge to Shenandoah approach
+  at_mile_start: 780.6
+  at_mile_end: 805.9
+  region: Virginia
 ---
 # Tuesday, April 13, 2010 — Seely-Woodworth Shelter
 **Start Location:** Punchbowl Shelter
@@ -1933,8 +2521,19 @@ destination: Reed's Gap
 miles_today: 22.3
 trip_miles: 828.2
 facts:
-  trail_section: Trail section from Seely-Woodworth Shelter to Reed's Gap.
+  trail_section: 'Virginia — Blue Ridge to Shenandoah approach (AT miles 806–828):
+    Approaching Shenandoah National Park through rolling Blue Ridge country and Civil
+    War-era landscape. Gradual climbs, horse trails, and increasing signs of proximity
+    to the DC metro exurbs. Landmarks in this corridor include Blacksburg area, Bluff
+    City, Shenandoah south entrance.'
   confidence: low
+  sources:
+  - AT segment guide
+  - firecrawl web search
+  segment: Virginia — Blue Ridge to Shenandoah approach
+  at_mile_start: 805.9
+  at_mile_end: 828.2
+  region: Virginia
 ---
 # Wednesday, April 14, 2010 — Reed's Gap
 **Start Location:** Seely-Woodworth Shelter
@@ -1956,13 +2555,22 @@ miles_today: 28.0
 trip_miles: 856.2
 facts:
   weather: High 71°F, low 34°F. Mainly clear.
-  trail_section: Trail section from Reed's Gap to Wesley's frat house (Charlottesville,
-    VA).
+  trail_section: 'Virginia — Blue Ridge to Shenandoah approach (AT miles 828–856):
+    Approaching Shenandoah National Park through rolling Blue Ridge country and Civil
+    War-era landscape. Gradual climbs, horse trails, and increasing signs of proximity
+    to the DC metro exurbs. Landmarks in this corridor include Blacksburg area, Bluff
+    City, Shenandoah south entrance.'
   town_events: Events
-  confidence: medium
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
   - https://appalachiantrail.org/events/
+  segment: Virginia — Blue Ridge to Shenandoah approach
+  at_mile_start: 828.2
+  at_mile_end: 856.2
+  region: Virginia
 ---
 # Thursday, April 15, 2010 — Wesley's frat house (Charlottesville, VA)
 **Start Location:** Reed's Gap
@@ -1981,13 +2589,22 @@ miles_today: 26.2
 trip_miles: 882.4
 facts:
   weather: High 72°F, low 44°F. Overcast.
-  trail_section: Trail section from Wesley's frat house (Charlottesville, VA) to Pinefield
-    Hut.
+  trail_section: 'Shenandoah National Park (AT miles 856–882): Shenandoah offers relatively
+    gentle graded walking, black bears, waysides with pie, and Skyline Drive crossings.
+    Broad, well-maintained trail on ridgecrest; frequent deer; summer heat and crowded
+    park traffic. Landmarks in this corridor include Skyline Drive, Big Meadows, Bearfence
+    Mountain.'
   town_events: 'The Virginia Creeper Trail: Then & Now'
-  confidence: medium
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
   - https://appalachiantrail.org/event/the-virginia-creeper-trail-then-now/
+  segment: Shenandoah National Park
+  at_mile_start: 856.2
+  at_mile_end: 882.4
+  region: Virginia
 ---
 # Friday, April 16, 2010 — Pinefield Hut
 **Start Location:** Wesley's frat house (Charlottesville, VA)
@@ -2185,8 +2802,19 @@ destination: Bearfence Mountain Hut
 miles_today: 20.6
 trip_miles: 903.0
 facts:
-  trail_section: Trail section from Pinefield Hut to Bearfence Mountain Hut.
+  trail_section: 'Shenandoah National Park (AT miles 882–903): Shenandoah offers relatively
+    gentle graded walking, black bears, waysides with pie, and Skyline Drive crossings.
+    Broad, well-maintained trail on ridgecrest; frequent deer; summer heat and crowded
+    park traffic. Landmarks in this corridor include Skyline Drive, Big Meadows, Bearfence
+    Mountain.'
   confidence: low
+  sources:
+  - AT segment guide
+  - firecrawl web search
+  segment: Shenandoah National Park
+  at_mile_start: 882.4
+  at_mile_end: 903.0
+  region: Virginia
 ---
 # Saturday, April 17, 2010 — Bearfence Mountain Hut
 **Start Location:** Pinefield Hut
@@ -2384,8 +3012,18 @@ destination: Treehaus
 miles_today: 0.0
 trip_miles: 903.0
 facts:
-  trail_section: Trail section from Bearfence Mountain Hut to Treehaus.
+  trail_section: 'Shenandoah National Park (AT miles 902–903): Shenandoah offers relatively
+    gentle graded walking, black bears, waysides with pie, and Skyline Drive crossings.
+    Broad, well-maintained trail on ridgecrest; frequent deer; summer heat and crowded
+    park traffic. Landmarks in this corridor include Skyline Drive, Big Meadows, Bearfence
+    Mountain.'
   confidence: low
+  sources:
+  - AT segment guide
+  segment: Shenandoah National Park
+  at_mile_start: 902.0
+  at_mile_end: 903.0
+  region: Virginia
 ---
 # Sunday, April 18, 2010 — Treehaus
 **Start Location:** Bearfence Mountain Hut
@@ -2583,8 +3221,19 @@ destination: 'Byrd''s Nest #3'
 miles_today: 22.4
 trip_miles: 925.4
 facts:
-  trail_section: 'Trail section from Treehaus to Byrd''s Nest #3.'
+  trail_section: 'Shenandoah National Park (AT miles 903–925): Shenandoah offers relatively
+    gentle graded walking, black bears, waysides with pie, and Skyline Drive crossings.
+    Broad, well-maintained trail on ridgecrest; frequent deer; summer heat and crowded
+    park traffic. Landmarks in this corridor include Skyline Drive, Big Meadows, Bearfence
+    Mountain.'
   confidence: low
+  sources:
+  - AT segment guide
+  - firecrawl web search
+  segment: Shenandoah National Park
+  at_mile_start: 903.0
+  at_mile_end: 925.4
+  region: Virginia
 ---
 # Monday, April 19, 2010 — Byrd's Nest #3
 **Start Location:** Treehaus
@@ -2782,8 +3431,19 @@ destination: Gravel Springs Hut
 miles_today: 17.5
 trip_miles: 942.9
 facts:
-  trail_section: 'Trail section from Byrd''s Nest #3 to Gravel Springs Hut.'
+  trail_section: 'Shenandoah National Park (AT miles 925–943): Shenandoah offers relatively
+    gentle graded walking, black bears, waysides with pie, and Skyline Drive crossings.
+    Broad, well-maintained trail on ridgecrest; frequent deer; summer heat and crowded
+    park traffic. Landmarks in this corridor include Skyline Drive, Big Meadows, Bearfence
+    Mountain.'
   confidence: low
+  sources:
+  - AT segment guide
+  - firecrawl web search
+  segment: Shenandoah National Park
+  at_mile_start: 925.4
+  at_mile_end: 942.9
+  region: Virginia
 ---
 # Tuesday, April 20, 2010 — Gravel Springs Hut
 **Start Location:** Byrd's Nest #3
@@ -2981,8 +3641,19 @@ destination: Dick's Dome Shelter
 miles_today: 28.6
 trip_miles: 971.5
 facts:
-  trail_section: Trail section from Gravel Springs Hut to Dick's Dome Shelter.
+  trail_section: 'Shenandoah National Park (AT miles 943–972): Shenandoah offers relatively
+    gentle graded walking, black bears, waysides with pie, and Skyline Drive crossings.
+    Broad, well-maintained trail on ridgecrest; frequent deer; summer heat and crowded
+    park traffic. Landmarks in this corridor include Skyline Drive, Big Meadows, Bearfence
+    Mountain.'
   confidence: low
+  sources:
+  - AT segment guide
+  - firecrawl web search
+  segment: Shenandoah National Park
+  at_mile_start: 942.9
+  at_mile_end: 971.5
+  region: Virginia
 ---
 # Wednesday, April 21, 2010 — Dick's Dome Shelter
 **Start Location:** Gravel Springs Hut
@@ -3180,8 +3851,19 @@ destination: Bear's Den Hostel
 miles_today: 18.3
 trip_miles: 989.8
 facts:
-  trail_section: Trail section from Dick's Dome Shelter to Bear's Den Hostel.
+  trail_section: 'Shenandoah National Park (AT miles 972–990): Shenandoah offers relatively
+    gentle graded walking, black bears, waysides with pie, and Skyline Drive crossings.
+    Broad, well-maintained trail on ridgecrest; frequent deer; summer heat and crowded
+    park traffic. Landmarks in this corridor include Skyline Drive, Big Meadows, Bearfence
+    Mountain.'
   confidence: low
+  sources:
+  - AT segment guide
+  - firecrawl web search
+  segment: Shenandoah National Park
+  at_mile_start: 971.5
+  at_mile_end: 989.8
+  region: Virginia
 ---
 # Friday, April 23, 2010 — Bear's Den Hostel
 **Start Location:** Dick's Dome Shelter
@@ -3380,10 +4062,20 @@ miles_today: 8.0
 trip_miles: 997.8
 facts:
   weather: High 58°F, low 47°F. Dense drizzle.
-  trail_section: Trail section from Bear's Den Hostel to Blackburn Trail Center.
-  confidence: medium
+  trail_section: 'Shenandoah National Park (AT miles 990–998): Shenandoah offers relatively
+    gentle graded walking, black bears, waysides with pie, and Skyline Drive crossings.
+    Broad, well-maintained trail on ridgecrest; frequent deer; summer heat and crowded
+    park traffic. Landmarks in this corridor include Skyline Drive, Big Meadows, Bearfence
+    Mountain.'
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
+  segment: Shenandoah National Park
+  at_mile_start: 989.8
+  at_mile_end: 997.8
+  region: Virginia
 ---
 # Saturday, April 24, 2010 — Blackburn Trail Center
 **Start Location:** Bear's Den Hostel
@@ -3404,10 +4096,20 @@ miles_today: 12.5
 trip_miles: 1010.3
 facts:
   weather: High 70°F, low 46°F. Moderate rain.
-  trail_section: Trail section from Blackburn Trail Center to Harper's Ferry Hostel.
-  confidence: medium
+  trail_section: 'Harpers Ferry to Maryland (AT miles 998–1010): The psychological
+    midpoint at Harpers Ferry leads through the historic Potomac and into rocky Maryland.
+    River corridors, towpath connectors, and the first northern rockiness in Maryland''s
+    roller-coaster ridges. Landmarks in this corridor include Harpers Ferry, ATC Headquarters,
+    Annapolis Rocks.'
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
+  segment: Harpers Ferry to Maryland
+  at_mile_start: 997.8
+  at_mile_end: 1010.3
+  region: Virginia / West Virginia / Maryland
 ---
 # Sunday, April 25, 2010 — Harper's Ferry Hostel
 **Start Location:** Blackburn Trail Center
@@ -3433,8 +4135,18 @@ destination: Pine Knob Shelter
 miles_today: 22.9
 trip_miles: 1033.2
 facts:
-  trail_section: Trail section from Harper's Ferry Hostel to Pine Knob Shelter.
+  trail_section: 'Harpers Ferry to Maryland (AT miles 1010–1033): The psychological
+    midpoint at Harpers Ferry leads through the historic Potomac and into rocky Maryland.
+    River corridors, towpath connectors, and the first northern rockiness in Maryland''s
+    roller-coaster ridges. Landmarks in this corridor include Harpers Ferry, ATC Headquarters,
+    Annapolis Rocks.'
   confidence: low
+  sources:
+  - AT segment guide
+  segment: Harpers Ferry to Maryland
+  at_mile_start: 1010.3
+  at_mile_end: 1033.2
+  region: Virginia / West Virginia / Maryland
 ---
 # Monday, April 26, 2010 — Pine Knob Shelter
 **Start Location:** Harper's Ferry Hostel
@@ -3450,8 +4162,19 @@ destination: near Devil's Racecourse Shelter
 miles_today: 13.1
 trip_miles: 1046.3
 facts:
-  trail_section: Trail section from Pine Knob Shelter to near Devil's Racecourse Shelter.
+  trail_section: 'Harpers Ferry to Maryland (AT miles 1033–1046): The psychological
+    midpoint at Harpers Ferry leads through the historic Potomac and into rocky Maryland.
+    River corridors, towpath connectors, and the first northern rockiness in Maryland''s
+    roller-coaster ridges. Landmarks in this corridor include Harpers Ferry, ATC Headquarters,
+    Annapolis Rocks.'
   confidence: low
+  sources:
+  - AT segment guide
+  - firecrawl web search
+  segment: Harpers Ferry to Maryland
+  at_mile_start: 1033.2
+  at_mile_end: 1046.3
+  region: Virginia / West Virginia / Maryland
 ---
 # Tuesday, April 27, 2010 — near Devil's Racecourse Shelter
 **Start Location:** Pine Knob Shelter
@@ -3468,11 +4191,20 @@ miles_today: 13.2
 trip_miles: 1059.5
 facts:
   weather: High 53°F, low 36°F. Overcast.
-  trail_section: Trail section from near Devil's Racecourse Shelter to Tumbling Run
-    Shelters.
-  confidence: medium
+  trail_section: 'Harpers Ferry to Maryland (AT miles 1046–1060): The psychological
+    midpoint at Harpers Ferry leads through the historic Potomac and into rocky Maryland.
+    River corridors, towpath connectors, and the first northern rockiness in Maryland''s
+    roller-coaster ridges. Landmarks in this corridor include Harpers Ferry, ATC Headquarters,
+    Annapolis Rocks.'
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
+  segment: Harpers Ferry to Maryland
+  at_mile_start: 1046.3
+  at_mile_end: 1059.5
+  region: Virginia / West Virginia / Maryland
 ---
 # Wednesday, April 28, 2010 — Tumbling Run Shelters
 **Start Location:** near Devil's Racecourse Shelter
@@ -3491,10 +4223,20 @@ miles_today: 25.8
 trip_miles: 1085.3
 facts:
   weather: High 63°F, low 36°F. Overcast.
-  trail_section: Trail section from Tumbling Run Shelters to Tom's Run Shelters.
-  confidence: medium
+  trail_section: 'Harpers Ferry to Maryland (AT miles 1060–1085): The psychological
+    midpoint at Harpers Ferry leads through the historic Potomac and into rocky Maryland.
+    River corridors, towpath connectors, and the first northern rockiness in Maryland''s
+    roller-coaster ridges. Landmarks in this corridor include Harpers Ferry, ATC Headquarters,
+    Annapolis Rocks.'
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
+  segment: Harpers Ferry to Maryland
+  at_mile_start: 1059.5
+  at_mile_end: 1085.3
+  region: Virginia / West Virginia / Maryland
 ---
 # Thursday, April 29, 2010 — Tom's Run Shelters
 **Start Location:** Tumbling Run Shelters
@@ -3515,10 +4257,20 @@ miles_today: 27.8
 trip_miles: 1113.1
 facts:
   weather: High 78°F, low 45°F. Overcast.
-  trail_section: Trail section from Tom's Run Shelters to north of Boiling Springs.
-  confidence: medium
+  trail_section: 'Harpers Ferry to Maryland (AT miles 1085–1113): The psychological
+    midpoint at Harpers Ferry leads through the historic Potomac and into rocky Maryland.
+    River corridors, towpath connectors, and the first northern rockiness in Maryland''s
+    roller-coaster ridges. Landmarks in this corridor include Harpers Ferry, ATC Headquarters,
+    Annapolis Rocks.'
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
+  segment: Harpers Ferry to Maryland
+  at_mile_start: 1085.3
+  at_mile_end: 1113.1
+  region: Virginia / West Virginia / Maryland
 ---
 # Friday, April 30, 2010 — north of Boiling Springs
 **Start Location:** Tom's Run Shelters
@@ -3534,9 +4286,18 @@ destination: Red Roof Inn (Duncannon, PA)
 miles_today: 20.7
 trip_miles: 1133.8
 facts:
-  trail_section: Trail section from north of Boiling Springs to Red Roof Inn (Duncannon,
-    PA).
+  trail_section: 'Maryland and Pennsylvania south (AT miles 1113–1134): Short but
+    rocky Maryland yields to Pennsylvania''s infamous jagged quartzite and long farm-country
+    walking. Ankle-rolling rocks become the dominant story; boots begin failing; town
+    stops every few days. Landmarks in this corridor include Pen Mar Park, Pine Grove
+    Furnace, Appalachian Trail Museum.'
   confidence: low
+  sources:
+  - AT segment guide
+  segment: Maryland and Pennsylvania south
+  at_mile_start: 1113.1
+  at_mile_end: 1133.8
+  region: Maryland / Pennsylvania
 ---
 # Saturday, May 01, 2010 — Red Roof Inn (Duncannon, PA)
 **Start Location:** north of Boiling Springs
@@ -3561,11 +4322,20 @@ miles_today: 11.2
 trip_miles: 1145.0
 facts:
   weather: High 82°F, low 62°F. Slight rain.
-  trail_section: Trail section from Red Roof Inn (Duncannon, PA) to Peters Mountain
-    Shelter.
-  confidence: medium
+  trail_section: 'Maryland and Pennsylvania south (AT miles 1134–1145): Short but
+    rocky Maryland yields to Pennsylvania''s infamous jagged quartzite and long farm-country
+    walking. Ankle-rolling rocks become the dominant story; boots begin failing; town
+    stops every few days. Landmarks in this corridor include Pen Mar Park, Pine Grove
+    Furnace, Appalachian Trail Museum.'
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
+  segment: Maryland and Pennsylvania south
+  at_mile_start: 1133.8
+  at_mile_end: 1145.0
+  region: Maryland / Pennsylvania
 ---
 # Sunday, May 02, 2010 — Peters Mountain Shelter
 **Start Location:** Red Roof Inn (Duncannon, PA)
@@ -3596,10 +4366,20 @@ miles_today: 18.0
 trip_miles: 1163.0
 facts:
   weather: High 77°F, low 66°F. Moderate rain.
-  trail_section: Trail section from Peters Mountain Shelter to Rausch Gap Shelter.
-  confidence: medium
+  trail_section: 'Maryland and Pennsylvania south (AT miles 1145–1163): Short but
+    rocky Maryland yields to Pennsylvania''s infamous jagged quartzite and long farm-country
+    walking. Ankle-rolling rocks become the dominant story; boots begin failing; town
+    stops every few days. Landmarks in this corridor include Pen Mar Park, Pine Grove
+    Furnace, Appalachian Trail Museum.'
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
+  segment: Maryland and Pennsylvania south
+  at_mile_start: 1145.0
+  at_mile_end: 1163.0
+  region: Maryland / Pennsylvania
 ---
 # Monday, May 03, 2010 — Rausch Gap Shelter
 **Start Location:** Peters Mountain Shelter
@@ -3620,13 +4400,22 @@ miles_today: 42.0
 trip_miles: 1205.0
 facts:
   weather: High 74°F, low 56°F. Light drizzle.
-  trail_section: Trail section from Rausch Gap Shelter to The Pavilion (Port Clinton,
-    PA).
+  trail_section: 'Maryland and Pennsylvania south (AT miles 1163–1205): Short but
+    rocky Maryland yields to Pennsylvania''s infamous jagged quartzite and long farm-country
+    walking. Ankle-rolling rocks become the dominant story; boots begin failing; town
+    stops every few days. Landmarks in this corridor include Pen Mar Park, Pine Grove
+    Furnace, Appalachian Trail Museum.'
   town_events: Day 110 | Port Clinton PA | Appalachian Trail Thru-hike
-  confidence: medium
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
   - https://www.youtube.com/watch?v=cClKiaJlYFg
+  segment: Maryland and Pennsylvania south
+  at_mile_start: 1163.0
+  at_mile_end: 1205.0
+  region: Maryland / Pennsylvania
 ---
 # Tuesday, May 04, 2010 — The Pavilion (Port Clinton, PA)
 **Start Location:** Rausch Gap Shelter
@@ -3652,11 +4441,20 @@ miles_today: 22.6
 trip_miles: 1227.6
 facts:
   weather: High 77°F, low 51°F. Clear sky.
-  trail_section: Trail section from The Pavilion (Port Clinton, PA) to Allentown Hiking
-    Club Shelter.
-  confidence: medium
+  trail_section: 'Pennsylvania rocks — mid state (AT miles 1205–1228): Pennsylvania''s
+    endless talus fields and flat-topped ridges test ankles and patience through the
+    long middle of the state. Sharp rocks, little elevation change but exhausting
+    footing; spring can be very wet. Landmarks in this corridor include Boiling Springs,
+    Duncannon, Palmerton.'
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
+  segment: Pennsylvania rocks — mid state
+  at_mile_start: 1205.0
+  at_mile_end: 1227.6
+  region: Pennsylvania
 ---
 # Wednesday, May 05, 2010 — Allentown Hiking Club Shelter
 **Start Location:** The Pavilion (Port Clinton, PA)
@@ -3674,12 +4472,20 @@ destination: The Jailhouse Hostel (Palmerton, PA)
 miles_today: 18.0
 trip_miles: 1245.6
 facts:
-  trail_section: Trail section from Allentown Hiking Club Shelter to The Jailhouse
-    Hostel (Palmerton, PA).
+  trail_section: 'Pennsylvania rocks — mid state (AT miles 1228–1246): Pennsylvania''s
+    endless talus fields and flat-topped ridges test ankles and patience through the
+    long middle of the state. Sharp rocks, little elevation change but exhausting
+    footing; spring can be very wet. Landmarks in this corridor include Boiling Springs,
+    Duncannon, Palmerton.'
   town_events: Day 87 | Hiking Into Palmerton, PA | Appalachian Trail Thru Hike 2021
   confidence: low
   sources:
+  - AT segment guide
   - https://www.youtube.com/watch?v=ElpZWqtRryE
+  segment: Pennsylvania rocks — mid state
+  at_mile_start: 1227.6
+  at_mile_end: 1245.6
+  region: Pennsylvania
 ---
 # Thursday, May 06, 2010 — The Jailhouse Hostel (Palmerton, PA)
 **Start Location:** Allentown Hiking Club Shelter
@@ -3699,12 +4505,20 @@ destination: Kirkridge Shelter
 miles_today: 29.8
 trip_miles: 1275.4
 facts:
-  trail_section: Trail section from The Jailhouse Hostel (Palmerton, PA) to Kirkridge
-    Shelter.
+  trail_section: 'Pennsylvania rocks — mid state (AT miles 1246–1275): Pennsylvania''s
+    endless talus fields and flat-topped ridges test ankles and patience through the
+    long middle of the state. Sharp rocks, little elevation change but exhausting
+    footing; spring can be very wet. Landmarks in this corridor include Boiling Springs,
+    Duncannon, Palmerton.'
   town_events: A.T. Community™ Program - Appalachian Trail Conservancy
   confidence: low
   sources:
+  - AT segment guide
   - https://appalachiantrail.org/protect/conservation/at-community-program/
+  segment: Pennsylvania rocks — mid state
+  at_mile_start: 1245.6
+  at_mile_end: 1275.4
+  region: Pennsylvania
 ---
 # Friday, May 07, 2010 — Kirkridge Shelter
 **Start Location:** The Jailhouse Hostel (Palmerton, PA)
@@ -3725,13 +4539,22 @@ miles_today: 6.5
 trip_miles: 1281.9
 facts:
   weather: High 67°F, low 53°F. Light drizzle.
-  trail_section: Trail section from Kirkridge Shelter to Church of the Mountain Hostel
-    (Delaware-Water Gap).
+  trail_section: 'Pennsylvania rocks — mid state (AT miles 1275–1282): Pennsylvania''s
+    endless talus fields and flat-topped ridges test ankles and patience through the
+    long middle of the state. Sharp rocks, little elevation change but exhausting
+    footing; spring can be very wet. Landmarks in this corridor include Boiling Springs,
+    Duncannon, Palmerton.'
   town_events: Pocono Mountains Towns and Villages - Delaware Water Gap
-  confidence: medium
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
   - https://www.youtube.com/watch?v=1LcdZYB3gNE
+  segment: Pennsylvania rocks — mid state
+  at_mile_start: 1275.4
+  at_mile_end: 1281.9
+  region: Pennsylvania
 ---
 # Saturday, May 08, 2010 — Church of the Mountain Hostel (Delaware-Water Gap)
 **Start Location:** Kirkridge Shelter
@@ -3748,13 +4571,22 @@ miles_today: 25.0
 trip_miles: 1306.9
 facts:
   weather: High 51°F, low 38°F. Overcast.
-  trail_section: Trail section from Church of the Mountain Hostel (Delaware-Water
-    Gap) to Brink Rd. Shelter.
+  trail_section: 'Pennsylvania rocks — mid state (AT miles 1282–1307): Pennsylvania''s
+    endless talus fields and flat-topped ridges test ankles and patience through the
+    long middle of the state. Sharp rocks, little elevation change but exhausting
+    footing; spring can be very wet. Landmarks in this corridor include Boiling Springs,
+    Duncannon, Palmerton.'
   town_events: 'Appalachian Trail Community: Delaware Water Gap'
-  confidence: medium
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
   - https://appalachiantrail.com/20140626/appalachian-trail-community-delaware-water-gap/
+  segment: Pennsylvania rocks — mid state
+  at_mile_start: 1281.9
+  at_mile_end: 1306.9
+  region: Pennsylvania
 ---
 # Sunday, May 09, 2010 — Brink Rd. Shelter
 **Start Location:** Church of the Mountain Hostel (Delaware-Water Gap)
@@ -3770,12 +4602,20 @@ destination: The Mayor's House (Unionville, NY)
 miles_today: 27.0
 trip_miles: 1333.9
 facts:
-  trail_section: Trail section from Brink Rd. Shelter to The Mayor's House (Unionville,
-    NY).
+  trail_section: 'PA to Delaware Water Gap (AT miles 1307–1334): Hikers cross into
+    New Jersey''s surprisingly rugged ridges and approach the Delaware Water Gap.
+    Boardwalks, bogs, and sudden steep climbs; increasing proximity to New York City
+    exurbs. Landmarks in this corridor include Delaware Water Gap, Kirkridge, Pochuck
+    Boardwalk.'
   town_events: Into and out of Unionville, NY (MM 1342-1354) - YouTube
   confidence: low
   sources:
+  - AT segment guide
   - https://www.youtube.com/watch?v=46llWpFxWjI
+  segment: PA to Delaware Water Gap
+  at_mile_start: 1306.9
+  at_mile_end: 1333.9
+  region: Pennsylvania / New Jersey / New York
 ---
 # Monday, May 10, 2010 — The Mayor's House (Unionville, NY)
 **Start Location:** Brink Rd. Shelter
@@ -3798,11 +4638,20 @@ miles_today: 26.8
 trip_miles: 1360.7
 facts:
   weather: High 52°F, low 36°F. Overcast.
-  trail_section: Trail section from The Mayor's House (Unionville, NY) to Linden Motel
-    pool house (Greenwood Lake, NY).
-  confidence: medium
+  trail_section: 'PA to Delaware Water Gap (AT miles 1334–1361): Hikers cross into
+    New Jersey''s surprisingly rugged ridges and approach the Delaware Water Gap.
+    Boardwalks, bogs, and sudden steep climbs; increasing proximity to New York City
+    exurbs. Landmarks in this corridor include Delaware Water Gap, Kirkridge, Pochuck
+    Boardwalk.'
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
+  segment: PA to Delaware Water Gap
+  at_mile_start: 1333.9
+  at_mile_end: 1360.7
+  region: Pennsylvania / New Jersey / New York
 ---
 # Tuesday, May 11, 2010 — Linden Motel pool house (Greenwood Lake, NY)
 **Start Location:** The Mayor's House (Unionville, NY)
@@ -3822,13 +4671,22 @@ miles_today: 16.4
 trip_miles: 1377.1
 facts:
   weather: High 48°F, low 38°F. Slight snow.
-  trail_section: Trail section from Linden Motel pool house (Greenwood Lake, NY) to
-    Fingerboard Shelter.
+  trail_section: 'PA to Delaware Water Gap (AT miles 1361–1377): Hikers cross into
+    New Jersey''s surprisingly rugged ridges and approach the Delaware Water Gap.
+    Boardwalks, bogs, and sudden steep climbs; increasing proximity to New York City
+    exurbs. Landmarks in this corridor include Delaware Water Gap, Kirkridge, Pochuck
+    Boardwalk.'
   town_events: Appalachian Trail view near Greenwood Lake - Facebook
-  confidence: medium
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
   - https://www.facebook.com/groups/thehudsonvalley/posts/2749626821987910/
+  segment: PA to Delaware Water Gap
+  at_mile_start: 1360.7
+  at_mile_end: 1377.1
+  region: Pennsylvania / New Jersey / New York
 ---
 # Wednesday, May 12, 2010 — Fingerboard Shelter
 **Start Location:** Linden Motel pool house (Greenwood Lake, NY)
@@ -3847,8 +4705,19 @@ destination: Graymore Spriritual Center
 miles_today: 21.0
 trip_miles: 1398.1
 facts:
-  trail_section: Trail section from Fingerboard Shelter to Graymore Spriritual Center.
+  trail_section: 'PA to Delaware Water Gap (AT miles 1377–1398): Hikers cross into
+    New Jersey''s surprisingly rugged ridges and approach the Delaware Water Gap.
+    Boardwalks, bogs, and sudden steep climbs; increasing proximity to New York City
+    exurbs. Landmarks in this corridor include Delaware Water Gap, Kirkridge, Pochuck
+    Boardwalk.'
   confidence: low
+  sources:
+  - AT segment guide
+  - firecrawl web search
+  segment: PA to Delaware Water Gap
+  at_mile_start: 1377.1
+  at_mile_end: 1398.1
+  region: Pennsylvania / New Jersey / New York
 ---
 # Thursday, May 13, 2010 — Graymore Spriritual Center
 **Start Location:** Fingerboard Shelter
@@ -3865,8 +4734,18 @@ destination: Morgan Steward Shelter
 miles_today: 28.0
 trip_miles: 1426.1
 facts:
-  trail_section: Trail section from Graymore Spriritual Center to Morgan Steward Shelter.
+  trail_section: 'Hudson Highlands and southern New England approach (AT miles 1398–1426):
+    Spectacular Hudson River views, steep scrambles, and the transition into New England
+    footpath culture. Steep pinewoods, rock scrambles, and suburban trail crossings;
+    black bears common. Landmarks in this corridor include Bear Mountain, West Point
+    views, Kent CT.'
   confidence: low
+  sources:
+  - AT segment guide
+  segment: Hudson Highlands and southern New England approach
+  at_mile_start: 1398.1
+  at_mile_end: 1426.1
+  region: New York / Connecticut
 ---
 # Friday, May 14, 2010 — Morgan Steward Shelter
 **Start Location:** Graymore Spriritual Center
@@ -3883,12 +4762,20 @@ destination: Bill's House (Ridgefield, CT)
 miles_today: 22.0
 trip_miles: 1448.1
 facts:
-  trail_section: Trail section from Morgan Steward Shelter to Bill's House (Ridgefield,
-    CT).
+  trail_section: 'Hudson Highlands and southern New England approach (AT miles 1426–1448):
+    Spectacular Hudson River views, steep scrambles, and the transition into New England
+    footpath culture. Steep pinewoods, rock scrambles, and suburban trail crossings;
+    black bears common. Landmarks in this corridor include Bear Mountain, West Point
+    views, Kent CT.'
   town_events: Events
   confidence: low
   sources:
+  - AT segment guide
   - https://appalachiantrail.org/events/
+  segment: Hudson Highlands and southern New England approach
+  at_mile_start: 1426.1
+  at_mile_end: 1448.1
+  region: New York / Connecticut
 ---
 # Saturday, May 15, 2010 — Bill's House (Ridgefield, CT)
 **Start Location:** Morgan Steward Shelter
@@ -3911,13 +4798,22 @@ miles_today: 14.0
 trip_miles: 1462.1
 facts:
   weather: High 66°F, low 48°F. Overcast.
-  trail_section: Trail section from Bill's House (Ridgefield, CT) to Stewart Hollow
-    Brook Lean-to.
+  trail_section: 'Hudson Highlands and southern New England approach (AT miles 1448–1462):
+    Spectacular Hudson River views, steep scrambles, and the transition into New England
+    footpath culture. Steep pinewoods, rock scrambles, and suburban trail crossings;
+    black bears common. Landmarks in this corridor include Bear Mountain, West Point
+    views, Kent CT.'
   town_events: A.T. Community™ Program - Appalachian Trail Conservancy
-  confidence: medium
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
   - https://appalachiantrail.org/protect/conservation/at-community-program/
+  segment: Hudson Highlands and southern New England approach
+  at_mile_start: 1448.1
+  at_mile_end: 1462.1
+  region: New York / Connecticut
 ---
 # Sunday, May 16, 2010 — Stewart Hollow Brook Lean-to
 **Start Location:** Bill's House (Ridgefield, CT)
@@ -4116,11 +5012,20 @@ miles_today: 26.4
 trip_miles: 1488.5
 facts:
   weather: High 71°F, low 48°F. Overcast.
-  trail_section: Trail section from Stewart Hollow Brook Lean-to to Vanessa's Place
-    (Salibury, CT).
-  confidence: medium
+  trail_section: 'Hudson Highlands and southern New England approach (AT miles 1462–1488):
+    Spectacular Hudson River views, steep scrambles, and the transition into New England
+    footpath culture. Steep pinewoods, rock scrambles, and suburban trail crossings;
+    black bears common. Landmarks in this corridor include Bear Mountain, West Point
+    views, Kent CT.'
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
+  segment: Hudson Highlands and southern New England approach
+  at_mile_start: 1462.1
+  at_mile_end: 1488.5
+  region: New York / Connecticut
 ---
 # Monday, May 17, 2010 — Vanessa's Place (Salibury, CT)
 **Start Location:** Stewart Hollow Brook Lean-to
@@ -4318,12 +5223,20 @@ destination: Tom Lenoard Lean-to
 miles_today: 27.8
 trip_miles: 1516.3
 facts:
-  trail_section: Trail section from Vanessa's Place (Salibury, CT) to Tom Lenoard
-    Lean-to.
+  trail_section: 'Southern New England (AT miles 1488–1516): Rolling New England ridgelines
+    through Connecticut and the Berkshires of western Massachusetts. Muddy spring
+    tread, stone walls, and frequent town access; trail clubs maintain steep, rocky
+    paths. Landmarks in this corridor include Sages Ravine, Mount Greylock, Dalton
+    MA.'
   town_events: 'Appalachian Trail Hike Day 24: Rest and History in Salisbury, CT'
   confidence: low
   sources:
+  - AT segment guide
   - https://www.facebook.com/groups/338899147027564/posts/1524861051764695/
+  segment: Southern New England
+  at_mile_start: 1488.5
+  at_mile_end: 1516.3
+  region: Connecticut / Massachusetts
 ---
 # Tuesday, May 18, 2010 — Tom Lenoard Lean-to
 **Start Location:** Vanessa's Place (Salibury, CT)
@@ -4522,12 +5435,22 @@ miles_today: 23.0
 trip_miles: 1539.3
 facts:
   weather: High 51°F, low 43°F. Moderate rain.
-  trail_section: Trail section from Tom Lenoard Lean-to to A pavillion (Lee, MA).
+  trail_section: 'Southern New England (AT miles 1516–1539): Rolling New England ridgelines
+    through Connecticut and the Berkshires of western Massachusetts. Muddy spring
+    tread, stone walls, and frequent town access; trail clubs maintain steep, rocky
+    paths. Landmarks in this corridor include Sages Ravine, Mount Greylock, Dalton
+    MA.'
   town_events: Lee, MA
-  confidence: medium
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
   - https://appalachiantrail.org/protect/conservation/at-community-program/lee-ma/
+  segment: Southern New England
+  at_mile_start: 1516.3
+  at_mile_end: 1539.3
+  region: Connecticut / Massachusetts
 ---
 # Wednesday, May 19, 2010 — A pavillion (Lee, MA)
 **Start Location:** Tom Lenoard Lean-to
@@ -4726,11 +5649,20 @@ miles_today: 19.0
 trip_miles: 1558.3
 facts:
   weather: High 73°F, low 45°F. Light drizzle.
-  trail_section: Trail section from A pavillion (Lee, MA) to Tom Levardi's home (Dalton,
-    MA).
-  confidence: medium
+  trail_section: 'Southern New England (AT miles 1539–1558): Rolling New England ridgelines
+    through Connecticut and the Berkshires of western Massachusetts. Muddy spring
+    tread, stone walls, and frequent town access; trail clubs maintain steep, rocky
+    paths. Landmarks in this corridor include Sages Ravine, Mount Greylock, Dalton
+    MA.'
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
+  segment: Southern New England
+  at_mile_start: 1539.3
+  at_mile_end: 1558.3
+  region: Connecticut / Massachusetts
 ---
 # Thursday, May 20, 2010 — Tom Levardi's home (Dalton, MA)
 **Start Location:** A pavillion (Lee, MA)
@@ -4929,13 +5861,22 @@ miles_today: 24.0
 trip_miles: 1582.3
 facts:
   weather: High 77°F, low 54°F. Overcast.
-  trail_section: Trail section from Tom Levardi's home (Dalton, MA) to Tom Levardi's
-    home (Dalton, MA).
+  trail_section: 'Southern New England (AT miles 1558–1582): Rolling New England ridgelines
+    through Connecticut and the Berkshires of western Massachusetts. Muddy spring
+    tread, stone walls, and frequent town access; trail clubs maintain steep, rocky
+    paths. Landmarks in this corridor include Sages Ravine, Mount Greylock, Dalton
+    MA.'
   town_events: Appalachian Trail, Dalton Massachusetts.
-  confidence: medium
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
   - https://www.facebook.com/groups/127351843985408/posts/6614146828639178/
+  segment: Southern New England
+  at_mile_start: 1558.3
+  at_mile_end: 1582.3
+  region: Connecticut / Massachusetts
 ---
 # Friday, May 21, 2010 — Tom Levardi's home (Dalton, MA)
 **Start Location:** Tom Levardi's home (Dalton, MA)
@@ -4962,12 +5903,22 @@ miles_today: 28.6
 trip_miles: 1610.9
 facts:
   weather: High 74°F, low 54°F. Light drizzle.
-  trail_section: Trail section from Tom Levardi's home (Dalton, MA) to Goddard Shelter.
+  trail_section: 'Southern New England (AT miles 1582–1611): Rolling New England ridgelines
+    through Connecticut and the Berkshires of western Massachusetts. Muddy spring
+    tread, stone walls, and frequent town access; trail clubs maintain steep, rocky
+    paths. Landmarks in this corridor include Sages Ravine, Mount Greylock, Dalton
+    MA.'
   town_events: 'History Day on Trail: Tour of the Berkshires & Dalton, MA - YouTube'
-  confidence: medium
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
   - https://www.youtube.com/watch?v=k2wDss3B32E
+  segment: Southern New England
+  at_mile_start: 1582.3
+  at_mile_end: 1610.9
+  region: Connecticut / Massachusetts
 ---
 # Saturday, May 22, 2010 — Goddard Shelter
 **Start Location:** Tom Levardi's home (Dalton, MA)
@@ -4988,13 +5939,22 @@ miles_today: 30.0
 trip_miles: 1640.9
 facts:
   weather: High 70°F, low 49°F. Overcast.
-  trail_section: Trail section from Goddard Shelter to Next to VT Route 11 (Manchester
-    Center, VT).
+  trail_section: 'Berkshires to southern Vermont (AT miles 1611–1641): The AT crosses
+    Massachusetts into Vermont''s Green Mountains — mud season and maple country.
+    Rooty, muddy tread; long climbs; increasing alpine feel heading toward Killington
+    and beyond. Landmarks in this corridor include Killington Peak, Manchester Center,
+    Stratton Mountain.'
   town_events: Manchester, VT
-  confidence: medium
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
   - https://appalachiantrail.org/protect/conservation/at-community-program/manchester-vt/
+  segment: Berkshires to southern Vermont
+  at_mile_start: 1610.9
+  at_mile_end: 1640.9
+  region: Massachusetts / Vermont
 ---
 # Sunday, May 23, 2010 — Next to VT Route 11 (Manchester Center, VT)
 **Start Location:** Goddard Shelter
@@ -5014,13 +5974,22 @@ miles_today: 30.0
 trip_miles: 1670.9
 facts:
   weather: High 76°F, low 50°F. Overcast.
-  trail_section: Trail section from Next to VT Route 11 (Manchester Center, VT) to
-    Minerva-Hinchey Shelter.
+  trail_section: 'Berkshires to southern Vermont (AT miles 1641–1671): The AT crosses
+    Massachusetts into Vermont''s Green Mountains — mud season and maple country.
+    Rooty, muddy tread; long climbs; increasing alpine feel heading toward Killington
+    and beyond. Landmarks in this corridor include Killington Peak, Manchester Center,
+    Stratton Mountain.'
   town_events: Manchester, VT
-  confidence: medium
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
   - https://appalachiantrail.org/protect/conservation/at-community-program/manchester-vt/
+  segment: Berkshires to southern Vermont
+  at_mile_start: 1640.9
+  at_mile_end: 1670.9
+  region: Massachusetts / Vermont
 ---
 # Monday, May 24, 2010 — Minerva-Hinchey Shelter
 **Start Location:** Next to VT Route 11 (Manchester Center, VT)
@@ -5039,13 +6008,22 @@ miles_today: 20.0
 trip_miles: 1690.9
 facts:
   weather: High 82°F, low 58°F. Overcast.
-  trail_section: Trail section from Minerva-Hinchey Shelter to Back Home Again Hostel
-    (Rutland, VT).
+  trail_section: 'Berkshires to southern Vermont (AT miles 1671–1691): The AT crosses
+    Massachusetts into Vermont''s Green Mountains — mud season and maple country.
+    Rooty, muddy tread; long climbs; increasing alpine feel heading toward Killington
+    and beyond. Landmarks in this corridor include Killington Peak, Manchester Center,
+    Stratton Mountain.'
   town_events: Appalachian trail events during nobo bubble? - Facebook
-  confidence: medium
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
   - https://www.facebook.com/groups/819170279191773/posts/1535211077587686/
+  segment: Berkshires to southern Vermont
+  at_mile_start: 1670.9
+  at_mile_end: 1690.9
+  region: Massachusetts / Vermont
 ---
 # Tuesday, May 25, 2010 — Back Home Again Hostel (Rutland, VT)
 **Start Location:** Minerva-Hinchey Shelter
@@ -5066,13 +6044,22 @@ miles_today: 10.0
 trip_miles: 1700.9
 facts:
   weather: High 85°F, low 61°F. Partly cloudy.
-  trail_section: Trail section from Back Home Again Hostel (Rutland, VT) to Stony
-    Brook Shelter.
+  trail_section: 'Berkshires to southern Vermont (AT miles 1691–1701): The AT crosses
+    Massachusetts into Vermont''s Green Mountains — mud season and maple country.
+    Rooty, muddy tread; long climbs; increasing alpine feel heading toward Killington
+    and beyond. Landmarks in this corridor include Killington Peak, Manchester Center,
+    Stratton Mountain.'
   town_events: Events
-  confidence: medium
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
   - https://appalachiantrail.org/events/
+  segment: Berkshires to southern Vermont
+  at_mile_start: 1690.9
+  at_mile_end: 1700.9
+  region: Massachusetts / Vermont
 ---
 # Wednesday, May 26, 2010 — Stony Brook Shelter
 **Start Location:** Back Home Again Hostel (Rutland, VT)
@@ -5090,13 +6077,22 @@ miles_today: 16.0
 trip_miles: 1716.9
 facts:
   weather: High 74°F, low 54°F. Light drizzle.
-  trail_section: Trail section from Stony Brook Shelter to Next to a road (Pomfret,
-    VT).
+  trail_section: 'Vermont to White Mountains approach (AT miles 1701–1717): Vermont''s
+    Green Mountains yield to the serious alpine country of the White Mountains in
+    New Hampshire. Mud, moose, and then sudden exposure above treeline; weather becomes
+    a primary hazard. Landmarks in this corridor include Hanover NH, Dartmouth, Mount
+    Moosilauke.'
   town_events: 'Appalachian Trail Conservancy: Home'
-  confidence: medium
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
   - https://appalachiantrail.org/
+  segment: Vermont to White Mountains approach
+  at_mile_start: 1700.9
+  at_mile_end: 1716.9
+  region: Vermont / New Hampshire
 ---
 # Thursday, May 27, 2010 — Next to a road (Pomfret, VT)
 **Start Location:** Stony Brook Shelter
@@ -5113,10 +6109,20 @@ miles_today: 21.0
 trip_miles: 1737.9
 facts:
   weather: High 76°F, low 50°F. Overcast.
-  trail_section: Trail section from Next to a road (Pomfret, VT) to Bob Boon's Home.
-  confidence: medium
+  trail_section: 'Vermont to White Mountains approach (AT miles 1717–1738): Vermont''s
+    Green Mountains yield to the serious alpine country of the White Mountains in
+    New Hampshire. Mud, moose, and then sudden exposure above treeline; weather becomes
+    a primary hazard. Landmarks in this corridor include Hanover NH, Dartmouth, Mount
+    Moosilauke.'
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
+  segment: Vermont to White Mountains approach
+  at_mile_start: 1716.9
+  at_mile_end: 1737.9
+  region: Vermont / New Hampshire
 ---
 # Friday, May 28, 2010 — Bob Boon's Home
 **Start Location:** Next to a road (Pomfret, VT)
@@ -5137,12 +6143,22 @@ miles_today: 18.0
 trip_miles: 1755.9
 facts:
   weather: High 75°F, low 54°F. Light drizzle.
-  trail_section: Trail section from Bob Boon's Home to Bob Boon's Home (Hanover, NH).
+  trail_section: 'Vermont to White Mountains approach (AT miles 1738–1756): Vermont''s
+    Green Mountains yield to the serious alpine country of the White Mountains in
+    New Hampshire. Mud, moose, and then sudden exposure above treeline; weather becomes
+    a primary hazard. Landmarks in this corridor include Hanover NH, Dartmouth, Mount
+    Moosilauke.'
   town_events: Appalachian Trail Hikers Appreciation Day in Hanover, NH - Facebook
-  confidence: medium
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
   - https://www.facebook.com/groups/thruhikers/posts/3766795623639109/
+  segment: Vermont to White Mountains approach
+  at_mile_start: 1737.9
+  at_mile_end: 1755.9
+  region: Vermont / New Hampshire
 ---
 # Saturday, May 29, 2010 — Bob Boon's Home (Hanover, NH)
 **Start Location:** Bob Boon's Home
@@ -5163,13 +6179,22 @@ miles_today: 25.0
 trip_miles: 1780.9
 facts:
   weather: High 72°F, low 56°F. Overcast.
-  trail_section: Trail section from Bob Boon's Home (Hanover, NH) to Hikers Welcome
-    Hostel.
+  trail_section: 'Vermont to White Mountains approach (AT miles 1756–1781): Vermont''s
+    Green Mountains yield to the serious alpine country of the White Mountains in
+    New Hampshire. Mud, moose, and then sudden exposure above treeline; weather becomes
+    a primary hazard. Landmarks in this corridor include Hanover NH, Dartmouth, Mount
+    Moosilauke.'
   town_events: Appalachian Trail Hikers Appreciation Day in Hanover, NH - Facebook
-  confidence: medium
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
   - https://www.facebook.com/groups/thruhikers/posts/3766795623639109/
+  segment: Vermont to White Mountains approach
+  at_mile_start: 1755.9
+  at_mile_end: 1780.9
+  region: Vermont / New Hampshire
 ---
 # Sunday, May 30, 2010 — Hikers Welcome Hostel
 **Start Location:** Bob Boon's Home (Hanover, NH)
@@ -5189,8 +6214,18 @@ destination: Lonesome Lakes Hut
 miles_today: 23.0
 trip_miles: 1803.9
 facts:
-  trail_section: Trail section from Hikers Welcome Hostel to Lonesome Lakes Hut.
+  trail_section: 'Vermont to White Mountains approach (AT miles 1781–1804): Vermont''s
+    Green Mountains yield to the serious alpine country of the White Mountains in
+    New Hampshire. Mud, moose, and then sudden exposure above treeline; weather becomes
+    a primary hazard. Landmarks in this corridor include Hanover NH, Dartmouth, Mount
+    Moosilauke.'
   confidence: low
+  sources:
+  - AT segment guide
+  segment: Vermont to White Mountains approach
+  at_mile_start: 1780.9
+  at_mile_end: 1803.9
+  region: Vermont / New Hampshire
 ---
 # Monday, May 31, 2010 — Lonesome Lakes Hut
 **Start Location:** Hikers Welcome Hostel
@@ -5214,8 +6249,18 @@ destination: Galehead Hut
 miles_today: 16.0
 trip_miles: 1819.9
 facts:
-  trail_section: Trail section from Lonesome Lakes Hut to Galehead Hut.
+  trail_section: 'White Mountains (AT miles 1804–1820): The White Mountains are the
+    AT''s alpine crucible: above-treeline exposure, hut system, and killer ascents.
+    Boulder scrambles, ferocious winds, and mandatory careful weather timing; falls
+    can be fatal. Landmarks in this corridor include Franconia Ridge, Presidential
+    Range, Lakes of the Clouds Hut.'
   confidence: low
+  sources:
+  - AT segment guide
+  segment: White Mountains
+  at_mile_start: 1803.9
+  at_mile_end: 1819.9
+  region: New Hampshire
 ---
 # Tuesday, June 01, 2010 — Galehead Hut
 **Start Location:** Lonesome Lakes Hut
@@ -5231,8 +6276,18 @@ destination: Lakes of the Clouds Hut
 miles_today: 26.0
 trip_miles: 1845.9
 facts:
-  trail_section: Trail section from Galehead Hut to Lakes of the Clouds Hut.
+  trail_section: 'White Mountains (AT miles 1820–1846): The White Mountains are the
+    AT''s alpine crucible: above-treeline exposure, hut system, and killer ascents.
+    Boulder scrambles, ferocious winds, and mandatory careful weather timing; falls
+    can be fatal. Landmarks in this corridor include Franconia Ridge, Presidential
+    Range, Lakes of the Clouds Hut.'
   confidence: low
+  sources:
+  - AT segment guide
+  segment: White Mountains
+  at_mile_start: 1819.9
+  at_mile_end: 1845.9
+  region: New Hampshire
 ---
 # Wednesday, June 02, 2010 — Lakes of the Clouds Hut
 **Start Location:** Galehead Hut
@@ -5257,13 +6312,22 @@ miles_today: 13.5
 trip_miles: 1859.4
 facts:
   weather: High 64°F, low 52°F. Slight rain.
-  trail_section: Trail section from Lakes of the Clouds Hut to Hikers Paradise Hostel
-    (Gorham, NH).
+  trail_section: 'White Mountains (AT miles 1846–1859): The White Mountains are the
+    AT''s alpine crucible: above-treeline exposure, hut system, and killer ascents.
+    Boulder scrambles, ferocious winds, and mandatory careful weather timing; falls
+    can be fatal. Landmarks in this corridor include Franconia Ridge, Presidential
+    Range, Lakes of the Clouds Hut.'
   town_events: A.T. Community™ Program - Appalachian Trail Conservancy
-  confidence: medium
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
   - https://appalachiantrail.org/protect/conservation/at-community-program/
+  segment: White Mountains
+  at_mile_start: 1845.9
+  at_mile_end: 1859.4
+  region: New Hampshire
 ---
 # Thursday, June 03, 2010 — Hikers Paradise Hostel (Gorham, NH)
 **Start Location:** Lakes of the Clouds Hut
@@ -5286,11 +6350,20 @@ miles_today: 21.1
 trip_miles: 1880.5
 facts:
   weather: High 67°F, low 53°F. Light drizzle.
-  trail_section: Trail section from Hikers Paradise Hostel (Gorham, NH) to Doc's front
-    porch (Gorham, NH).
-  confidence: medium
+  trail_section: 'White Mountains (AT miles 1859–1880): The White Mountains are the
+    AT''s alpine crucible: above-treeline exposure, hut system, and killer ascents.
+    Boulder scrambles, ferocious winds, and mandatory careful weather timing; falls
+    can be fatal. Landmarks in this corridor include Franconia Ridge, Presidential
+    Range, Lakes of the Clouds Hut.'
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
+  segment: White Mountains
+  at_mile_start: 1859.4
+  at_mile_end: 1880.5
+  region: New Hampshire
 ---
 # Friday, June 04, 2010 — Doc's front porch (Gorham, NH)
 **Start Location:** Hikers Paradise Hostel (Gorham, NH)
@@ -5312,12 +6385,22 @@ miles_today: 11.8
 trip_miles: 1892.3
 facts:
   weather: High 69°F, low 52°F. Moderate rain.
-  trail_section: Trail section from Doc's front porch to Gentian Pond Shelter.
+  trail_section: 'White Mountains (AT miles 1880–1892): The White Mountains are the
+    AT''s alpine crucible: above-treeline exposure, hut system, and killer ascents.
+    Boulder scrambles, ferocious winds, and mandatory careful weather timing; falls
+    can be fatal. Landmarks in this corridor include Franconia Ridge, Presidential
+    Range, Lakes of the Clouds Hut.'
   town_events: A.T. Community™ Program - Appalachian Trail Conservancy
-  confidence: medium
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
   - https://appalachiantrail.org/protect/conservation/at-community-program/
+  segment: White Mountains
+  at_mile_start: 1880.5
+  at_mile_end: 1892.3
+  region: New Hampshire
 ---
 # Saturday, June 05, 2010 — Gentian Pond Shelter
 **Start Location:** Doc's front porch
@@ -5335,8 +6418,19 @@ destination: Carlo Col Shelter
 miles_today: 5.6
 trip_miles: 1897.9
 facts:
-  trail_section: Trail section from Gentian Pond Shelter to Carlo Col Shelter.
+  trail_section: 'White Mountains (AT miles 1892–1898): The White Mountains are the
+    AT''s alpine crucible: above-treeline exposure, hut system, and killer ascents.
+    Boulder scrambles, ferocious winds, and mandatory careful weather timing; falls
+    can be fatal. Landmarks in this corridor include Franconia Ridge, Presidential
+    Range, Lakes of the Clouds Hut.'
   confidence: low
+  sources:
+  - AT segment guide
+  - firecrawl web search
+  segment: White Mountains
+  at_mile_start: 1892.3
+  at_mile_end: 1897.9
+  region: New Hampshire
 ---
 # Sunday, June 06, 2010 — Carlo Col Shelter
 **Start Location:** Gentian Pond Shelter
@@ -5353,12 +6447,22 @@ miles_today: 14.1
 trip_miles: 1912.0
 facts:
   weather: High 57°F, low 45°F. Light drizzle.
-  trail_section: Trail section from Carlo Col Shelter to The Cabin (Andover, ME).
+  trail_section: 'New Hampshire north to Mahoosuc (AT miles 1898–1912): Northern NH
+    and the Mahoosuc Notch — the slowest mile on the AT — lead into Maine. Brutal
+    boulder caves in Mahoosuc; knee-wrecking; then big Maine woods and first 100-mile
+    wilderness approach. Landmarks in this corridor include Mahoosuc Notch, Gorham
+    NH, Speck Pond.'
   town_events: Appalachian Trail Conservancy's 100th Anniversary To Be ...
-  confidence: medium
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
   - https://andovermanews.com/appalachian-trail-conservancys-100th-anniversary-to-be-celebrated-in-andover/
+  segment: New Hampshire north to Mahoosuc
+  at_mile_start: 1897.9
+  at_mile_end: 1912.0
+  region: New Hampshire / Maine
 ---
 # Monday, June 07, 2010 — The Cabin (Andover, ME)
 **Start Location:** Carlo Col Shelter
@@ -5380,10 +6484,20 @@ miles_today: 29.1
 trip_miles: 1941.1
 facts:
   weather: High 56°F, low 44°F. Light drizzle.
-  trail_section: Trail section from The Cabin (Andover, ME) to Bemis Mountain Lean-to.
-  confidence: medium
+  trail_section: 'New Hampshire north to Mahoosuc (AT miles 1912–1941): Northern NH
+    and the Mahoosuc Notch — the slowest mile on the AT — lead into Maine. Brutal
+    boulder caves in Mahoosuc; knee-wrecking; then big Maine woods and first 100-mile
+    wilderness approach. Landmarks in this corridor include Mahoosuc Notch, Gorham
+    NH, Speck Pond.'
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
+  segment: New Hampshire north to Mahoosuc
+  at_mile_start: 1912.0
+  at_mile_end: 1941.1
+  region: New Hampshire / Maine
 ---
 # Tuesday, June 08, 2010 — Bemis Mountain Lean-to
 **Start Location:** The Cabin (Andover, ME)
@@ -5405,13 +6519,22 @@ miles_today: 17.7
 trip_miles: 1958.8
 facts:
   weather: High 58°F, low 40°F. Overcast.
-  trail_section: Trail section from Bemis Mountain Lean-to to Bob's Hostel (Rangely,
-    ME).
+  trail_section: 'New Hampshire north to Mahoosuc (AT miles 1941–1959): Northern NH
+    and the Mahoosuc Notch — the slowest mile on the AT — lead into Maine. Brutal
+    boulder caves in Mahoosuc; knee-wrecking; then big Maine woods and first 100-mile
+    wilderness approach. Landmarks in this corridor include Mahoosuc Notch, Gorham
+    NH, Speck Pond.'
   town_events: Rangeley Trail Town Festival
-  confidence: medium
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
   - https://appalachiantrail.org/event/rangeley-trail-town-festival/
+  segment: New Hampshire north to Mahoosuc
+  at_mile_start: 1941.1
+  at_mile_end: 1958.8
+  region: New Hampshire / Maine
 ---
 # Wednesday, June 09, 2010 — Bob's Hostel (Rangely, ME)
 **Start Location:** Bemis Mountain Lean-to
@@ -5432,13 +6555,22 @@ miles_today: 10.7
 trip_miles: 1969.5
 facts:
   weather: High 52°F, low 42°F. Moderate drizzle.
-  trail_section: Trail section from Bob's Hostel (Rangely, ME) to Spaulding Mountain
-    Lean-to.
+  trail_section: 'New Hampshire north to Mahoosuc (AT miles 1959–1970): Northern NH
+    and the Mahoosuc Notch — the slowest mile on the AT — lead into Maine. Brutal
+    boulder caves in Mahoosuc; knee-wrecking; then big Maine woods and first 100-mile
+    wilderness approach. Landmarks in this corridor include Mahoosuc Notch, Gorham
+    NH, Speck Pond.'
   town_events: Rangeley Trail Town Festival - Appalachian Trail Conservancy
-  confidence: medium
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
   - https://appalachiantrail.org/event/rangeley-trail-town-festival/
+  segment: New Hampshire north to Mahoosuc
+  at_mile_start: 1958.8
+  at_mile_end: 1969.5
+  region: New Hampshire / Maine
 ---
 # Thursday, June 10, 2010 — Spaulding Mountain Lean-to
 **Start Location:** Bob's Hostel (Rangely, ME)
@@ -5637,10 +6769,20 @@ miles_today: 27.0
 trip_miles: 1996.5
 facts:
   weather: High 64°F, low 43°F. Overcast.
-  trail_section: Trail section from Spaulding Mountain Lean-to to Horns Pond Lean-to.
-  confidence: medium
+  trail_section: 'New Hampshire north to Mahoosuc (AT miles 1970–1996): Northern NH
+    and the Mahoosuc Notch — the slowest mile on the AT — lead into Maine. Brutal
+    boulder caves in Mahoosuc; knee-wrecking; then big Maine woods and first 100-mile
+    wilderness approach. Landmarks in this corridor include Mahoosuc Notch, Gorham
+    NH, Speck Pond.'
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
+  segment: New Hampshire north to Mahoosuc
+  at_mile_start: 1969.5
+  at_mile_end: 1996.5
+  region: New Hampshire / Maine
 ---
 # Friday, June 11, 2010 — Horns Pond Lean-to
 **Start Location:** Spaulding Mountain Lean-to
@@ -5659,11 +6801,20 @@ miles_today: 25.0
 trip_miles: 2021.5
 facts:
   weather: High 61°F, low 44°F. Light drizzle.
-  trail_section: Trail section from Horns Pond Lean-to to A swamp near Pierce Pond
-    Lean-to.
-  confidence: medium
+  trail_section: 'New Hampshire north to Mahoosuc (AT miles 1996–2022): Northern NH
+    and the Mahoosuc Notch — the slowest mile on the AT — lead into Maine. Brutal
+    boulder caves in Mahoosuc; knee-wrecking; then big Maine woods and first 100-mile
+    wilderness approach. Landmarks in this corridor include Mahoosuc Notch, Gorham
+    NH, Speck Pond.'
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
+  segment: New Hampshire north to Mahoosuc
+  at_mile_start: 1996.5
+  at_mile_end: 2021.5
+  region: New Hampshire / Maine
 ---
 # Saturday, June 12, 2010 — A swamp near Pierce Pond Lean-to
 **Start Location:** Horns Pond Lean-to
@@ -5861,9 +7012,18 @@ destination: Shaw's Boarding House
 miles_today: 40.0
 trip_miles: 2061.5
 facts:
-  trail_section: Trail section from A swamp near Pierce Pond Lean-to to Shaw's Boarding
-    House.
+  trail_section: '100 Mile Wilderness (AT miles 2022–2062): Maine''s legendary 100
+    Mile Wilderness: remote lakes, ford crossings, and no resupply for over a week.
+    Root ladders, river fords, black flies in June, and profound remoteness; carry
+    enough food or you suffer. Landmarks in this corridor include Monson ME, Shaw''s
+    Boarding House, Barren-Chairlift Lean-tos.'
   confidence: low
+  sources:
+  - AT segment guide
+  segment: 100 Mile Wilderness
+  at_mile_start: 2021.5
+  at_mile_end: 2061.5
+  region: Maine
 ---
 # Sunday, June 13, 2010 — Shaw's Boarding House
 **Start Location:** A swamp near Pierce Pond Lean-to
@@ -5888,8 +7048,19 @@ destination: Shaw's Boarding House
 miles_today: 0.0
 trip_miles: 2061.5
 facts:
-  trail_section: Trail section from Shaw's Boarding House to Shaw's Boarding House.
+  trail_section: '100 Mile Wilderness (AT miles 2060–2062): Maine''s legendary 100
+    Mile Wilderness: remote lakes, ford crossings, and no resupply for over a week.
+    Root ladders, river fords, black flies in June, and profound remoteness; carry
+    enough food or you suffer. Landmarks in this corridor include Monson ME, Shaw''s
+    Boarding House, Barren-Chairlift Lean-tos.'
   confidence: low
+  sources:
+  - AT segment guide
+  - firecrawl web search
+  segment: 100 Mile Wilderness
+  at_mile_start: 2060.5
+  at_mile_end: 2061.5
+  region: Maine
 ---
 # Monday, June 14, 2010 — Shaw's Boarding House
 **Start Location:** Shaw's Boarding House
@@ -6088,10 +7259,20 @@ miles_today: 13.7
 trip_miles: 2075.2
 facts:
   weather: High 66°F, low 50°F. Clear sky.
-  trail_section: Trail section from Shaw's Boarding House to Wilson Valley Lean-to.
-  confidence: medium
+  trail_section: '100 Mile Wilderness (AT miles 2062–2075): Maine''s legendary 100
+    Mile Wilderness: remote lakes, ford crossings, and no resupply for over a week.
+    Root ladders, river fords, black flies in June, and profound remoteness; carry
+    enough food or you suffer. Landmarks in this corridor include Monson ME, Shaw''s
+    Boarding House, Barren-Chairlift Lean-tos.'
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
+  segment: 100 Mile Wilderness
+  at_mile_start: 2061.5
+  at_mile_end: 2075.2
+  region: Maine
 ---
 # Tuesday, June 15, 2010 — Wilson Valley Lean-to
 **Start Location:** Shaw's Boarding House
@@ -6290,10 +7471,20 @@ miles_today: 15.6
 trip_miles: 2090.8
 facts:
   weather: High 69°F, low 47°F. Overcast.
-  trail_section: Trail section from Wilson Valley Lean-to to Chairback Gap Lean-to.
-  confidence: medium
+  trail_section: '100 Mile Wilderness (AT miles 2075–2091): Maine''s legendary 100
+    Mile Wilderness: remote lakes, ford crossings, and no resupply for over a week.
+    Root ladders, river fords, black flies in June, and profound remoteness; carry
+    enough food or you suffer. Landmarks in this corridor include Monson ME, Shaw''s
+    Boarding House, Barren-Chairlift Lean-tos.'
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
+  segment: 100 Mile Wilderness
+  at_mile_start: 2075.2
+  at_mile_end: 2090.8
+  region: Maine
 ---
 # Wednesday, June 16, 2010 — Chairback Gap Lean-to
 **Start Location:** Wilson Valley Lean-to
@@ -6492,10 +7683,20 @@ miles_today: 29.0
 trip_miles: 2119.8
 facts:
   weather: High 67°F, low 49°F. Slight rain.
-  trail_section: Trail section from Chairback Gap Lean-to to Cooper Brook Falls Lean-to.
-  confidence: medium
+  trail_section: '100 Mile Wilderness (AT miles 2091–2120): Maine''s legendary 100
+    Mile Wilderness: remote lakes, ford crossings, and no resupply for over a week.
+    Root ladders, river fords, black flies in June, and profound remoteness; carry
+    enough food or you suffer. Landmarks in this corridor include Monson ME, Shaw''s
+    Boarding House, Barren-Chairlift Lean-tos.'
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
+  segment: 100 Mile Wilderness
+  at_mile_start: 2090.8
+  at_mile_end: 2119.8
+  region: Maine
 ---
 # Thursday, June 17, 2010 — Cooper Brook Falls Lean-to
 **Start Location:** Chairback Gap Lean-to
@@ -6694,11 +7895,20 @@ miles_today: 21.5
 trip_miles: 2141.3
 facts:
   weather: High 79°F, low 58°F. Overcast.
-  trail_section: Trail section from Cooper Brook Falls Lean-to to Wadleigh Stream
-    Lean-to.
-  confidence: medium
+  trail_section: '100 Mile Wilderness (AT miles 2120–2141): Maine''s legendary 100
+    Mile Wilderness: remote lakes, ford crossings, and no resupply for over a week.
+    Root ladders, river fords, black flies in June, and profound remoteness; carry
+    enough food or you suffer. Landmarks in this corridor include Monson ME, Shaw''s
+    Boarding House, Barren-Chairlift Lean-tos.'
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
+  segment: 100 Mile Wilderness
+  at_mile_start: 2119.8
+  at_mile_end: 2141.3
+  region: Maine
 ---
 # Friday, June 18, 2010 — Wadleigh Stream Lean-to
 **Start Location:** Cooper Brook Falls Lean-to
@@ -6897,10 +8107,20 @@ miles_today: 33.0
 trip_miles: 2174.3
 facts:
   weather: High 84°F, low 60°F. Overcast.
-  trail_section: Trail section from Wadleigh Stream Lean-to to The Birches Lean-tos.
-  confidence: medium
+  trail_section: 'Baxter State Park — Katahdin (AT miles 2141–2174): The final miles
+    in Baxter State Park climb Katahdin via the Hunt Trail — knife-edge exposure and
+    the northern terminus. Alpine boulder scramble on the Hunt Trail; weather windows
+    are short; summit fog is common in June. Landmarks in this corridor include The
+    Birches, Baxter Peak, Katahdin sign.'
+  confidence: high
   sources:
+  - AT segment guide
+  - AT location database
   - Open-Meteo archive
+  segment: Baxter State Park — Katahdin
+  at_mile_start: 2141.3
+  at_mile_end: 2174.3
+  region: Maine
 ---
 # Saturday, June 19, 2010 — The Birches Lean-tos
 **Start Location:** Wadleigh Stream Lean-to
@@ -7098,9 +8318,20 @@ destination: Baxter Peak, Mount Katahdin
 miles_today: 5.2
 trip_miles: 2179.5
 facts:
-  trail_section: Mount Katahdin (5,267 ft) in Baxter State Park, Maine, is the northern
-    terminus of the Appalachian Trail.
+  trail_section: 'Baxter State Park — Katahdin (AT miles 2174–2180): The final miles
+    in Baxter State Park climb Katahdin via the Hunt Trail — knife-edge exposure and
+    the northern terminus. Alpine boulder scramble on the Hunt Trail; weather windows
+    are short; summit fog is common in June. Landmarks in this corridor include The
+    Birches, Baxter Peak, Katahdin sign. Mount Katahdin (5,267 ft) in Baxter State
+    Park, Maine, is the northern terminus of the Appalachian Trail.'
   confidence: low
+  sources:
+  - AT segment guide
+  - firecrawl web search
+  segment: Baxter State Park — Katahdin
+  at_mile_start: 2174.3
+  at_mile_end: 2179.5
+  region: Maine
 ---
 # Sunday, June 20, 2010 — Baxter Peak, Mount Katahdin
 **Start Location:** The Birches Lean-tos
@@ -7120,9 +8351,20 @@ destination: HOME
 miles_today: 0.0
 trip_miles: 2179.5
 facts:
-  trail_section: Mount Katahdin (5,267 ft) in Baxter State Park, Maine, is the northern
-    terminus of the Appalachian Trail.
+  trail_section: 'Baxter State Park — Katahdin (AT miles 2178–2180): The final miles
+    in Baxter State Park climb Katahdin via the Hunt Trail — knife-edge exposure and
+    the northern terminus. Alpine boulder scramble on the Hunt Trail; weather windows
+    are short; summit fog is common in June. Landmarks in this corridor include The
+    Birches, Baxter Peak, Katahdin sign. Mount Katahdin (5,267 ft) in Baxter State
+    Park, Maine, is the northern terminus of the Appalachian Trail.'
   confidence: low
+  sources:
+  - AT segment guide
+  - firecrawl web search
+  segment: Baxter State Park — Katahdin
+  at_mile_start: 2178.5
+  at_mile_end: 2179.5
+  region: Maine
 ---
 # Monday, June 21, 2010 — HOME
 **Start Location:** Baxter Peak, Mount Katahdin

--- a/examples/uncle-frank/metadata.json
+++ b/examples/uncle-frank/metadata.json
@@ -1,0 +1,16 @@
+{
+  "journal_id": 10467,
+  "trail_name": "Uncle Frank",
+  "author": "Ford Prior",
+  "trail": "Appalachian Trail",
+  "direction": "northbound",
+  "year": 2010,
+  "start_date": "2010-01-21",
+  "finish_date": "2010-06-21",
+  "summit": "Baxter Peak, Mount Katahdin",
+  "source_url": "https://www.trailjournals.com/journal/10467",
+  "entry_count": 133,
+  "locations_in_database": 153,
+  "enriched_at": "2026-07-09",
+  "description": "2010 AT thru-hike journal with YAML frontmatter facts (weather, trail section, town events)."
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ mutagen
 boto3==1.34.122
 botocore==1.34.122
 pytest==8.0.2
+requests
+pyyaml

--- a/scripts/enrich_facts.py
+++ b/scripts/enrich_facts.py
@@ -51,6 +51,11 @@ def main() -> int:
         help="Enable firecrawl for town event searches on town days",
     )
     parser.add_argument(
+        "--refresh-trail",
+        action="store_true",
+        help="Recompute trail section facts only (keep weather/town cache)",
+    )
+    parser.add_argument(
         "--skip-firecrawl",
         action="store_true",
         help="Deprecated: firecrawl is off by default; use --use-firecrawl to enable",

--- a/scripts/enrich_facts.py
+++ b/scripts/enrich_facts.py
@@ -1,0 +1,88 @@
+"""CLI entry point for journal frontmatter enrichment.
+
+Usage:
+    python scripts/enrich_facts.py journal.txt \\
+        --output out.txt \\
+        --cache cache/facts \\
+        --limit 10
+"""
+import argparse
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="enrich_facts",
+        description="Enrich an AT journal with YAML frontmatter facts.",
+    )
+    parser.add_argument(
+        "input_file",
+        type=Path,
+        help="Path to the input journal text file.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Path for the enriched output file (default: <input>_facts.txt).",
+    )
+    parser.add_argument(
+        "--cache",
+        type=Path,
+        default=Path("cache/facts"),
+        help="Directory for per-entry cache (default: cache/facts).",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum number of entries to process.",
+    )
+    parser.add_argument(
+        "--start",
+        type=int,
+        default=1,
+        help="1-based entry index to start from (default: 1).",
+    )
+    parser.add_argument(
+        "--skip-firecrawl",
+        action="store_true",
+        default=True,
+        help="Skip optional firecrawl validation (default: True for pilot).",
+    )
+
+    args = parser.parse_args()
+
+    if not args.input_file.exists():
+        print(f"ERROR: Input file not found: {args.input_file}", file=sys.stderr)
+        return 1
+
+    if args.output is None:
+        args.output = args.input_file.parent / f"{args.input_file.stem}_facts.txt"
+
+    from scripts.facts.orchestrator import enrich_journal
+
+    print(f"[INFO] Input:  {args.input_file}")
+    print(f"[INFO] Output: {args.output}")
+    print(f"[INFO] Cache:  {args.cache}")
+    if args.limit:
+        print(f"[INFO] Limit:  {args.limit} entries")
+
+    try:
+        enrich_journal(
+            input_path=args.input_file,
+            output_path=args.output,
+            cache_dir=args.cache,
+            limit=args.limit,
+            start=args.start,
+        )
+    except Exception as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/enrich_facts.py
+++ b/scripts/enrich_facts.py
@@ -46,10 +46,14 @@ def main() -> int:
         help="1-based entry index to start from (default: 1).",
     )
     parser.add_argument(
+        "--use-firecrawl",
+        action="store_true",
+        help="Enable firecrawl for town event searches on town days",
+    )
+    parser.add_argument(
         "--skip-firecrawl",
         action="store_true",
-        default=True,
-        help="Skip optional firecrawl validation (default: True for pilot).",
+        help="Deprecated: firecrawl is off by default; use --use-firecrawl to enable",
     )
 
     args = parser.parse_args()
@@ -76,6 +80,7 @@ def main() -> int:
             cache_dir=args.cache,
             limit=args.limit,
             start=args.start,
+            use_firecrawl=args.use_firecrawl,
         )
     except Exception as exc:
         print(f"ERROR: {exc}", file=sys.stderr)

--- a/scripts/expand_locations.py
+++ b/scripts/expand_locations.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Add journal locations missing from at_locations.json using Nominatim geocoding."""
+from __future__ import annotations
+
+import json
+import re
+import time
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+from scripts.facts.location_resolver import lookup, normalize_name
+
+JOURNAL = Path("examples/uncle-frank/journal.txt")
+LOCATIONS = Path("data/at_locations.json")
+USER_AGENT = "trail-journal-extractor/1.0 (example journal geocoder)"
+
+
+def parse_locations(journal_text: str) -> set[str]:
+    names: set[str] = set()
+    for line in journal_text.splitlines():
+        if line.startswith("**Start Location:**"):
+            names.add(line.split(":", 1)[1].strip())
+        elif line.startswith("# "):
+            _, _, dest = line.partition(" — ")
+            if dest:
+                names.add(dest.strip())
+    return {n for n in names if n and n not in {"Unknown", "Gear List"}}
+
+
+def geocode(name: str) -> dict | None:
+    # Prefer town in parentheses
+    town_match = re.search(r"\(([^)]+)\)", name)
+    query = town_match.group(1) if town_match else name
+    query = f"{query}, Appalachian Trail"
+    url = "https://nominatim.openstreetmap.org/search?" + urllib.parse.urlencode(
+        {"q": query, "format": "json", "limit": 1}
+    )
+    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    with urllib.request.urlopen(req, timeout=20) as resp:
+        data = json.loads(resp.read().decode())
+    if not data:
+        return None
+    hit = data[0]
+    return {
+        "name": name,
+        "lat": float(hit["lat"]),
+        "lon": float(hit["lon"]),
+        "state": _guess_state(hit.get("display_name", "")),
+        "at_mile": None,
+        "is_town": bool(town_match) or any(k in name.lower() for k in ("motel", "hotel", "town")),
+    }
+
+
+def _guess_state(display_name: str) -> str:
+    parts = [p.strip() for p in display_name.split(",")]
+    for part in reversed(parts):
+        if len(part) == 2 and part.isalpha():
+            return part.upper()
+    return "US"
+
+
+def main() -> None:
+    journal_text = JOURNAL.read_text(encoding="utf-8")
+    existing = json.loads(LOCATIONS.read_text(encoding="utf-8"))
+    existing_names = {normalize_name(loc["name"]) for loc in existing}
+
+    missing = [n for n in sorted(parse_locations(journal_text)) if normalize_name(n) not in existing_names]
+    print(f"Missing locations: {len(missing)}")
+
+    added = 0
+    for name in missing:
+        try:
+            loc = geocode(name)
+            if loc:
+                existing.append(loc)
+                existing_names.add(normalize_name(name))
+                added += 1
+                print(f"  + {name} -> {loc['lat']:.4f}, {loc['lon']:.4f}")
+        except Exception as exc:
+            print(f"  ! {name}: {exc}")
+        time.sleep(1.1)  # Nominatim rate limit
+
+    LOCATIONS.write_text(json.dumps(existing, indent=2) + "\n", encoding="utf-8")
+    print(f"Added {added} locations ({len(existing)} total)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/extract_journal_firecrawl.py
+++ b/scripts/extract_journal_firecrawl.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Extract a TrailJournals.com journal using the Firecrawl CLI (Cloudflare-safe)."""
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+import tempfile
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+
+ENTRY_URL_RE = re.compile(
+    r"https://www\.trailjournals\.com/journal/entry/(\d+)"
+)
+FIELD_PATTERNS = {
+    "date": re.compile(
+        r"^(?:Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday), "
+        r"(January|February|March|April|May|June|July|August|September|October|November|December) "
+        r"\d{1,2}, \d{4}$",
+        re.MULTILINE,
+    ),
+    "destination": re.compile(r"^Destination:[ \t]*([^\n]*)", re.MULTILINE),
+    "start": re.compile(r"^Start Location:[ \t]*([^\n]*)", re.MULTILINE),
+    "miles_today": re.compile(r"^Today'?s Miles:\s*([\d.]+)", re.MULTILINE),
+    "trip_miles": re.compile(r"^Trip Miles:\s*([\d.]+)", re.MULTILINE),
+}
+
+
+def _firecrawl_scrape(url: str, output: Path) -> bool:
+    result = subprocess.run(
+        ["firecrawl", "scrape", url, "-o", str(output)],
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0 and output.exists()
+
+
+def _first_match(pattern: re.Pattern[str], text: str, group: int = 0) -> str | None:
+    match = pattern.search(text)
+    return match.group(group).strip() if match else None
+
+
+def _parse_date(text: str) -> str | None:
+    full = _first_match(FIELD_PATTERNS["date"], text, group=0)
+    if full:
+        return full
+    # Breadcrumb fallback: "7. February 07, 2010"
+    crumb = re.search(
+        r"\d+\.\s+((?:January|February|March|April|May|June|July|August|September|"
+        r"October|November|December)\s+\d{1,2},\s+\d{4})",
+        text,
+    )
+    if crumb:
+        return crumb.group(1).strip()
+    return None
+
+
+def _extract_body(text: str, trip_miles_line: str | None) -> str:
+    """Pull journal prose from scraped markdown."""
+    if not trip_miles_line:
+        return text.strip()
+
+    idx = text.find(trip_miles_line)
+    if idx == -1:
+        return text.strip()
+
+    after = text[idx + len(trip_miles_line) :]
+    # Drop duplicate metadata block that TrailJournals repeats
+    lines = after.splitlines()
+    body_lines: list[str] = []
+    started = False
+    for line in lines:
+        stripped = line.strip()
+        if not started:
+            if stripped.startswith("Destination:") or stripped.startswith("Start Location:"):
+                continue
+            if stripped.startswith("Today's Miles:") or stripped.startswith("Trip Miles:"):
+                continue
+            if not stripped:
+                continue
+            if stripped.startswith("[First]") or stripped.startswith("### Hiker Entries"):
+                break
+            started = True
+        if stripped.startswith("[First]") or stripped.startswith("### Hiker Entries"):
+            break
+        body_lines.append(line)
+
+    body = "\n".join(body_lines).strip()
+    return body or text.strip()
+
+
+def parse_entry_markdown(text: str) -> dict:
+    date = _parse_date(text)
+    destination = _first_match(FIELD_PATTERNS["destination"], text, group=1) or ""
+    if not destination or destination.lower() in {"view entry", "n/a"}:
+        # Title line fallback: "# Uncle Frank's 2010 Appalachian Trail Journal" skipped;
+        # use table link text or generic planning label for zero-mile pre-hike posts
+        if _first_match(FIELD_PATTERNS["miles_today"], text, group=1) == "0" and not destination:
+            destination = "Pre-Hike Planning"
+        else:
+            destination = destination or "Trail Journal Entry"
+    start = _first_match(FIELD_PATTERNS["start"], text, group=1) or "Unknown"
+    miles_today = _first_match(FIELD_PATTERNS["miles_today"], text, group=1) or "0"
+    trip_miles = _first_match(FIELD_PATTERNS["trip_miles"], text, group=1) or "0"
+
+    trip_line = None
+    for line in text.splitlines():
+        if line.strip().startswith("Trip Miles:"):
+            trip_line = line.strip()
+            break
+
+    body = _extract_body(text, trip_line)
+    return {
+        "date": date or "Unknown Date",
+        "destination": destination,
+        "start_location": start,
+        "miles_today": miles_today,
+        "trip_miles": trip_miles,
+        "body": body,
+    }
+
+
+def format_entry(entry: dict) -> str:
+    return (
+        f"# {entry['date']} — {entry['destination']}\n"
+        f"**Start Location:** {entry['start_location']}\n"
+        f"**Miles Today:** {entry['miles_today']}\n"
+        f"**Trip Miles:** {entry['trip_miles']}\n\n"
+        f"{entry['body']}\n"
+    )
+
+
+TABLE_ENTRY_RE = re.compile(
+    r"\| \[[^\]]*\]\(https://www\.trailjournals\.com/journal/entry/(\d+)\) \| "
+    r"(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) "
+)
+
+
+def fetch_entry_urls(journal_id: str, scratch: Path) -> list[str]:
+    index_url = f"https://www.trailjournals.com/journal/entries/{journal_id}"
+    index_file = scratch / "entries_index.md"
+    if not _firecrawl_scrape(index_url, index_file):
+        raise RuntimeError(f"Failed to scrape journal index: {index_url}")
+
+    text = index_file.read_text(encoding="utf-8")
+    ids = list(dict.fromkeys(TABLE_ENTRY_RE.findall(text)))
+    if not ids:
+        # Fallback: any entry links on the page
+        ids = list(dict.fromkeys(ENTRY_URL_RE.findall(text)))
+    return [f"https://www.trailjournals.com/journal/entry/{eid}" for eid in ids]
+
+
+def scrape_entry(url: str, scratch: Path) -> tuple[str, dict | None]:
+    entry_id = url.rstrip("/").split("/")[-1]
+    out = scratch / f"entry_{entry_id}.md"
+    if not _firecrawl_scrape(url, out):
+        return url, None
+    try:
+        parsed = parse_entry_markdown(out.read_text(encoding="utf-8"))
+        return url, parsed
+    except Exception:
+        return url, None
+
+
+def build_journal(
+    journal_id: str,
+    output_file: Path,
+    workers: int = 8,
+    limit: int | None = None,
+) -> int:
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="tj_extract_") as tmp:
+        scratch = Path(tmp)
+        urls = fetch_entry_urls(journal_id, scratch)
+        if limit:
+            urls = urls[:limit]
+
+        print(f"Found {len(urls)} entries. Scraping with {workers} workers...")
+        results: list[tuple[str, dict | None]] = []
+
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            futures = {pool.submit(scrape_entry, url, scratch): url for url in urls}
+            for i, future in enumerate(as_completed(futures), 1):
+                url, entry = future.result()
+                status = "ok" if entry else "FAIL"
+                print(f"[{i}/{len(urls)}] {status} {url}")
+                results.append((url, entry))
+
+        # Preserve index page order
+        url_order = {url: idx for idx, url in enumerate(urls)}
+        results.sort(key=lambda pair: url_order[pair[0]])
+
+        entries: list[str] = []
+        for url, entry in results:
+            if entry:
+                entries.append(format_entry(entry))
+            else:
+                print(f"WARNING: skipped {url}", file=sys.stderr)
+
+        output_file.write_text("\n---\n\n".join(entries) + ("\n" if entries else ""), encoding="utf-8")
+        print(f"Wrote {len(entries)} entries to {output_file}")
+        return len(entries)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Extract TrailJournals journal via Firecrawl")
+    parser.add_argument("journal_id", help="TrailJournals journal ID (e.g. 10467)")
+    parser.add_argument("-o", "--output", type=Path, required=True, help="Output journal text file")
+    parser.add_argument("--workers", type=int, default=8, help="Parallel scrape workers")
+    parser.add_argument("--limit", type=int, default=None, help="Limit number of entries")
+    args = parser.parse_args()
+
+    try:
+        count = build_journal(args.journal_id, args.output, workers=args.workers, limit=args.limit)
+    except Exception as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    return 0 if count else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/facts/__init__.py
+++ b/scripts/facts/__init__.py
@@ -1,0 +1,1 @@
+# facts package: models, location resolution, and weather fetching

--- a/scripts/facts/cache.py
+++ b/scripts/facts/cache.py
@@ -1,0 +1,90 @@
+"""File-based per-entry cache for the facts pipeline.
+
+Directory layout:
+    <cache_dir>/<entry_key>/
+        draft.json
+        validation.json
+        weather.json
+        town_events.json
+        frontmatter.yaml
+
+Pass names: "draft", "validation", "weather", "town_events", "frontmatter"
+"""
+import dataclasses
+import json
+import re
+from pathlib import Path
+from typing import Optional
+
+
+_PASS_FILES = {
+    "draft": "draft.json",
+    "validation": "validation.json",
+    "weather": "weather.json",
+    "town_events": "town_events.json",
+    "frontmatter": "frontmatter.yaml",
+}
+
+_REQUIRED_PASSES = list(_PASS_FILES.keys())
+
+
+def _safe_key(entry_key: str) -> str:
+    """Sanitise an entry key for use as a directory name."""
+    return re.sub(r"[^\w\-]", "_", entry_key)[:128]
+
+
+def _serialise(data) -> str:
+    """Convert a dataclass or dict to JSON string."""
+    if dataclasses.is_dataclass(data) and not isinstance(data, type):
+        return json.dumps(dataclasses.asdict(data), indent=2, ensure_ascii=False)
+    if isinstance(data, dict):
+        return json.dumps(data, indent=2, ensure_ascii=False)
+    return str(data)
+
+
+class EntryCache:
+    """Cache for a single journal entry's pipeline passes."""
+
+    def __init__(self, cache_dir: Path, entry_key: str):
+        self.entry_dir = Path(cache_dir) / _safe_key(entry_key)
+        self.entry_dir.mkdir(parents=True, exist_ok=True)
+
+    def _path(self, pass_name: str) -> Path:
+        filename = _PASS_FILES.get(pass_name, f"{pass_name}.json")
+        return self.entry_dir / filename
+
+    def load_pass(self, pass_name: str) -> Optional[dict]:
+        """Load a cached pass.  Returns a dict (or {"frontmatter": str}) or None."""
+        path = self._path(pass_name)
+        if not path.exists():
+            return None
+        try:
+            text = path.read_text(encoding="utf-8")
+            if pass_name == "frontmatter":
+                return {"frontmatter": text}
+            return json.loads(text)
+        except (json.JSONDecodeError, OSError):
+            return None
+
+    def save_pass(self, pass_name: str, data) -> None:
+        """Persist a pass result.
+
+        Accepts dataclass instances, dicts, or plain strings (for frontmatter).
+        """
+        path = self._path(pass_name)
+        if pass_name == "frontmatter":
+            if isinstance(data, dict):
+                text = data.get("frontmatter", "")
+            else:
+                text = str(data)
+            path.write_text(text, encoding="utf-8")
+        else:
+            path.write_text(_serialise(data), encoding="utf-8")
+
+    def is_complete(self) -> bool:
+        """Return True when every required pass file exists on disk."""
+        return all(self._path(p).exists() for p in _REQUIRED_PASSES)
+
+    def completed_passes(self) -> list:
+        """Return list of pass names that have been written."""
+        return [p for p in _REQUIRED_PASSES if self._path(p).exists()]

--- a/scripts/facts/compiler.py
+++ b/scripts/facts/compiler.py
@@ -110,6 +110,8 @@ def compile_facts(
             at_mile_end=draft.at_mile_end,
             state=draft.state,
             nearest_town=draft.nearest_town,
+            segment_name=draft.segment_name,
+            region=draft.region,
         )
     elif validation.verified:
         # Reconstruct minimal DraftFacts from verified claims alone

--- a/scripts/facts/compiler.py
+++ b/scripts/facts/compiler.py
@@ -1,0 +1,133 @@
+"""Deterministic facts compiler.
+
+Assembles validated claims, weather data, and town events into CompiledFacts.
+No LLM or external service calls are made here.
+
+Confidence scale (float 0–1):
+  high   ≥ 0.8 : 2+ verified claims AND weather present
+  medium ≈ 0.5 : weather present but fewer than 2 verified claims
+  low    ≈ 0.2 : neither condition met
+"""
+from typing import Optional
+
+from scripts.facts.models import (
+    CompiledFacts,
+    DraftFacts,
+    TownEventsResult,
+    ValidationResult,
+    WeatherFacts,
+)
+
+_CONFIDENCE_HIGH = 0.9
+_CONFIDENCE_MEDIUM = 0.5
+_CONFIDENCE_LOW = 0.2
+
+
+def format_weather_str(weather: Optional[WeatherFacts]) -> str:
+    """Format a WeatherFacts object into the canonical display string."""
+    if not weather:
+        return ""
+    if weather.high_f is None and weather.low_f is None:
+        return ""
+
+    parts: list = []
+    if weather.high_f is not None and weather.low_f is not None:
+        parts.append(f"High {weather.high_f:.0f}°F, low {weather.low_f:.0f}°F.")
+    elif weather.high_f is not None:
+        parts.append(f"High {weather.high_f:.0f}°F.")
+    elif weather.low_f is not None:
+        parts.append(f"Low {weather.low_f:.0f}°F.")
+
+    if weather.conditions:
+        cond = weather.conditions.rstrip(".")
+        parts.append(f"{cond}.")
+
+    return " ".join(parts)
+
+
+def _collect_sources(
+    validation: ValidationResult,
+    weather: Optional[WeatherFacts],
+    town_events: Optional[TownEventsResult],
+) -> list:
+    sources: list = []
+    seen: set = set()
+
+    for vc in validation.verified:
+        s = vc.source
+        if s and s not in seen:
+            sources.append(s)
+            seen.add(s)
+
+    if weather and weather.source and weather.source not in seen:
+        sources.append(weather.source)
+        seen.add(weather.source)
+
+    if town_events and town_events.source and town_events.source not in seen:
+        sources.append(town_events.source)
+        seen.add(town_events.source)
+
+    return sources
+
+
+def compile_facts(
+    validation: ValidationResult,
+    weather: Optional[WeatherFacts],
+    town_events: Optional[TownEventsResult],
+    metadata,
+    draft: Optional[DraftFacts] = None,
+) -> CompiledFacts:
+    """Assemble a CompiledFacts object from pipeline outputs.
+
+    Args:
+        validation:   result from validate_agent.validate_claims
+        weather:      result from weather_agent.fetch_weather (may be None)
+        town_events:  result from town_events_agent.fetch_town_events
+        metadata:     dict or EntryMetadata with entry fields
+        draft:        original DraftFacts (used to populate CompiledFacts.trail_section)
+    """
+    verified_count = len(validation.verified)
+    has_weather = weather is not None and (
+        weather.high_f is not None or weather.low_f is not None
+    )
+
+    if verified_count >= 2 and has_weather:
+        confidence = _CONFIDENCE_HIGH
+    elif has_weather:
+        confidence = _CONFIDENCE_MEDIUM
+    else:
+        confidence = _CONFIDENCE_LOW
+
+    # Build filtered DraftFacts from verified claims when draft is available
+    trail_section: Optional[DraftFacts] = None
+    if draft is not None:
+        verified_claim_texts = {vc.claim.text for vc in validation.verified}
+        filtered_claims = [c for c in draft.claims if c.text in verified_claim_texts]
+        trail_section = DraftFacts(
+            trail_section_summary=draft.trail_section_summary,
+            claims=filtered_claims,
+            at_mile_start=draft.at_mile_start,
+            at_mile_end=draft.at_mile_end,
+            state=draft.state,
+            nearest_town=draft.nearest_town,
+        )
+    elif validation.verified:
+        # Reconstruct minimal DraftFacts from verified claims alone
+        trail_section = DraftFacts(
+            trail_section_summary=" ".join(vc.claim.text for vc in validation.verified),
+            claims=[vc.claim for vc in validation.verified],
+            at_mile_start=None,
+            at_mile_end=None,
+            state=None,
+            nearest_town=None,
+        )
+
+    sources = _collect_sources(validation, weather, town_events)
+
+    return CompiledFacts(
+        weather=weather if has_weather else None,
+        trail_section=trail_section,
+        town_events=town_events,
+        confidence=confidence,
+        sources=sources,
+    )

--- a/scripts/facts/draft_agent.py
+++ b/scripts/facts/draft_agent.py
@@ -1,0 +1,366 @@
+"""Rule-based draft facts generator for AT journal entries.
+
+Produces DraftFacts from entry metadata using a static AT location knowledge base.
+No external services or AWS required—safe to run in pilot mode.
+"""
+from typing import Optional
+
+from scripts.facts.models import Claim, DraftFacts
+
+
+def _get_attr(obj, attr: str, default=""):
+    """Retrieve a field from either a dataclass/object or a plain dict."""
+    if isinstance(obj, dict):
+        return obj.get(attr, default)
+    return getattr(obj, attr, default)
+
+
+# ---------------------------------------------------------------------------
+# Static knowledge base
+# ---------------------------------------------------------------------------
+
+# Each entry: normalized substring to match → dict with:
+#   state, at_mile, nearest_town (optional), claims, summary
+_LOCATION_KNOWLEDGE = [
+    {
+        "keys": ["springer mountain"],
+        "state": "Georgia",
+        "at_mile": 0.0,
+        "summary": "Springer Mountain (3,782 ft) is the southern terminus of the 2,190-mile Appalachian Trail.",
+        "claims": [
+            Claim("landmark", "Springer Mountain is the official southern terminus of the Appalachian Trail at 3,782 feet."),
+            Claim("landmark", "A bronze plaque and a register box mark the AT's starting point at Springer Mountain's summit."),
+            Claim("terrain", "Most northbound thru-hikers begin their journey at Springer Mountain in late winter or early spring."),
+        ],
+    },
+    {
+        "keys": ["amicalola falls"],
+        "state": "Georgia",
+        "at_mile": None,
+        "summary": "Amicalola Falls State Park is the traditional gateway to Springer Mountain for northbound thru-hikers.",
+        "claims": [
+            Claim("landmark", "Amicalola Falls State Park is the traditional starting gateway for northbound AT thru-hikers."),
+            Claim("terrain", "The 8.5-mile Approach Trail from Amicalola Falls gains substantial elevation to reach Springer Mountain."),
+            Claim("landmark", "Amicalola Falls at 729 feet is one of the tallest cascading waterfalls in the eastern United States."),
+        ],
+    },
+    {
+        "keys": ["hike inn", "the hike inn"],
+        "state": "Georgia",
+        "at_mile": None,
+        "summary": "The Hike Inn is a backcountry eco-lodge accessible only by a 5-mile trail near Amicalola Falls.",
+        "claims": [
+            Claim("landmark", "The Hike Inn is a backcountry eco-lodge accessible only on foot via a 5-mile trail near Amicalola Falls."),
+            Claim("terrain", "The Hike Inn sits within sight of the AT approach corridor through classic Blue Ridge hardwood forest."),
+        ],
+    },
+    {
+        "keys": ["stover creek shelter", "stover creek"],
+        "state": "Georgia",
+        "at_mile": 2.6,
+        "summary": "Stover Creek Shelter (AT mile ~2.6) is one of the first shelter stops north of Springer Mountain.",
+        "claims": [
+            Claim("landmark", "Stover Creek Shelter at roughly AT mile 2.6 is among the first overnight shelters north of Springer Mountain."),
+            Claim("terrain", "The Stover Creek area features a stream crossing and dense mixed forest typical of the Georgia Blue Ridge."),
+        ],
+    },
+    {
+        "keys": ["hawk mountain shelter", "hawk mountain"],
+        "state": "Georgia",
+        "at_mile": 8.1,
+        "summary": "Hawk Mountain Shelter (AT mile ~8) is an early overnight stop in Georgia's Blue Ridge.",
+        "claims": [
+            Claim("landmark", "Hawk Mountain Shelter sits at roughly AT mile 8 from Springer Mountain in the Georgia Blue Ridge."),
+            Claim("terrain", "The trail between Springer Mountain and Hawk Mountain traverses rocky ridgeline sections through hardwood forest."),
+        ],
+    },
+    {
+        "keys": ["gooch mountain shelter", "gooch mountain"],
+        "state": "Georgia",
+        "at_mile": 15.8,
+        "summary": "Gooch Mountain Shelter (AT mile ~16) is a popular early multi-day destination for northbound hikers.",
+        "claims": [
+            Claim("landmark", "Gooch Mountain Shelter near AT mile 16 is a popular first multi-night destination for northbound thru-hikers."),
+            Claim("terrain", "The trail from Hawk Mountain to Gooch Mountain crosses Justus Creek and climbs through mixed hardwood forest."),
+            Claim("terrain", "The Gooch Mountain area receives heavy hiker traffic in early spring during thru-hiking season."),
+        ],
+    },
+    {
+        "keys": ["woody gap"],
+        "state": "Georgia",
+        "at_mile": 20.9,
+        "summary": "Woody Gap (GA-60, AT mile ~21) is the first major road crossing northbound in Georgia.",
+        "claims": [
+            Claim("landmark", "Woody Gap at GA-60 provides a road crossing with a small picnic area and is a popular day-hiker trailhead."),
+        ],
+    },
+    {
+        "keys": ["blood mountain shelter", "blood mountain"],
+        "state": "Georgia",
+        "at_mile": 31.7,
+        "summary": "Blood Mountain (4,458 ft) is the highest peak in Georgia on the AT, with a 1930s stone shelter.",
+        "claims": [
+            Claim("landmark", "Blood Mountain at 4,458 feet is the highest point on the Appalachian Trail in Georgia."),
+            Claim("landmark", "The stone Blood Mountain Shelter dates to the 1930s CCC era and offers panoramic views from the summit."),
+            Claim("history", "Blood Mountain takes its name from a Cherokee legend of a great battle fought on its slopes."),
+        ],
+    },
+    {
+        "keys": ["neels gap", "mountain crossings", "walasi-yi"],
+        "state": "Georgia",
+        "at_mile": 31.7,
+        "nearest_town": "Blairsville, GA",
+        "summary": "Neels Gap is the only point where the AT passes through a building — Mountain Crossings outfitter at Walasi-Yi.",
+        "claims": [
+            Claim("landmark", "Neels Gap at US-129 is unique as the only point where the Appalachian Trail passes through a building."),
+            Claim("landmark", "Mountain Crossings at Walasi-Yi is a legendary AT outfitter where many hikers cull pack weight."),
+        ],
+    },
+    {
+        "keys": ["unicoi gap"],
+        "state": "Georgia",
+        "at_mile": 45.2,
+        "nearest_town": "Helen, GA",
+        "summary": "Unicoi Gap (GA-75) provides access to Helen, GA, a quirky Bavarian-themed mountain town.",
+        "claims": [
+            Claim("landmark", "Unicoi Gap at GA-75 is the nearest AT trailhead to Helen, Georgia's Bavarian-themed mountain town."),
+        ],
+    },
+    {
+        "keys": ["tray mountain"],
+        "state": "Georgia",
+        "at_mile": 56.7,
+        "summary": "Tray Mountain (4,430 ft) is the second-highest peak in Georgia on the AT.",
+        "claims": [
+            Claim("terrain", "Tray Mountain at 4,430 feet is the second-highest peak on the AT in Georgia with open rocky summit views."),
+        ],
+    },
+    {
+        "keys": ["bly gap"],
+        "state": "Georgia",
+        "at_mile": 78.2,
+        "summary": "Bly Gap marks the Georgia-North Carolina state line, the first state border northbound hikers cross.",
+        "claims": [
+            Claim("landmark", "Bly Gap marks the Georgia-North Carolina state line—the first state crossing celebrated by northbound thru-hikers."),
+        ],
+    },
+    {
+        "keys": ["standing indian"],
+        "state": "North Carolina",
+        "at_mile": 88.1,
+        "summary": "Standing Indian Mountain (5,498 ft) is the highest peak south of the Smokies on the AT.",
+        "claims": [
+            Claim("landmark", "Standing Indian Mountain at 5,498 feet is the highest peak south of the Great Smokies on the AT."),
+            Claim("terrain", "The Standing Indian area is known for its high balds and sweeping views of the southern Appalachians."),
+        ],
+    },
+    {
+        "keys": ["franklin"],
+        "state": "North Carolina",
+        "nearest_town": "Franklin, NC",
+        "summary": "Franklin, NC is the first major trail town in North Carolina, offering full resupply and services.",
+        "claims": [
+            Claim("landmark", "Franklin, NC is a major trail town accessible from the AT via US-64, offering full resupply and hiker services."),
+        ],
+    },
+    {
+        "keys": ["wayah bald"],
+        "state": "North Carolina",
+        "at_mile": 109.6,
+        "summary": "Wayah Bald (5,342 ft) features a restored 1930s stone fire tower with 360-degree views.",
+        "claims": [
+            Claim("landmark", "Wayah Bald at 5,342 feet features a restored 1930s stone fire tower with 360-degree mountain views."),
+            Claim("terrain", "The open grassy bald atop Wayah offers clear-day views stretching to the Great Smoky Mountains."),
+        ],
+    },
+    {
+        "keys": ["nantahala outdoor center", "nantahala", "noc"],
+        "state": "North Carolina",
+        "at_mile": 135.8,
+        "nearest_town": "Bryson City, NC",
+        "summary": "The Nantahala Outdoor Center (NOC) at the Nantahala River gorge offers food, lodging, and gear.",
+        "claims": [
+            Claim("landmark", "The Nantahala Outdoor Center sits at the Nantahala River gorge and is a major AT resupply landmark."),
+            Claim("terrain", "The climb out of the NOC is famously steep—over 3,000 feet to Swim Bald, one of the hardest single climbs in the South."),
+        ],
+    },
+    {
+        "keys": ["fontana dam", "fontana hilton"],
+        "state": "North Carolina",
+        "at_mile": 161.9,
+        "summary": "Fontana Dam (480 ft tall) is crossed by the AT entering Great Smoky Mountains National Park.",
+        "claims": [
+            Claim("landmark", "Fontana Dam at 480 feet is the tallest dam east of the Mississippi River; the AT crosses it entering GSMNP."),
+            Claim("landmark", "Fontana Dam Shelter is nicknamed the 'Fontana Hilton' for its spacious shower and laundry facilities."),
+        ],
+    },
+    {
+        "keys": ["clingmans dome", "clingman's dome"],
+        "state": "Tennessee",
+        "at_mile": 197.5,
+        "summary": "Clingmans Dome (6,643 ft) is the highest point on the entire Appalachian Trail.",
+        "claims": [
+            Claim("landmark", "Clingmans Dome at 6,643 feet is the highest point on the entire Appalachian Trail."),
+            Claim("landmark", "A concrete observation tower atop Clingmans Dome offers iconic views over Great Smoky Mountains NP."),
+        ],
+    },
+    {
+        "keys": ["davenport gap"],
+        "state": "Tennessee",
+        "at_mile": 231.5,
+        "summary": "Davenport Gap marks the northern exit from Great Smoky Mountains National Park.",
+        "claims": [
+            Claim("landmark", "Davenport Gap at TN-32/NC-284 marks the northern exit from Great Smoky Mountains National Park."),
+        ],
+    },
+    {
+        "keys": ["hot springs"],
+        "state": "North Carolina",
+        "at_mile": 273.2,
+        "nearest_town": "Hot Springs, NC",
+        "summary": "Hot Springs, NC is a beloved trail town where the AT runs through Main Street past natural hot springs.",
+        "claims": [
+            Claim("landmark", "Hot Springs, NC is one of the few towns where the Appalachian Trail passes directly through Main Street."),
+            Claim("landmark", "The natural hot spring spas in Hot Springs are a beloved thru-hiker destination for soaking tired muscles."),
+        ],
+    },
+    {
+        "keys": ["roan mountain", "roan highlands"],
+        "state": "Tennessee",
+        "at_mile": 373.0,
+        "summary": "Roan Mountain's high balds above 6,000 feet feature some of the most spectacular ridge walking on the AT.",
+        "claims": [
+            Claim("terrain", "Roan Mountain's high balds above 6,000 feet offer some of the most dramatic open ridge walking on the AT."),
+            Claim("terrain", "The Roan Highlands are famous for June rhododendron blooms and sweeping Appalachian views year-round."),
+        ],
+    },
+    {
+        "keys": ["damascus"],
+        "state": "Virginia",
+        "at_mile": 469.6,
+        "nearest_town": "Damascus, VA",
+        "summary": "Damascus, VA — 'Trail Town USA' — hosts Trail Days each May and is a beloved thru-hiker milestone.",
+        "claims": [
+            Claim("landmark", "Damascus, VA is known as 'Trail Town USA'; the AT runs directly through the center of town."),
+            Claim("landmark", "Damascus hosts Trail Days each May, the largest annual gathering of Appalachian Trail hikers."),
+        ],
+    },
+    {
+        "keys": ["mcafee knob"],
+        "state": "Virginia",
+        "at_mile": 714.2,
+        "summary": "McAfee Knob's overhanging rock ledge is the most photographed spot on the Appalachian Trail.",
+        "claims": [
+            Claim("landmark", "McAfee Knob's overhanging rock ledge is the single most photographed location on the entire AT."),
+            Claim("terrain", "The view from McAfee Knob extends across the Catawba Valley and surrounding Virginia ridgelines."),
+        ],
+    },
+    {
+        "keys": ["harpers ferry"],
+        "state": "West Virginia",
+        "at_mile": 1023.2,
+        "nearest_town": "Harpers Ferry, WV",
+        "summary": "Harpers Ferry is the psychological midpoint of the AT and home to the Appalachian Trail Conservancy headquarters.",
+        "claims": [
+            Claim("landmark", "Harpers Ferry, WV is the psychological midpoint of the AT and headquarters of the Appalachian Trail Conservancy."),
+            Claim("history", "Harpers Ferry's historic downtown is the site of John Brown's 1859 raid on the federal arsenal."),
+        ],
+    },
+    {
+        "keys": ["katahdin", "baxter peak"],
+        "state": "Maine",
+        "at_mile": 2190.0,
+        "summary": "Mount Katahdin (5,267 ft) in Baxter State Park, Maine, is the northern terminus of the Appalachian Trail.",
+        "claims": [
+            Claim("landmark", "Mount Katahdin at 5,267 feet in Baxter State Park is the northern terminus of the Appalachian Trail."),
+            Claim("landmark", "The summit sign at Baxter Peak on Katahdin marks the end—or beginning—of the 2,190-mile AT."),
+        ],
+    },
+]
+
+# General terrain facts by state (appended when a state match is found)
+_STATE_TERRAIN: dict = {
+    "Georgia": [
+        Claim("terrain", "The Georgia AT traverses the southern Blue Ridge Mountains, crossing several 4,000-foot summits in ~76 miles."),
+        Claim("terrain", "Georgia's AT features rocky ridgelines alternating with dense hardwood forest typical of the southern Appalachians."),
+    ],
+    "North Carolina": [
+        Claim("terrain", "The North Carolina AT includes some of the highest peaks east of the Mississippi outside the Rockies."),
+    ],
+    "Tennessee": [
+        Claim("terrain", "The Tennessee AT passes through Great Smoky Mountains National Park, the most visited national park in the US."),
+    ],
+    "Virginia": [
+        Claim("terrain", "Virginia contains more AT miles than any other state—over 550—through the Blue Ridge and Allegheny Mountains."),
+    ],
+}
+
+
+def _match_location(normalized: str):
+    """Return the first knowledge entry whose any key is a substring match."""
+    for entry in _LOCATION_KNOWLEDGE:
+        for key in entry["keys"]:
+            if key in normalized or normalized in key:
+                return entry
+    return None
+
+
+def draft_section_facts(metadata) -> DraftFacts:
+    """Generate rule-based draft facts for an AT journal entry.
+
+    Works entirely from the static knowledge base; no network calls required.
+    """
+    from scripts.facts.location_resolver import normalize_name
+
+    start = _get_attr(metadata, "start_location", "")
+    dest = _get_attr(metadata, "destination", "")
+
+    start_norm = normalize_name(start) if start else ""
+    dest_norm = normalize_name(dest) if dest else ""
+
+    collected_claims: list = []
+    summaries: list = []
+    at_mile_start: Optional[float] = None
+    at_mile_end: Optional[float] = None
+    state: Optional[str] = None
+    nearest_town: Optional[str] = None
+
+    for norm, is_start in [(start_norm, True), (dest_norm, False)]:
+        entry = _match_location(norm)
+        if entry:
+            collected_claims.extend(entry.get("claims", []))
+            summaries.append(entry.get("summary", ""))
+            if entry.get("state"):
+                state = entry["state"]
+            if entry.get("nearest_town"):
+                nearest_town = entry["nearest_town"]
+            if entry.get("at_mile") is not None:
+                if is_start:
+                    at_mile_start = entry["at_mile"]
+                else:
+                    at_mile_end = entry["at_mile"]
+
+    # Add state terrain context when identified
+    if state and state in _STATE_TERRAIN:
+        collected_claims.extend(_STATE_TERRAIN[state])
+
+    # Deduplicate claims by text
+    seen: set = set()
+    unique_claims: list = []
+    for claim in collected_claims:
+        if claim.text not in seen:
+            seen.add(claim.text)
+            unique_claims.append(claim)
+
+    summary = " ".join(s for s in summaries if s)
+    if not summary:
+        summary = f"Trail section from {start} to {dest}." if start and dest else ""
+
+    return DraftFacts(
+        trail_section_summary=summary,
+        claims=unique_claims,
+        at_mile_start=at_mile_start,
+        at_mile_end=at_mile_end,
+        state=state,
+        nearest_town=nearest_town,
+    )

--- a/scripts/facts/draft_agent.py
+++ b/scripts/facts/draft_agent.py
@@ -308,12 +308,15 @@ def _match_location(normalized: str):
 def draft_section_facts(metadata) -> DraftFacts:
     """Generate rule-based draft facts for an AT journal entry.
 
-    Works entirely from the static knowledge base; no network calls required.
+    Combines endpoint landmark knowledge with mile-range segment guides.
     """
     from scripts.facts.location_resolver import normalize_name
+    from scripts.facts.segment_guide import build_segment_description
 
     start = _get_attr(metadata, "start_location", "")
     dest = _get_attr(metadata, "destination", "")
+    miles_hiked = float(_get_attr(metadata, "miles_hiked") or 0)
+    trip_miles = float(_get_attr(metadata, "total_miles") or 0)
 
     start_norm = normalize_name(start) if start else ""
     dest_norm = normalize_name(dest) if dest else ""
@@ -324,6 +327,8 @@ def draft_section_facts(metadata) -> DraftFacts:
     at_mile_end: Optional[float] = None
     state: Optional[str] = None
     nearest_town: Optional[str] = None
+    segment_name: Optional[str] = None
+    region: Optional[str] = None
 
     for norm, is_start in [(start_norm, True), (dest_norm, False)]:
         entry = _match_location(norm)
@@ -339,6 +344,23 @@ def draft_section_facts(metadata) -> DraftFacts:
                     at_mile_start = entry["at_mile"]
                 else:
                     at_mile_end = entry["at_mile"]
+
+    # Mile-range segment guide (primary narrative for the day's hike)
+    seg_summary, seg_claims, seg_meta = build_segment_description(
+        start, dest, miles_hiked, trip_miles
+    )
+    if seg_summary:
+        summaries.insert(0, seg_summary)
+        collected_claims = seg_claims + collected_claims
+    if seg_meta:
+        segment_name = seg_meta.get("segment_name") or segment_name
+        region = seg_meta.get("region") or region
+        if seg_meta.get("at_mile_start") is not None:
+            at_mile_start = seg_meta["at_mile_start"]
+        if seg_meta.get("at_mile_end") is not None:
+            at_mile_end = seg_meta["at_mile_end"]
+        if region and not state:
+            state = region.split("/")[0].strip() if "/" in region else region
 
     # Add state terrain context when identified
     if state and state in _STATE_TERRAIN:
@@ -363,4 +385,6 @@ def draft_section_facts(metadata) -> DraftFacts:
         at_mile_end=at_mile_end,
         state=state,
         nearest_town=nearest_town,
+        segment_name=segment_name,
+        region=region,
     )

--- a/scripts/facts/frontmatter.py
+++ b/scripts/facts/frontmatter.py
@@ -97,20 +97,57 @@ def _frontmatter_data_to_dict(fm: FrontmatterData) -> dict:
     return result
 
 
+def _confidence_label(score: float) -> str:
+    if score >= 0.8:
+        return "high"
+    if score >= 0.5:
+        return "medium"
+    return "low"
+
+
+def _trail_section_text(compiled: CompiledFacts) -> Optional[str]:
+    ts = compiled.trail_section
+    if not ts:
+        return None
+    if ts.claims:
+        return " ".join(c.text for c in ts.claims)
+    return ts.trail_section_summary or None
+
+
 def build_frontmatter(metadata, compiled: CompiledFacts) -> str:
     """Return a YAML frontmatter block (including --- delimiters) for an entry."""
     import yaml
 
-    fm_data = _to_frontmatter_data(metadata, compiled)
-    data_dict = _frontmatter_data_to_dict(fm_data)
+    date = _get_attr(metadata, "date") or ""
+    start_location = _get_attr(metadata, "start_location") or ""
+    destination = _get_attr(metadata, "destination") or ""
+    miles_hiked = float(_get_attr(metadata, "miles_hiked") or 0.0)
+    total_miles = float(_get_attr(metadata, "total_miles") or 0.0)
 
-    # Also include the formatted weather string for human readability
-    weather_str = format_weather_str(compiled.weather)
-    if weather_str:
-        data_dict["weather_summary"] = weather_str
+    weather_summary = format_weather_str(compiled.weather) or None
+    trail_section = _trail_section_text(compiled)
+    town_events = None
+    if compiled.town_events and compiled.town_events.event:
+        town_events = compiled.town_events.event
 
-    # Include confidence score
-    data_dict["facts_confidence"] = round(compiled.confidence, 2)
+    data_dict = {
+        "date": date,
+        "start": start_location,
+        "destination": destination,
+        "miles_today": miles_hiked,
+        "trip_miles": total_miles,
+        "facts": {
+            "weather": weather_summary,
+            "trail_section": trail_section,
+            "town_events": town_events,
+            "confidence": _confidence_label(compiled.confidence),
+            "sources": compiled.sources or None,
+        },
+    }
+
+    # Drop empty facts keys
+    facts = data_dict["facts"]
+    data_dict["facts"] = {k: v for k, v in facts.items() if v is not None}
 
     yaml_str = yaml.safe_dump(
         data_dict,

--- a/scripts/facts/frontmatter.py
+++ b/scripts/facts/frontmatter.py
@@ -1,0 +1,149 @@
+"""YAML frontmatter builder and injector for journal entries.
+
+Produces Hugo/Jekyll-compatible YAML frontmatter from CompiledFacts.
+Uses PyYAML (available via boto3's dependency chain) for serialisation.
+"""
+from typing import Optional
+
+from scripts.facts.models import CompiledFacts, FrontmatterData
+from scripts.facts.compiler import format_weather_str
+
+
+def _get_attr(obj, attr: str, default=None):
+    if isinstance(obj, dict):
+        return obj.get(attr, default)
+    return getattr(obj, attr, default)
+
+
+def _to_frontmatter_data(metadata, compiled: CompiledFacts) -> FrontmatterData:
+    """Map pipeline outputs to a FrontmatterData dataclass."""
+    date = _get_attr(metadata, "date") or ""
+    destination = _get_attr(metadata, "destination") or ""
+    start_location = _get_attr(metadata, "start_location") or ""
+    miles_hiked = float(_get_attr(metadata, "miles_hiked") or 0.0)
+    total_miles = float(_get_attr(metadata, "total_miles") or 0.0)
+
+    title = destination or date
+
+    ts = compiled.trail_section
+    state: Optional[str] = ts.state if ts else None
+    nearest_town: Optional[str] = ts.nearest_town if ts else None
+    at_mile_start: Optional[float] = ts.at_mile_start if ts else None
+    at_mile_end: Optional[float] = ts.at_mile_end if ts else None
+    trail_section_summary: Optional[str] = ts.trail_section_summary if ts else None
+
+    weather = compiled.weather
+    weather_high_f: Optional[float] = weather.high_f if weather else None
+    weather_low_f: Optional[float] = weather.low_f if weather else None
+    weather_precip_in: Optional[float] = weather.precip_in if weather else None
+    weather_conditions: Optional[str] = weather.conditions if weather else None
+    weather_source: Optional[str] = weather.source if weather else None
+    weather_caveat: Optional[str] = weather.caveat if weather else None
+
+    town_event: Optional[str] = (
+        compiled.town_events.event
+        if compiled.town_events and compiled.town_events.event
+        else None
+    )
+
+    return FrontmatterData(
+        date=date,
+        title=title,
+        start_location=start_location,
+        destination=destination,
+        miles_hiked=miles_hiked,
+        total_miles=total_miles,
+        state=state,
+        nearest_town=nearest_town,
+        at_mile_start=at_mile_start,
+        at_mile_end=at_mile_end,
+        weather_high_f=weather_high_f,
+        weather_low_f=weather_low_f,
+        weather_precip_in=weather_precip_in,
+        weather_conditions=weather_conditions,
+        weather_source=weather_source,
+        weather_caveat=weather_caveat,
+        trail_section_summary=trail_section_summary,
+        town_event=town_event,
+    )
+
+
+def _frontmatter_data_to_dict(fm: FrontmatterData) -> dict:
+    """Convert FrontmatterData to an ordered dict, omitting None values."""
+    import dataclasses
+
+    raw = dataclasses.asdict(fm)
+
+    # Preferred key ordering for readability
+    ordered_keys = [
+        "date", "title", "start_location", "destination",
+        "miles_hiked", "total_miles",
+        "state", "nearest_town",
+        "at_mile_start", "at_mile_end",
+        "weather_high_f", "weather_low_f", "weather_precip_in",
+        "weather_conditions", "weather_source", "weather_caveat",
+        "trail_section_summary",
+        "town_event",
+    ]
+    result: dict = {}
+    for key in ordered_keys:
+        val = raw.get(key)
+        if val is not None:
+            result[key] = val
+    # Include any extra fields not in the ordered list
+    for key, val in raw.items():
+        if key not in result and val is not None:
+            result[key] = val
+    return result
+
+
+def build_frontmatter(metadata, compiled: CompiledFacts) -> str:
+    """Return a YAML frontmatter block (including --- delimiters) for an entry."""
+    import yaml
+
+    fm_data = _to_frontmatter_data(metadata, compiled)
+    data_dict = _frontmatter_data_to_dict(fm_data)
+
+    # Also include the formatted weather string for human readability
+    weather_str = format_weather_str(compiled.weather)
+    if weather_str:
+        data_dict["weather_summary"] = weather_str
+
+    # Include confidence score
+    data_dict["facts_confidence"] = round(compiled.confidence, 2)
+
+    yaml_str = yaml.safe_dump(
+        data_dict,
+        default_flow_style=False,
+        allow_unicode=True,
+        sort_keys=False,
+    )
+    return f"---\n{yaml_str}---\n"
+
+
+def inject_frontmatter(entry_text: str, frontmatter: str) -> str:
+    """Prepend frontmatter immediately before the first # header line.
+
+    If no header is found, the frontmatter is prepended to the entry.
+    Leading blank lines before the header are preserved.
+    """
+    lines = entry_text.split("\n")
+    for i, line in enumerate(lines):
+        if line.startswith("#"):
+            prefix = "\n".join(lines[:i])
+            rest = "\n".join(lines[i:])
+            if prefix:
+                return prefix + "\n" + frontmatter + rest
+            return frontmatter + rest
+    # No header found — prepend
+    return frontmatter + entry_text
+
+
+def has_frontmatter(entry_text: str) -> bool:
+    """Return True if the entry already starts with a YAML frontmatter block."""
+    stripped = entry_text.lstrip()
+    if not stripped.startswith("---"):
+        return False
+    # Must have a closing --- on a subsequent line
+    after_open = stripped[3:].lstrip("\n")
+    return "---" in after_open

--- a/scripts/facts/frontmatter.py
+++ b/scripts/facts/frontmatter.py
@@ -109,8 +109,15 @@ def _trail_section_text(compiled: CompiledFacts) -> Optional[str]:
     ts = compiled.trail_section
     if not ts:
         return None
+    # Prefer the composed segment summary over a flat claim dump
+    if ts.trail_section_summary and "AT miles" in ts.trail_section_summary:
+        return ts.trail_section_summary
     if ts.claims:
-        return " ".join(c.text for c in ts.claims)
+        segment_bits = [c.text for c in ts.claims if c.type == "segment"]
+        other_bits = [c.text for c in ts.claims if c.type != "segment"][:2]
+        combined = segment_bits + other_bits
+        if combined:
+            return " ".join(combined)
     return ts.trail_section_summary or None
 
 
@@ -130,19 +137,32 @@ def build_frontmatter(metadata, compiled: CompiledFacts) -> str:
     if compiled.town_events and compiled.town_events.event:
         town_events = compiled.town_events.event
 
+    facts_block = {
+        "weather": weather_summary,
+        "trail_section": trail_section,
+        "town_events": town_events,
+        "confidence": _confidence_label(compiled.confidence),
+        "sources": compiled.sources or None,
+    }
+
+    ts = compiled.trail_section
+    if ts:
+        if ts.segment_name:
+            facts_block["segment"] = ts.segment_name
+        if ts.at_mile_start is not None:
+            facts_block["at_mile_start"] = ts.at_mile_start
+        if ts.at_mile_end is not None:
+            facts_block["at_mile_end"] = ts.at_mile_end
+        if ts.region:
+            facts_block["region"] = ts.region
+
     data_dict = {
         "date": date,
         "start": start_location,
         "destination": destination,
         "miles_today": miles_hiked,
         "trip_miles": total_miles,
-        "facts": {
-            "weather": weather_summary,
-            "trail_section": trail_section,
-            "town_events": town_events,
-            "confidence": _confidence_label(compiled.confidence),
-            "sources": compiled.sources or None,
-        },
+        "facts": facts_block,
     }
 
     # Drop empty facts keys

--- a/scripts/facts/location_resolver.py
+++ b/scripts/facts/location_resolver.py
@@ -1,0 +1,91 @@
+import json
+import re
+from pathlib import Path
+from typing import Optional
+
+_LOCATIONS_PATH = Path(__file__).parent.parent.parent / "data" / "at_locations.json"
+
+_locations: Optional[list] = None
+
+
+def _load_locations() -> list:
+    global _locations
+    if _locations is None:
+        with open(_LOCATIONS_PATH, "r") as f:
+            _locations = json.load(f)
+    return _locations
+
+
+def normalize_name(name: str) -> str:
+    """Lowercase, strip parentheticals, and collapse whitespace."""
+    # Remove parenthetical suffixes like "(Helen, GA)"
+    name = re.sub(r"\s*\(.*?\)", "", name)
+    return name.lower().strip()
+
+
+def lookup(name: str) -> Optional[dict]:
+    """Look up a location by name. Returns dict with lat, lon, state, at_mile, is_town."""
+    normalized = normalize_name(name)
+    for loc in _load_locations():
+        if normalize_name(loc["name"]) == normalized:
+            return loc
+    return None
+
+
+def extract_town_from_location(location: str) -> Optional[str]:
+    """Extract town name from a parenthetical, e.g. 'EconoLodge Motel (Helen, GA)' -> 'Helen, GA'."""
+    match = re.search(r"\(([^)]+)\)", location)
+    if match:
+        return match.group(1).strip()
+    return None
+
+
+_TOWN_KEYWORDS = frozenset(
+    ["motel", "hostel", "inn", "lodge", "hotel", "b&b", "bed and breakfast"]
+)
+
+
+def is_town_day(metadata) -> bool:
+    """
+    Heuristic: return True if the entry likely represents a town stay rather
+    than a trail camp. Checks:
+      - destination or start_location contains a lodging keyword
+      - destination or start_location has a parenthetical town suffix
+      - miles_hiked == 0 (zero-mile rest/zero day)
+    """
+    fields = [
+        getattr(metadata, "destination", "") or "",
+        getattr(metadata, "start_location", "") or "",
+    ]
+    for field_val in fields:
+        lowered = field_val.lower()
+        if any(kw in lowered for kw in _TOWN_KEYWORDS):
+            return True
+        if re.search(r"\([^)]+,\s*[A-Z]{2}\)", field_val):
+            return True
+
+    miles = getattr(metadata, "miles_hiked", None)
+    if miles is not None and miles == 0:
+        return True
+
+    return False
+
+
+def resolve_coords(start: str, destination: str) -> Optional[tuple]:
+    """
+    Return midpoint (lat, lon) between start and destination lookups.
+    Falls back to whichever single point is found, or None if neither found.
+    """
+    start_loc = lookup(start)
+    dest_loc = lookup(destination)
+
+    if start_loc and dest_loc:
+        lat = (start_loc["lat"] + dest_loc["lat"]) / 2
+        lon = (start_loc["lon"] + dest_loc["lon"]) / 2
+        return (lat, lon)
+
+    for loc in (start_loc, dest_loc):
+        if loc:
+            return (loc["lat"], loc["lon"])
+
+    return None

--- a/scripts/facts/location_resolver.py
+++ b/scripts/facts/location_resolver.py
@@ -40,33 +40,58 @@ def extract_town_from_location(location: str) -> Optional[str]:
     return None
 
 
-_TOWN_KEYWORDS = frozenset(
-    ["motel", "hostel", "inn", "lodge", "hotel", "b&b", "bed and breakfast"]
+_TRAIL_LODGES = frozenset(
+    [
+        "hike inn",
+        "neel gap hostel",
+        "blueberry patch hostel",
+        "standing bear farm hostel",
+        "mountain harbour hostel",
+        "the place",
+        "woods hole hostel",
+        "bear's den hostel",
+        "harper's ferry hostel",
+        "hikers welcome hostel",
+        "shaw's boarding house",
+    ]
 )
+
+_TOWN_LODGING_KEYWORDS = frozenset(["motel", "hotel", "econolodge", "travelodge", "holiday inn"])
+
+
+def _metadata_field(metadata, field: str) -> str:
+    if isinstance(metadata, dict):
+        return str(metadata.get(field) or "")
+    return str(getattr(metadata, field, "") or "")
 
 
 def is_town_day(metadata) -> bool:
     """
-    Heuristic: return True if the entry likely represents a town stay rather
-    than a trail camp. Checks:
-      - destination or start_location contains a lodging keyword
-      - destination or start_location has a parenthetical town suffix
-      - miles_hiked == 0 (zero-mile rest/zero day)
+    Heuristic: return True when the entry is a town stop worth researching.
+
+    Trail shelters and backcountry inns are excluded. Town days are entries with
+    an explicit town in parentheses, a known town location, or commercial lodging.
     """
     fields = [
-        getattr(metadata, "destination", "") or "",
-        getattr(metadata, "start_location", "") or "",
+        _metadata_field(metadata, "destination"),
+        _metadata_field(metadata, "start_location"),
     ]
+
     for field_val in fields:
-        lowered = field_val.lower()
-        if any(kw in lowered for kw in _TOWN_KEYWORDS):
-            return True
-        if re.search(r"\([^)]+,\s*[A-Z]{2}\)", field_val):
+        if extract_town_from_location(field_val):
             return True
 
-    miles = getattr(metadata, "miles_hiked", None)
-    if miles is not None and miles == 0:
-        return True
+        normalized = normalize_name(field_val)
+        if normalized in _TRAIL_LODGES:
+            continue
+
+        loc = lookup(field_val)
+        if loc and loc.get("is_town"):
+            return True
+
+        lowered = field_val.lower()
+        if any(kw in lowered for kw in _TOWN_LODGING_KEYWORDS):
+            return True
 
     return False
 

--- a/scripts/facts/location_resolver.py
+++ b/scripts/facts/location_resolver.py
@@ -17,7 +17,9 @@ def _load_locations() -> list:
 
 
 def normalize_name(name: str) -> str:
-    """Lowercase, strip parentheticals, and collapse whitespace."""
+    """Lowercase, strip markdown/asterisks, parentheticals, and collapse whitespace."""
+    name = re.sub(r"^\*+\s*", "", name)
+    name = re.sub(r"\s*\*+$", "", name)
     # Remove parenthetical suffixes like "(Helen, GA)"
     name = re.sub(r"\s*\(.*?\)", "", name)
     return name.lower().strip()

--- a/scripts/facts/models.py
+++ b/scripts/facts/models.py
@@ -1,0 +1,90 @@
+from dataclasses import dataclass, field
+from typing import Optional, List
+
+
+@dataclass
+class EntryMetadata:
+    date: str
+    start_location: str
+    destination: str
+    miles_hiked: float
+    total_miles: float
+
+
+@dataclass
+class Claim:
+    type: str
+    text: str
+
+
+@dataclass
+class DraftFacts:
+    trail_section_summary: str
+    claims: List[Claim]
+    at_mile_start: Optional[float]
+    at_mile_end: Optional[float]
+    state: Optional[str]
+    nearest_town: Optional[str]
+
+
+@dataclass
+class VerifiedClaim:
+    claim: Claim
+    source: str
+    confidence: float
+
+
+@dataclass
+class ValidationResult:
+    verified: List[VerifiedClaim]
+    rejected: List[Claim]
+    corrections: List[str]
+
+
+@dataclass
+class WeatherFacts:
+    high_f: Optional[float]
+    low_f: Optional[float]
+    precip_in: Optional[float]
+    conditions: Optional[str]
+    source: str
+    coords: Optional[tuple]
+    caveat: Optional[str] = None
+
+
+@dataclass
+class TownEventsResult:
+    event: Optional[str] = None
+    source: Optional[str] = None
+    confidence: Optional[float] = None
+
+
+@dataclass
+class CompiledFacts:
+    weather: Optional[WeatherFacts]
+    trail_section: Optional[DraftFacts]
+    town_events: Optional[TownEventsResult]
+    confidence: float
+    sources: List[str] = field(default_factory=list)
+
+
+@dataclass
+class FrontmatterData:
+    date: str
+    title: str
+    start_location: str
+    destination: str
+    miles_hiked: float
+    total_miles: float
+    state: Optional[str] = None
+    nearest_town: Optional[str] = None
+    at_mile_start: Optional[float] = None
+    at_mile_end: Optional[float] = None
+    weather_high_f: Optional[float] = None
+    weather_low_f: Optional[float] = None
+    weather_precip_in: Optional[float] = None
+    weather_conditions: Optional[str] = None
+    weather_source: Optional[str] = None
+    weather_caveat: Optional[str] = None
+    trail_section_summary: Optional[str] = None
+    town_event: Optional[str] = None

--- a/scripts/facts/models.py
+++ b/scripts/facts/models.py
@@ -25,6 +25,8 @@ class DraftFacts:
     at_mile_end: Optional[float]
     state: Optional[str]
     nearest_town: Optional[str]
+    segment_name: Optional[str] = None
+    region: Optional[str] = None
 
 
 @dataclass

--- a/scripts/facts/orchestrator.py
+++ b/scripts/facts/orchestrator.py
@@ -1,0 +1,268 @@
+"""Pipeline orchestrator for journal frontmatter enrichment.
+
+Public API:
+    enrich_entry(metadata, entry_text, cache_dir, skip_firecrawl=True) -> str
+    enrich_journal(input_path, output_path, cache_dir, limit=None, start=1)
+"""
+import dataclasses
+import json
+import re
+from pathlib import Path
+from typing import Optional
+
+from scripts.facts.models import (
+    Claim,
+    CompiledFacts,
+    DraftFacts,
+    EntryMetadata,
+    TownEventsResult,
+    ValidationResult,
+    VerifiedClaim,
+    WeatherFacts,
+)
+from scripts.facts.cache import EntryCache
+from scripts.facts.compiler import compile_facts
+from scripts.facts.draft_agent import draft_section_facts
+from scripts.facts.frontmatter import build_frontmatter, has_frontmatter, inject_frontmatter
+from scripts.facts.town_events_agent import fetch_town_events
+from scripts.facts.validate_agent import validate_claims
+
+
+# ---------------------------------------------------------------------------
+# Metadata helpers
+# ---------------------------------------------------------------------------
+
+def _get_attr(obj, attr: str, default=None):
+    if isinstance(obj, dict):
+        return obj.get(attr, default)
+    return getattr(obj, attr, default)
+
+
+def _to_entry_metadata(metadata) -> EntryMetadata:
+    """Convert a dict (from parse_entry_metadata) or pass-through an EntryMetadata."""
+    if isinstance(metadata, EntryMetadata):
+        return metadata
+    return EntryMetadata(
+        date=str(_get_attr(metadata, "date") or ""),
+        start_location=str(_get_attr(metadata, "start_location") or ""),
+        destination=str(_get_attr(metadata, "destination") or ""),
+        miles_hiked=float(_get_attr(metadata, "miles_hiked") or 0.0),
+        total_miles=float(_get_attr(metadata, "total_miles") or 0.0),
+    )
+
+
+def _entry_key(metadata) -> str:
+    date = _get_attr(metadata, "date") or ""
+    start = _get_attr(metadata, "start_location") or ""
+    dest = _get_attr(metadata, "destination") or ""
+    return f"{date}_{start}_{dest}"
+
+
+# ---------------------------------------------------------------------------
+# Deserialise cached JSON dicts back to dataclass objects
+# ---------------------------------------------------------------------------
+
+def _deserialise_claim(d: dict) -> Claim:
+    return Claim(type=d.get("type", ""), text=d.get("text", ""))
+
+
+def _deserialise_draft(d: dict) -> DraftFacts:
+    return DraftFacts(
+        trail_section_summary=d.get("trail_section_summary", ""),
+        claims=[_deserialise_claim(c) for c in d.get("claims", [])],
+        at_mile_start=d.get("at_mile_start"),
+        at_mile_end=d.get("at_mile_end"),
+        state=d.get("state"),
+        nearest_town=d.get("nearest_town"),
+    )
+
+
+def _deserialise_validation(d: dict) -> ValidationResult:
+    verified = [
+        VerifiedClaim(
+            claim=_deserialise_claim(vc["claim"]),
+            source=vc.get("source", ""),
+            confidence=float(vc.get("confidence", 0.0)),
+        )
+        for vc in d.get("verified", [])
+    ]
+    rejected = [_deserialise_claim(c) for c in d.get("rejected", [])]
+    return ValidationResult(
+        verified=verified,
+        rejected=rejected,
+        corrections=d.get("corrections", []),
+    )
+
+
+def _deserialise_weather(d: dict) -> Optional[WeatherFacts]:
+    if not d:
+        return None
+    coords_raw = d.get("coords")
+    coords = tuple(coords_raw) if coords_raw else None
+    return WeatherFacts(
+        high_f=d.get("high_f"),
+        low_f=d.get("low_f"),
+        precip_in=d.get("precip_in"),
+        conditions=d.get("conditions"),
+        source=d.get("source", ""),
+        coords=coords,
+        caveat=d.get("caveat"),
+    )
+
+
+def _deserialise_town_events(d: dict) -> TownEventsResult:
+    return TownEventsResult(
+        event=d.get("event"),
+        source=d.get("source"),
+        confidence=d.get("confidence"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Weather fetch wrapper
+# ---------------------------------------------------------------------------
+
+def _fetch_weather_safe(metadata: EntryMetadata) -> Optional[WeatherFacts]:
+    """Fetch weather if coordinates are resolvable; returns None on any failure."""
+    try:
+        from scripts.facts.location_resolver import resolve_coords
+        from scripts.facts.weather_agent import fetch_weather
+
+        coords = resolve_coords(metadata.start_location, metadata.destination)
+        if coords is None:
+            return None
+        lat, lon = coords
+        return fetch_weather(metadata.date, lat, lon)
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Single-entry pipeline
+# ---------------------------------------------------------------------------
+
+def enrich_entry(
+    metadata,
+    entry_text: str,
+    cache_dir,
+    skip_firecrawl: bool = True,
+) -> str:
+    """Run the facts pipeline for one journal entry and return the enriched text.
+
+    Each pipeline pass is cached so re-runs are cheap.
+    If the entry already has frontmatter it is returned unchanged.
+    """
+    if has_frontmatter(entry_text):
+        return entry_text
+
+    em = _to_entry_metadata(metadata)
+    cache = EntryCache(Path(cache_dir), _entry_key(em))
+
+    # --- Pass 1: draft ---
+    cached_draft = cache.load_pass("draft")
+    if cached_draft:
+        draft = _deserialise_draft(cached_draft)
+    else:
+        draft = draft_section_facts(em)
+        cache.save_pass("draft", draft)
+
+    # --- Pass 2: validation ---
+    cached_val = cache.load_pass("validation")
+    if cached_val:
+        validation = _deserialise_validation(cached_val)
+    else:
+        validation = validate_claims(em, draft)
+        cache.save_pass("validation", validation)
+
+    # --- Pass 3: weather ---
+    cached_weather = cache.load_pass("weather")
+    if cached_weather:
+        weather = _deserialise_weather(cached_weather)
+    else:
+        weather = _fetch_weather_safe(em)
+        cache.save_pass("weather", dataclasses.asdict(weather) if weather else {})
+
+    # --- Pass 4: town events ---
+    cached_town = cache.load_pass("town_events")
+    if cached_town:
+        town_events = _deserialise_town_events(cached_town)
+    else:
+        town_events = fetch_town_events(em)
+        cache.save_pass("town_events", town_events)
+
+    # --- Pass 5: compile + frontmatter ---
+    cached_fm = cache.load_pass("frontmatter")
+    if cached_fm:
+        frontmatter_str = cached_fm["frontmatter"]
+    else:
+        compiled = compile_facts(validation, weather, town_events, em, draft)
+        frontmatter_str = build_frontmatter(em, compiled)
+        cache.save_pass("frontmatter", frontmatter_str)
+
+    return inject_frontmatter(entry_text, frontmatter_str)
+
+
+# ---------------------------------------------------------------------------
+# Journal-level pipeline
+# ---------------------------------------------------------------------------
+
+def enrich_journal(
+    input_path,
+    output_path,
+    cache_dir,
+    limit: Optional[int] = None,
+    start: int = 1,
+) -> None:
+    """Enrich all entries in a journal file with YAML frontmatter.
+
+    Args:
+        input_path:  path to the source journal text file
+        output_path: path for the enriched output file
+        cache_dir:   directory for per-entry cache subdirectories
+        limit:       maximum number of entries to process (None = all)
+        start:       1-based entry index to start processing from
+    """
+    from scripts.enhance_entries import parse_entry_metadata
+
+    input_path = Path(input_path)
+    output_path = Path(output_path)
+    cache_dir = Path(cache_dir)
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    content = input_path.read_text(encoding="utf-8")
+    raw_entries = content.split("\n---\n")
+
+    enriched: list = []
+    processed = 0
+
+    for idx, entry in enumerate(raw_entries, 1):
+        entry_stripped = entry.strip()
+        if not entry_stripped:
+            enriched.append(entry)
+            continue
+
+        if idx < start:
+            enriched.append(entry)
+            continue
+
+        if limit is not None and processed >= limit:
+            enriched.append(entry)
+            continue
+
+        metadata = parse_entry_metadata(entry_stripped)
+        if not metadata:
+            enriched.append(entry)
+            continue
+
+        try:
+            result = enrich_entry(metadata, entry_stripped, cache_dir)
+            enriched.append(result)
+        except Exception as exc:
+            # Never drop an entry on error; preserve original text
+            print(f"[WARNING] Entry {idx} enrichment failed: {exc}")
+            enriched.append(entry)
+
+        processed += 1
+
+    output_path.write_text("\n---\n".join(enriched), encoding="utf-8")
+    print(f"[INFO] Wrote {len(enriched)} entries to {output_path}")

--- a/scripts/facts/orchestrator.py
+++ b/scripts/facts/orchestrator.py
@@ -212,6 +212,7 @@ def enrich_journal(
     cache_dir,
     limit: Optional[int] = None,
     start: int = 1,
+    use_firecrawl: bool = False,
 ) -> None:
     """Enrich all entries in a journal file with YAML frontmatter.
 
@@ -255,7 +256,9 @@ def enrich_journal(
             continue
 
         try:
-            result = enrich_entry(metadata, entry_stripped, cache_dir)
+            result = enrich_entry(
+                metadata, entry_stripped, cache_dir, skip_firecrawl=not use_firecrawl
+            )
             enriched.append(result)
         except Exception as exc:
             # Never drop an entry on error; preserve original text

--- a/scripts/facts/orchestrator.py
+++ b/scripts/facts/orchestrator.py
@@ -187,7 +187,7 @@ def enrich_entry(
     if cached_town:
         town_events = _deserialise_town_events(cached_town)
     else:
-        town_events = fetch_town_events(em)
+        town_events = fetch_town_events(em, skip_firecrawl=skip_firecrawl)
         cache.save_pass("town_events", town_events)
 
     # --- Pass 5: compile + frontmatter ---

--- a/scripts/facts/orchestrator.py
+++ b/scripts/facts/orchestrator.py
@@ -74,6 +74,8 @@ def _deserialise_draft(d: dict) -> DraftFacts:
         at_mile_end=d.get("at_mile_end"),
         state=d.get("state"),
         nearest_town=d.get("nearest_town"),
+        segment_name=d.get("segment_name"),
+        region=d.get("region"),
     )
 
 

--- a/scripts/facts/segment_guide.py
+++ b/scripts/facts/segment_guide.py
@@ -1,0 +1,149 @@
+"""Mile-range segment guides for rich per-hike trail section descriptions."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional
+
+from scripts.facts.models import Claim
+
+_GUIDES_PATH = Path(__file__).parent.parent.parent / "data" / "at_segment_guides.json"
+_LOCATIONS_PATH = Path(__file__).parent.parent.parent / "data" / "at_locations.json"
+
+_guides: Optional[list] = None
+_locations: Optional[list] = None
+
+
+def _load_guides() -> list:
+    global _guides
+    if _guides is None:
+        with open(_GUIDES_PATH, encoding="utf-8") as f:
+            _guides = json.load(f)
+    return _guides
+
+
+def _load_locations() -> list:
+    global _locations
+    if _locations is None:
+        with open(_LOCATIONS_PATH, encoding="utf-8") as f:
+            _locations = json.load(f)
+    return _locations
+
+
+def guides_overlapping(mile_start: float, mile_end: float) -> list[dict]:
+    """Return segment guides that overlap the hiked mile range."""
+    lo, hi = (mile_start, mile_end) if mile_start <= mile_end else (mile_end, mile_start)
+    return [
+        g
+        for g in _load_guides()
+        if g["mile_end"] >= lo and g["mile_start"] <= hi
+    ]
+
+
+def landmarks_between(mile_start: float, mile_end: float, limit: int = 4) -> list[str]:
+    """Notable named places with AT miles falling inside the hiked range."""
+    lo, hi = (mile_start, mile_end) if mile_start <= mile_end else (mile_end, mile_start)
+    hits = []
+    for loc in _load_locations():
+        mile = loc.get("at_mile")
+        if mile is None or not (lo <= mile <= hi):
+            continue
+        hits.append((mile, loc["name"]))
+    hits.sort(key=lambda x: x[0])
+    return [name for _, name in hits[:limit]]
+
+
+def resolve_mile_range(
+    start_location: str,
+    destination: str,
+    miles_hiked: float,
+    trip_miles: float,
+) -> tuple[Optional[float], Optional[float]]:
+    """Best-effort AT mile range for a day's hike."""
+    from scripts.facts.location_resolver import lookup
+
+    start_loc = lookup(start_location) if start_location else None
+    dest_loc = lookup(destination) if destination else None
+
+    mile_start = start_loc.get("at_mile") if start_loc else None
+    mile_end = dest_loc.get("at_mile") if dest_loc else None
+
+    if mile_end is None and trip_miles:
+        mile_end = float(trip_miles)
+    if mile_start is None and mile_end is not None and miles_hiked:
+        mile_start = max(0.0, mile_end - float(miles_hiked))
+
+    return mile_start, mile_end
+
+
+def build_segment_description(
+    start_location: str,
+    destination: str,
+    miles_hiked: float,
+    trip_miles: float,
+) -> tuple[str, list[Claim], dict]:
+    """
+    Return (summary_text, claims, meta) for the hiked segment.
+
+    meta keys: segment_name, region, at_mile_start, at_mile_end
+    """
+    mile_start, mile_end = resolve_mile_range(
+        start_location, destination, miles_hiked, trip_miles
+    )
+
+    if mile_start is None and mile_end is None:
+        return "", [], {}
+
+    if mile_start is None:
+        mile_start = max(0.0, (mile_end or 0) - max(miles_hiked, 1))
+    if mile_end is None:
+        mile_end = mile_start + max(miles_hiked, 0)
+
+    guides = guides_overlapping(mile_start, mile_end)
+    if not guides:
+        return "", [], {
+            "segment_name": None,
+            "region": None,
+            "at_mile_start": mile_start,
+            "at_mile_end": mile_end,
+        }
+
+    # Primary guide = the one containing the midpoint of the day's hike
+    midpoint = (mile_start + mile_end) / 2
+    primary = min(guides, key=lambda g: abs((g["mile_start"] + g["mile_end"]) / 2 - midpoint))
+
+    between = landmarks_between(mile_start, mile_end)
+    mile_label = f"AT miles {mile_start:.0f}–{mile_end:.0f}"
+
+    parts = [
+        f"{primary['name']} ({mile_label}): {primary['summary']}",
+        primary["terrain"],
+    ]
+    if between:
+        parts.append(f"Notable points along this leg include {', '.join(between)}.")
+    elif primary.get("notable"):
+        parts.append(
+            "Landmarks in this corridor include "
+            + ", ".join(primary["notable"][:4])
+            + "."
+        )
+
+    summary = " ".join(parts)
+
+    claims = [
+        Claim("segment", primary["summary"]),
+        Claim("terrain", primary["terrain"]),
+        Claim("segment", f"Section: {primary['name']} ({primary['region']})."),
+    ]
+    if between:
+        claims.append(
+            Claim("landmark", f"Today's hike passes near: {', '.join(between)}.")
+        )
+
+    meta = {
+        "segment_name": primary["name"],
+        "region": primary["region"],
+        "at_mile_start": round(mile_start, 1),
+        "at_mile_end": round(mile_end, 1),
+    }
+    return summary, claims, meta

--- a/scripts/facts/town_events_agent.py
+++ b/scripts/facts/town_events_agent.py
@@ -17,12 +17,25 @@ def _get_attr(obj, attr: str, default=""):
     return getattr(obj, attr, default)
 
 
+def _extract_search_items(data: dict) -> list:
+    """Normalise firecrawl search JSON into a list of result dicts."""
+    raw = data.get("data") or data.get("results") or []
+    if isinstance(raw, list):
+        return raw
+    if isinstance(raw, dict):
+        for key in ("web", "news", "results"):
+            nested = raw.get(key)
+            if isinstance(nested, list):
+                return nested
+    return []
+
+
 def _firecrawl_search_event(town: str, date: str) -> TownEventsResult:
     """Query firecrawl for events in a town on a given date. Never invents sources."""
     query = f"Appalachian Trail town events {town} {date}"
     try:
         result = subprocess.run(
-            ["firecrawl", "search", "--json", query[:200]],
+            ["firecrawl", "search", query[:200], "--json"],
             capture_output=True,
             text=True,
             timeout=15,
@@ -30,24 +43,27 @@ def _firecrawl_search_event(town: str, date: str) -> TownEventsResult:
         if result.returncode != 0:
             return TownEventsResult(event=None)
         data = json.loads(result.stdout)
-        items = data.get("data") or data.get("results") or []
-        if items:
-            first = items[0]
-            title = first.get("title") or first.get("snippet") or ""
-            url = first.get("url") or ""
-            if title:
-                source = url if url else "firecrawl web search"
-                return TownEventsResult(
-                    event=title[:300],
-                    source=source,
-                    confidence=0.5,
-                )
-    except (subprocess.TimeoutExpired, json.JSONDecodeError, OSError):
+        items = _extract_search_items(data)
+        if not items:
+            return TownEventsResult(event=None)
+        first = items[0]
+        if not isinstance(first, dict):
+            return TownEventsResult(event=None)
+        title = first.get("title") or first.get("snippet") or ""
+        url = first.get("url") or ""
+        if title:
+            source = url if url else "firecrawl web search"
+            return TownEventsResult(
+                event=title[:300],
+                source=source,
+                confidence=0.5,
+            )
+    except (subprocess.TimeoutExpired, json.JSONDecodeError, OSError, KeyError, IndexError, TypeError):
         pass
     return TownEventsResult(event=None)
 
 
-def fetch_town_events(metadata) -> TownEventsResult:
+def fetch_town_events(metadata, skip_firecrawl: bool = True) -> TownEventsResult:
     """Return town event information for an entry.
 
     Returns TownEventsResult(event=None) when:
@@ -71,7 +87,7 @@ def fetch_town_events(metadata) -> TownEventsResult:
         or start
     )
 
-    if shutil.which("firecrawl") and town and date:
+    if not skip_firecrawl and shutil.which("firecrawl") and town and date:
         return _firecrawl_search_event(town, date)
 
     return TownEventsResult(event=None)

--- a/scripts/facts/town_events_agent.py
+++ b/scripts/facts/town_events_agent.py
@@ -1,0 +1,77 @@
+"""Town events agent for AT journal entries.
+
+For the pilot:
+  - Returns TownEventsResult(event=None) for non-town days.
+  - Attempts a firecrawl search on town days only if firecrawl is available.
+"""
+import json
+import shutil
+import subprocess
+
+from scripts.facts.models import TownEventsResult
+
+
+def _get_attr(obj, attr: str, default=""):
+    if isinstance(obj, dict):
+        return obj.get(attr, default)
+    return getattr(obj, attr, default)
+
+
+def _firecrawl_search_event(town: str, date: str) -> TownEventsResult:
+    """Query firecrawl for events in a town on a given date. Never invents sources."""
+    query = f"Appalachian Trail town events {town} {date}"
+    try:
+        result = subprocess.run(
+            ["firecrawl", "search", "--json", query[:200]],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        if result.returncode != 0:
+            return TownEventsResult(event=None)
+        data = json.loads(result.stdout)
+        items = data.get("data") or data.get("results") or []
+        if items:
+            first = items[0]
+            title = first.get("title") or first.get("snippet") or ""
+            url = first.get("url") or ""
+            if title:
+                source = url if url else "firecrawl web search"
+                return TownEventsResult(
+                    event=title[:300],
+                    source=source,
+                    confidence=0.5,
+                )
+    except (subprocess.TimeoutExpired, json.JSONDecodeError, OSError):
+        pass
+    return TownEventsResult(event=None)
+
+
+def fetch_town_events(metadata) -> TownEventsResult:
+    """Return town event information for an entry.
+
+    Returns TownEventsResult(event=None) when:
+      - The entry is not a town day, or
+      - firecrawl is unavailable and no local data applies.
+    """
+    from scripts.facts.location_resolver import extract_town_from_location, is_town_day
+
+    if not is_town_day(metadata):
+        return TownEventsResult(event=None)
+
+    # Resolve the nearest town name for search
+    dest = _get_attr(metadata, "destination", "")
+    start = _get_attr(metadata, "start_location", "")
+    date = _get_attr(metadata, "date", "")
+
+    town = (
+        extract_town_from_location(dest)
+        or extract_town_from_location(start)
+        or dest
+        or start
+    )
+
+    if shutil.which("firecrawl") and town and date:
+        return _firecrawl_search_event(town, date)
+
+    return TownEventsResult(event=None)

--- a/scripts/facts/validate_agent.py
+++ b/scripts/facts/validate_agent.py
@@ -58,6 +58,9 @@ def _endpoint_confidence(start_resolved: bool, dest_resolved: bool) -> float:
     return 0.0
 
 
+_SEGMENT_SOURCE = "AT segment guide"
+
+
 def validate_claims(metadata, draft: DraftFacts) -> ValidationResult:
     """
     Validate draft claims against the AT location database.
@@ -81,6 +84,12 @@ def validate_claims(metadata, draft: DraftFacts) -> ValidationResult:
     corrections: list = []
 
     for claim in draft.claims:
+        # Segment-guide claims are verified when mile range is known
+        if claim.type == "segment":
+            verified.append(
+                VerifiedClaim(claim=claim, source=_SEGMENT_SOURCE, confidence=0.85)
+            )
+            continue
         if base_confidence > 0:
             verified.append(
                 VerifiedClaim(

--- a/scripts/facts/validate_agent.py
+++ b/scripts/facts/validate_agent.py
@@ -1,0 +1,110 @@
+"""Rule-based claim validator for AT journal facts.
+
+For the pilot, claims are verified against the location resolver database.
+Optional firecrawl integration is available when the CLI tool is on PATH but
+is never required—the agent works fully offline.
+"""
+import json
+import shutil
+import subprocess
+from typing import Optional
+
+from scripts.facts.models import Claim, DraftFacts, ValidationResult, VerifiedClaim
+
+_AT_DB_SOURCE = "AT location database"
+
+
+def _get_attr(obj, attr: str, default=""):
+    if isinstance(obj, dict):
+        return obj.get(attr, default)
+    return getattr(obj, attr, default)
+
+
+def _safe_lookup(name: str) -> Optional[dict]:
+    """Wrap location_resolver.lookup with graceful handling for missing data file."""
+    try:
+        from scripts.facts.location_resolver import lookup
+        return lookup(name)
+    except (FileNotFoundError, OSError, json.JSONDecodeError):
+        return None
+
+
+def _try_firecrawl_validate(claim_text: str) -> bool:
+    """
+    Attempt to verify a claim via a firecrawl web search subprocess.
+    Returns True only if firecrawl confirms the claim text; never invents sources.
+    """
+    try:
+        result = subprocess.run(
+            ["firecrawl", "search", "--json", claim_text[:200]],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        if result.returncode != 0:
+            return False
+        data = json.loads(result.stdout)
+        # Accept if firecrawl returned at least one result
+        return bool(data.get("data") or data.get("results"))
+    except (subprocess.TimeoutExpired, json.JSONDecodeError, OSError):
+        return False
+
+
+def _endpoint_confidence(start_resolved: bool, dest_resolved: bool) -> float:
+    if start_resolved and dest_resolved:
+        return 1.0
+    if start_resolved or dest_resolved:
+        return 0.8
+    return 0.0
+
+
+def validate_claims(metadata, draft: DraftFacts) -> ValidationResult:
+    """
+    Validate draft claims against the AT location database.
+
+    Strategy:
+      - If both endpoints resolve  → all claims verified at confidence 1.0
+      - If one endpoint resolves   → all claims verified at confidence 0.8
+      - If neither resolves        → try firecrawl (if available); otherwise reject
+    """
+    start = _get_attr(metadata, "start_location", "")
+    dest = _get_attr(metadata, "destination", "")
+
+    start_resolved = _safe_lookup(start) is not None if start else False
+    dest_resolved = _safe_lookup(dest) is not None if dest else False
+
+    base_confidence = _endpoint_confidence(start_resolved, dest_resolved)
+    have_firecrawl = shutil.which("firecrawl") is not None
+
+    verified: list = []
+    rejected: list = []
+    corrections: list = []
+
+    for claim in draft.claims:
+        if base_confidence > 0:
+            verified.append(
+                VerifiedClaim(
+                    claim=claim,
+                    source=_AT_DB_SOURCE,
+                    confidence=base_confidence,
+                )
+            )
+        elif have_firecrawl:
+            if _try_firecrawl_validate(claim.text):
+                verified.append(
+                    VerifiedClaim(
+                        claim=claim,
+                        source="firecrawl web search",
+                        confidence=0.6,
+                    )
+                )
+            else:
+                rejected.append(claim)
+        else:
+            rejected.append(claim)
+
+    return ValidationResult(
+        verified=verified,
+        rejected=rejected,
+        corrections=corrections,
+    )

--- a/scripts/facts/weather_agent.py
+++ b/scripts/facts/weather_agent.py
@@ -1,0 +1,126 @@
+import requests
+from scripts.facts.models import WeatherFacts
+
+_OPEN_METEO_URL = (
+    "https://archive-api.open-meteo.com/v1/archive"
+    "?latitude={lat}&longitude={lon}"
+    "&start_date={date}&end_date={date}"
+    "&daily=temperature_2m_max,temperature_2m_min,precipitation_sum,weathercode"
+    "&temperature_unit=fahrenheit&precipitation_unit=inch"
+)
+
+# WMO Weather interpretation codes → human-readable strings
+_WMO_CONDITIONS = {
+    0: "Clear sky",
+    1: "Mainly clear",
+    2: "Partly cloudy",
+    3: "Overcast",
+    45: "Fog",
+    48: "Icy fog",
+    51: "Light drizzle",
+    53: "Moderate drizzle",
+    55: "Dense drizzle",
+    56: "Light freezing drizzle",
+    57: "Heavy freezing drizzle",
+    61: "Slight rain",
+    63: "Moderate rain",
+    65: "Heavy rain",
+    66: "Light freezing rain",
+    67: "Heavy freezing rain",
+    71: "Slight snow",
+    73: "Moderate snow",
+    75: "Heavy snow",
+    77: "Snow grains",
+    80: "Slight rain showers",
+    81: "Moderate rain showers",
+    82: "Violent rain showers",
+    85: "Slight snow showers",
+    86: "Heavy snow showers",
+    95: "Thunderstorm",
+    96: "Thunderstorm with light hail",
+    99: "Thunderstorm with heavy hail",
+}
+
+
+def _wmo_to_conditions(code: int) -> str:
+    return _WMO_CONDITIONS.get(code, f"Unknown (WMO {code})")
+
+
+def fetch_weather(date: str, lat: float, lon: float) -> WeatherFacts:
+    """
+    Fetch historical weather for a given date and coordinates from Open-Meteo archive.
+
+    Args:
+        date: ISO date string, e.g. "2010-03-15"
+        lat: latitude (float)
+        lon: longitude (float)
+
+    Returns:
+        WeatherFacts populated from the API response, with caveat set on any error.
+    """
+    url = _OPEN_METEO_URL.format(lat=lat, lon=lon, date=date)
+    coords = (lat, lon)
+    source = "Open-Meteo archive"
+
+    try:
+        response = requests.get(url, timeout=15)
+        response.raise_for_status()
+        data = response.json()
+    except requests.exceptions.Timeout:
+        return WeatherFacts(
+            high_f=None,
+            low_f=None,
+            precip_in=None,
+            conditions=None,
+            source=source,
+            coords=coords,
+            caveat="Request timed out fetching weather data.",
+        )
+    except requests.exceptions.RequestException as exc:
+        return WeatherFacts(
+            high_f=None,
+            low_f=None,
+            precip_in=None,
+            conditions=None,
+            source=source,
+            coords=coords,
+            caveat=f"HTTP error fetching weather data: {exc}",
+        )
+    except ValueError:
+        return WeatherFacts(
+            high_f=None,
+            low_f=None,
+            precip_in=None,
+            conditions=None,
+            source=source,
+            coords=coords,
+            caveat="Invalid JSON in weather response.",
+        )
+
+    try:
+        daily = data["daily"]
+        high_f = daily["temperature_2m_max"][0]
+        low_f = daily["temperature_2m_min"][0]
+        precip_in = daily["precipitation_sum"][0]
+        wmo_code = daily["weathercode"][0]
+        conditions = _wmo_to_conditions(int(wmo_code))
+    except (KeyError, IndexError, TypeError) as exc:
+        return WeatherFacts(
+            high_f=None,
+            low_f=None,
+            precip_in=None,
+            conditions=None,
+            source=source,
+            coords=coords,
+            caveat=f"Unexpected response structure: {exc}",
+        )
+
+    return WeatherFacts(
+        high_f=high_f,
+        low_f=low_f,
+        precip_in=precip_in,
+        conditions=conditions,
+        source=source,
+        coords=coords,
+        caveat=None,
+    )

--- a/tests/fixtures/pilot_journal_10.txt
+++ b/tests/fixtures/pilot_journal_10.txt
@@ -1,0 +1,237 @@
+# Thursday, January 21, 2010 — Pre-Hike Planning
+**Start Location:** Gear List
+**Miles Today:** 0
+**Trip Miles:** 0
+
+I'm loading my pack and thinking of Lewis & Clark. Hell, how do you pack for an 5,000-plus march into the unknown? Start with alot of meat, apparently: the Corps packed "a ton of dried pork." Maybe I should bring a baggy of deer jerky.
+
+Food, fuel, shoes, and H20 aside, here's my gear list so far. Keep in mind, I'm going "ultra-light", which basically means I'm trying really hard to keep my pack as light as possible. Duh, right? That's called "common sense", not "ultra-light". Either way, I've slashed significant poundage, leaving my total weight at a skimpy 13.8 lbs!
+
+Anyways, please, give me feedback! Too much? Too little? Missing something?
+
+I-The Big Stuff
+
+Pack (Gossamer Gear Gorilla): 23.3 oz.
+
+Sleeping bag (0-degree GoLite Women's): 45 oz.
+
+Poncho/shelter (Sea-to-Summit): 12.7 oz.
+
+Thermarest (Thermarest ProLite Rig): 16.2 oz.
+
+II-Non-Clothes
+
+Stove (homemade alcohol): 2.1 oz.
+
+Bowl (silicone, 16 fl. oz.): 2.3 oz.
+
+Spork (LightMyFire): 0.5 oz
+
+Tent stakes (4): 2.8 oz.
+
+Latrine digger (MSR): 0.7 oz.
+
+Knife (Gerber): 7.8 oz.
+
+Headlamp (Petzl): 0.7 oz.
+
+Bible (ESV): 9.2 oz.
+
+Journal:
+
+Toothbrush & Floss: 1.5 oz.
+
+Mini-lighter: 1 oz.
+
+First Aid kit (8 BandAids, needle & thread, clothespin, Anti-biotic ointment, .5" medical tape, 5 ft. duct tape, 8 Advil, Moleskin, Gauze): 3.5 oz.
+
+Water bladder (Platypus): 3.5 oz.
+
+50 ft. parachute cord: 2.8 oz.
+
+Harmonica: 2.1 oz.
+
+Pipe & Tobacco: 6 oz.
+
+ID, cash, etc.: 2 oz.
+
+Bags (garbage, zip-lock):
+
+Compass: 1 oz.
+
+1 liter water bottle (Dasani): 1.5 oz.
+
+III-Clothes
+
+Baclava (Seirus): 2.8 oz.
+
+Long underwear bottoms (SmartWool, Merino): 7.8 oz.
+
+Long underwear top (Icebreaker, Merino): 13.5 oz.
+
+Rain shell pants (Marmot Precip): 12 oz.
+
+Rain shell jacket (North Face Venture): 13.5 oz.
+
+Gloves (REI): 2.1 oz.
+
+Down jacket (MontBell Alpine): 11.3 oz.
+
+Wool socks (REI, 3 pairs): 8.5 oz.
+
+Down booties (North Face): 12 oz.
+
+Beanie (normal): 2.8 oz.
+
+Liner socks (1 pair, Merino wool):
+
+It's a long list, indeed. Yet amazingly, it only comes out to only 13.8 lbs! I've still got a couple pounds to add...but still! Technology these days.
+
+---
+
+# Saturday, February 06, 2010 — Hike Inn
+**Start Location:** Amicalola Falls State Park
+**Miles Today:** 0
+**Trip Miles:** 0
+
+In the darkness we trudged on without words. After a late start, at 3:45pm, the trail took us up Amicalola Falls and higher into Frosty Mountain as dusk drew near. And Frosty it was, thanks to an ice storm that blew in the previous night, leaving the forest glassy and white. The ices thawed, shattered down from the trees overhead, and buried the trail in 2 inches of shards. Rain had fallen below at Amicalola State Park HQ where we set off, but up here the world was gripped in ice. the foul weather slowed progress - not only did we have to march through ice but detour around splintered branches and trees fallen across the trail. So by nightfall, there I was. Trudging by flashlight along the blue-blazed "approach trail", feeling tired of walking even before the white blazes began.
+
+I expected a damp and dismal shelter that night, but we stumbled across a glowing refuge in the middle of the woods: The Hiker Inn. the situation that night was by no means an emergency, but with my Dad and Morgan it seemed like one for some reason. Morgan was having knee problems and looked on the verge of tears, branches and trees were falling all around us, my hands were numb and it was pitch black for a cloud-covered moon. Emergency or not, we saw a trail sign for The Hiker Inn and decided to pull off. I expected a cold night on the front porch or in an old shed. What I found was a lone innkeeper offering a lamp-lit dwelling warmed by woodstove. All's well that ends well.
+
+Let's go back to where it all begins, to my weeping mother by the car in front of the house. I forget sometimes, how much I mean to people. I forget that I have the power to bring great joy and great sadness, that me going actually matters to someone. So when I put my arms around my mother and she started to cry, I was filled with this incredible sense that I was home, the only place in the world where I really mean something. There I was crucial. I guess it all comes back to love, something I've never really been able to put into words. All I can do is point to my mother and father, my two best friends in the whole world, without whom I would just be a scared little boy. They've brought me here. They've made me a man. and although I didn't think any of this at the time, it was painted so perfectly as I held my weeping mother by the car.
+
+That night we drove to South Carolina and stayed at a hotel. I stayed up late that night reading Thoreau out of my sister's Lit book. He rambles alot, but I liked the marrow part: "When I would recreate myself, I seek the darkest wood and most interminable swamp, and enter it as a sacred place, a sanctum sanctorum. Three is strength, the marrow of nature." I'm about to enter a dark season on an interminable trail, I said to myself, so the suffering is all to shine on that marrow. there is the heart of God. We ate at Cracker Barrel at 6:30 the next morning and then drove to Springer Mountain, "Southern Terminus to the Applachian Trail". I fell asleep in the backseat and awoke to the Amicalola State Park HQ, gateway to the Springer Mountain trail. I registered, weighed my pack, and hit the blue-blazed approach trail to the Springer's summit. 8.8 miles. It was 3:45pm. the trail led into ice, night fell, and we ended up in The Hikers Inn warm log-cabin lobby. We met Stanley, the innkeeper and former A.T. thru-hiker himself, who started up the wood stove and offered me advice for my own hike. I was so fortunate to be there with my father and sister, really enjoying our time together. That was the only thing on my mind that night before I began my 2,000 mile trek to Maine.
+
+---
+
+# Sunday, February 07, 2010 — Hawk Mountain Shelter
+**Start Location:** Hike Inn
+**Miles Today:** 9
+**Trip Miles:** 9
+
+We parted ways at 10:00am. My father and sister walked out the door like I’ve seen them do so many times this past month, but this time I wouldn’t wee them return that evening. This was different. It was hard saying goodbye at what I knew was an exit from their lives for the next six months, before I’d go off and live my life and they’d go off and live theirs. As they walked out the door and out of view, I felt just about as lonely as I’d ever felt. I kind of wanted to chase them but that would be too embarrassing. So I sat there, trying to nap but unable. I think it was because I was alone now and knew it, making me uncomfortable and on edge. From here on out it’ll be like that, more or less, with my guard up full-time. I need to stop writing about this or it’ll get to me.
+
+By 10:30 I was at it, trudging through the aftermath of the ice storm, slipping and sliding in the snow and ice and trying not to yell curse words at the huge limbs blocking the trail. It was slow and painful to the summit of Springer Mountain, by 1:00 I was there, wiping snow off the plaque that read, “Southern Terminus of the Appalachian Trail”. It was too cold and windy to relish the moment, so I marched down to the gap for a break. From there to the shelter, elevation decreased and trail conditions improved. No more ice. No more debris to climb over. Just 2” of snow to stomp down. My spirits immediately brightened as well.
+
+At a shelter, I took a nap and ate. It was only 3:00 by then, so I decided to hoof it to the next shelter, 5.5 miles away. This leg turned out to be in perfect shape. I shot through at a steady 3 mph, descending into an amazing ravine of rhododendron and amazing old growth hemlocks. Some were 300 years old and 5 feet thick, I later learned.
+
+Walking through those holy trees was the highlight of my day. I reached Hawk Mountain shelter before sundown, totaling 9 miles that day. I ran down to the stream to get water, cooked, strung up a bear bag, and wrote for an hour by candlelight. I drifted off and had a strange demon dream where Satan was in my head and barking at me so I couldn’t think, and then I flooded him out by begging God to intervene and jerked awake. After that I was spooked and couldn’t drift off. The mice, in their audacious fashion, ran all over me and all over my stuff, flatly ignoring both my yells and the beams of my flashlight. I slept well that night.
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/301866) [Next](https://www.trailjournals.com/journal/entry/301868) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+---
+
+# Monday, February 08, 2010 — Gooch Mountain Shelter
+**Start Location:** Hawk Mountain Shelter
+**Miles Today:** 14
+**Trip Miles:** 23
+
+I woke up at 8:30 and saw a huge red woodpecker which made me smile. By 9:15, I was on the trail strong and fast to my destination 20 miles away. The trail was gradual and I was happy to be on it, hoofing towards Maine. About an hour passed wuntil I realized I was going in the wrong direction. I cursed aloud. I cursed aloud again. And you know how I realized it? “Cool, that guy’s shoe tracks look just like mine. I wonder if he has the same ….oh shit.”
+
+So after logging a total of 6 idiot miles, I was once again back at the shelter. It was 11:15. I took a nap had breakfast, dressed a blister, then set off again towards the next shelter 8 miles away (I gave up on 20 miles after losing so much daylight). And this time I was going North.
+
+Still, the mountain was white out – all white in snow, fog, and sky – and the temperature was still 23F from that morning. But very quickly, the bad weather lifted. The sky cleared, temperatures rose, and somehow the trail was 100% cleared for the nearly all 8 miles. The sun out and surrounding mountains visible, I stopped for a second and though about how they chase the phrase “Appalachian Scenic Trail”: this was no forced march like I’d been treating it that day. It was a scenic route, carved for the likes of Thoreau’s saunterer traveling to the Holy Land. Then I thought of how fortunate I was to be there on that mountain. I could’ve been a lot of other places – like stuck at work or school, in a wheelchair, or in the twisted metal of a car on the side of River Road- like should’ve happened so many times. So here’s to a blessing. “I’m goin’ to Maine!” I said laughing. “I’m goin’ to Maine!”
+
+At dusk, at the shelter, I finished dinner and let the fire die down to dull embers. In his classic hiker’s manual, The Walker’s Handbook, Colin Fletcher let it die from time to time, to let the darkness surround you. There’s nothing as pure and powerful he said, as darkness deep in the woods. So I stood on the porch of the shelter and let everything go black around me. The wind blew in the trees and it was eerily quiet. “Say something” I said to God. I didn’t know whether to expect something good to happen or something bad, because I’ve found that he’s speaking all the time in the strangest ways, and he’s found in both the happy and the hard. I stood there for a long time, dreaming not thinking about all the blackness. It was addicting. It cozied the mind and numbed it over, like the way you cease when you finally arrive home. I was at home, in the wooded blackness. After half an hour, I retired to my sleeping bag and fell asleep.
+
+---
+
+# Tuesday, February 09, 2010 — Neel Gap Hostel
+**Start Location:** Gooch Mountain Shelter
+**Miles Today:** 15.50
+**Trip Miles:** 38.50
+
+In the morning, I awoke before 8:00 and prepared to leave. It was very cold, but off I went towards Neels Gap. After several hours I passed through Woody Gap, where I met a middle-aged couple on a geo mission. The man took my photo with his iphone and emailed it to my mom and dad. They lady kept looking at me like she wished she had a son of her own. My first run in with Trail Magic!
+
+It was 11:00 and I continued on up to the ominously titled Blood Mountain. Cherokee and Creek warriors met head to head on these slopes, leaving so many dead that the streams ran red with blood. On the way up, I passed homeless and unemployed, two 2001 thru-hikers on a stroll for the day. Two of the nicest hippies I’ve ever met. The man really wanted to give me tips and advice and the woman was beaming at me the whole time. I’m not entirely sure why, but that couple filled me up with so much positive energy.
+
+Down into the next gap, I began to micro-nap. I don’t know how long it lasted, but I continued to twist my ankle and walk off the trail, and even hallucinate (I saw my dad’s face in a poplar tree, even double-taking to make sure) until, at last, I threw down my pack and collapsed trailside for a deep, hour long nap.
+
+Blood Mountain wasn’t too difficult. It climbed up and over several false summits and finally wound up into a rocky, rhododendron covered peak. The wind was steady and snow was still on the ground. I Exploded off the trail and shot down the mountain (small birds for once played in the rhododendron). I found cougar tracks. An ornery, cantankerous skunk was said to occupy the mountaintop shelter, and a bear had reportedly been “hanging out” around the summit. To accentuate the sense of wildness was the narrow trail itself, which tunneled through the rhododendron and crawled over mossy rocks. On the summit’s main rocky outcrop, I saw the entire North Georgia Mountains rolling out and a pink and purple sunset over them. The CCC constructed shelter, a 2 room stone edifice complete with windows and a fireplace. Still, drafts of cold wind kept the shelter far from cozy, so I gambled on finding a free place to stay and moved on down the mountain to Neels Gap.
+
+I reached Neels Gap outfitter by 5 o’clock, closing time, but fortunately the Hiker Hostel was open. There were several men milling about, all with foot-long gray beards and long hair. A long beard means one thing in the mountains - experience- so, naturally, I was excited to spend a night with the experts. The price was only $15, said one bearded man, with the possibility of working it off. I sat down inside and wrote while another bearded man prepared tacos and rambled on about how “everything was going to shit” thanks to an enforcement of state ordinances. Two more bearded men walked in the door and dissappeared out the back. “Can you shoot a cougar?” I asked. “Sure, I don’t see why not. But if they catch you they’ll throw you in jail”, said one of the gnarliest of the bunch. Then he let out a long calm laugh and started talking to the cats. “Come get dinner,” he said after awhile, “or the cats’ll get to it. Actually, they already have.” He laughed at that.
+
+After dinner I boiled some tea and sat by the heater to write in my journal. In ten minutes I was curled up in the chair asleep. It was so nice being warm.
+
+---
+
+# Wednesday, February 10, 2010 — Low Gap Shelter
+**Start Location:** Neel Gap Hostel
+**Miles Today:** 11
+**Trip Miles:** 49.50
+
+In the morning I got up at 6:15 to get a hot shower before the others did, then sat by the heater and read a book about trees. At 9:00, I packed up, and walked up to the outfitters. I asked to do some work to pay off my stay, but the owner wasn’t there so I settled up to save time. I hit the trail just before 10, just as the rains came.
+
+That day was divided sharply between great and God-awful. The first half, the great part, flew past as I hoofed without stopping through the wind and rain. 6 miles over to Tesnatee Gap. I went hard and strong and felt like a champ. But after a short stop at Tesnatee, things fell apart. During the stop, I’d quickly lost all doby and hand heart and became a numb-fingered, shivering - and , not to mention, dripping wet – mess. My hands lost the benign feeling of numbness and began to hurt like someone was bending them back. Groaning aloud and cursing, I began to march. I won’t go into details because the next 4 hours was a drama of the most boring kind. I’ll just say it really sucked and skip to the moment with God, which occurred near the end of the ordeal. I was mouthing off at him again (aloud, mind you), not really making a case but just pissed at the day’s suffering. I had to yell at someone. I told h im to make it okay, or at least give me the big picture so I could at least calm down. All of the sudden, I said it aloud, “This is all part of it”. This is part of the Good, the adventure, the chase after an elusive Spirit. This very moment of numb hands, wet clothes and stabbing blisters was the very reason I set off. Because this is Thoreau’s “marrow of life”, and in it I will find my God.
+
+I went to sleep that night with no idea what to do about my blisters for the next day. The wind picked up and a fog rolled in and the night was all dense blackness and I thought to myself about the old proverb “When I saw I stumbled.”
+
+---
+
+# Thursday, February 11, 2010 — EconoLodge Motel (Helen, GA)
+**Start Location:** Low Gap Shelter
+**Miles Today:** 13.50
+**Trip Miles:** 63
+
+That was a rough night. The temperature plummeted, freezing to rock everything in the shelter I thought was safe – my water bottles, my boots, my clothes. Snow flurries blew in while I slept and covered my down sleeping bag, soaking into the goosedown inside and forming a shell of ice on the surface. As a result, my feet went numb. I awoke cold and discouraged. I fumbled with numb hands to gather my gear and apply my moleskin. My boots were too frozen to put on so I screamed at God in the ravine “What the hell am I supposed to do??” I put on my down booties and started walking.
+
+To my surprise, the down booties did an excellent job. By the time I reached the Blue Mountain Shelter, I had marched through 8 miles of snow and ice and my feet felt great. Close to the summit the wind blasted through the trees. It filled the ears like deafening static. “C’mon! C’mon!” I yelled exhilarated by the struggle against the elements. At the summit shelter, I found an old-timer with his dog and Kevin, a young thru-hiker. “Fire!”, I said, seeing the wind ripping smoke out of the fire pit. “How’d you pull that off?” Kevin was knelt by the fire. He grinned like it was no big deal. “Sticks and fire”. Then he laughed. “Respect”, I said, I asked for more details. The old-timer had a long beard and a weathered face. He was smoking a Backwoods cigar. As it were, the two were holed up in the shelter because the next peak on the trail, Tray Mountain, was demolished by a terrible ice storm. The trail was impassable, said the old-timer; he had tried. The company was nice, especially by two with more knowledge of mountain survival than I. “So where’d you learn to make a fire in the snow?”, I asked. Kevin had been a hunting guide in British Columbia for half of the year, for the past six years, and had “pulled out bodies” from the snow many times. I told him of the previous night’s problems and asked for advice, “The learning curve in the cold is steep, bro” he said grinning. He was really impressed by my light pack. “Hats off to you, mate. Especially in cold weather.”
+
+I gave Kevin some cheese, warmed my hands up by the fire, and marched on down to Unicoi Gap to hitch into town. Dry gear and a warm motel were in high demand. After a minute of thumbing a black car pulled over. Alex, a gay artist on his way to see his boyfriend, was glad to drive me around town to check various motel prices. He was “paying back a favor, or paying it forward, whichever one” He said in his hometown, Hayesville, NC, alcohol had just become legal last month. He had been a vocal advocate. His father, a Baptist minister, had led the opposition. I laughed. Alex said goodbye at the EconoLodge, and I fell asleep on my $30/night bed. I woke up, took a shower, called home, and ate some shrimp ramen with tuna and olive oil. Everyone seemed fine at home, like they’d moved on without me as I’m accustomed to them doing. When you’re away, all you can really say is “I love you” or “I miss you” but those words don’t mean much. It still kinda sucks. I thought about that while I ate my ramen. That night I watched a cheesy movie about aliens. I just didn’t feel like writing.
+
+---
+
+# Friday, February 12, 2010 — Mull's Motel (Hiawasee, GA)
+**Start Location:** EconoLodge Motel (Helen, GA)
+**Miles Today:** 15
+**Trip Miles:** 78
+
+At 6:15 the next morning, I was packing my gear up. It was all so warm and dry. I wrote until 7 o’clock then went to breakfast. Ron, the on-duty manager, was fiddling around with setting up breakfast. He rambled on about how dismal Richmond was for various reasons, including one story about two hookers begging him for crack money. Another story involved drug-running and leaving town after a 6’5” friend fooled around with some other guy’s girlfriend. “I gotta ask you something”, he said. “Are you carrying a gun?”
+
+After breakfast, I dressed my blisters. I bought moleskin at Randy’s pharmacy and the lady let me sit inside to apply it. Randy gave me free blister tape: Trail Magic! “Stay as long as you want, I’d let you lay out and take a nap if we still had those mattresses!”
+
+I walked out to the road and stuck out my thumb. Believe it or not, Ron pulled over. He rambled about me burning ukp all his gas money, running a homeless shelter, how “he don’t pay me shit” at his job and the yars he spent with black ops in Vietnam. “I help people like you out because of what I done to all them”, he said looking skyward. “You wouldn’t believe the sniper rifles they got these days,” he said next. Ron was a good man, a wreck but worth every penny. I’m glad I met him. “I can’t afford to burn all this gas,” he said. “But I need to get up into these mountains. It’s beautiful”. I got out and slammed the door at the trailhead. He rolled down his window and yelled for me. “Hey, hey…I’ve gotta ask you a question.” “Do you ever see things up there that you’d never see down here?” I said “Yes, you do.”
+
+That day on the trail was great. I passed one hiker after another, meeting and greeting and exchanging trail info. I first passed Ryan, another thru-hiker. He’d been laid off, but luckily gotten into law school, and, with his wife’s permission, took off on the A.T. during the layover. He had a nice North Carolina draw. “I’m one of those slow, deliberate people”, he said as I passed. “Yeah,” I laughed. “You’ll probably pass me napping in the next shelter”. Next, I passed three sturdy men moving in the opposite direction. They were older, yet were “tougher than your average weekenders” as they assured, and seemed it. They were impressed by my ultralight pack. On my way up Tray Mountain, I passed an older fellow coming down. Dave Herring was in his 60’s and still climbing Georgia’s mountains, meeting up with thru-hikers and helping them along the way. A full-time Trail Angel, you might say. Today, he escorted two thru-hikers up and over Tray Mountain (remember, the trail was all but wiped out by the storm). For two separate nights, Dave had brought the hikers homecooked dinner, a warm bed, and a place to watch the Super Bowl. For three days, he had brought in two thru-hikers for hot meals, beds, and a Super Bowl party while icy conditions on Tray Mountain improved. Today, he escorted them up and over the mountain. He used to be a big runner, he said, but had lost cartilage in his knee. Now, he was down to just day-hiking for he and his wife. I was overwhelmed with gratitude for this man and his wife, for people who give themselves so fully to the strangers passing through. I’m talking about the A.T.’s host of Angels, and they’re watching over our road north.
+
+After a long nap at the top of Tray, I passed two thru-hikers, Fauma and Second Stage, on the way down the mountain (when I say “down the mountain”, I’m referring t the many ups and downs between a summit and a gap. Rarely is there black-and-white ascent and descent on the AT). All day, I’d been tracking their prints through the snow and around the debris. Catching up to them was the climax of the day. “You hear about these hikers ahead of you and you read all their entries in the shelter journals. You start to paint a mental picture of them,” I told Fauma when I caught him. “It’s kinda like online dating.” He laughed, “Wow, guy”.
+
+My eyes were set on Dicks Creek Gap, still 5.5 miles away by dusk. I flicked on my headlamp, chugged some orange juice and kept trucking. My legs were tired and my feet sore from walking in my booties for 8 miles already. I made it by 7:30 and hitched a ride into Hiawasee by 8pm. I got a motel room for $50 despite efforts at bargaining. I walked across the street to Hardee’s for dinner. I wrote, took a hot shower, and fell asleep by 11:00 with the lights on.
+
+---
+
+# Saturday, February 13, 2010 — Mull's Motel (Hiawasee, GA)
+**Start Location:** Mull's Motel (Hiawasee, GA)
+**Miles Today:** 0
+**Trip Miles:** 78
+
+I woke up and caught the motel on fire. My alcohol stove liaks, you see, so when I placed it right outside the door of my second-story room it soaked the green carpet with alcohol. When I lit it, it exploded in a flame. I tried to blow it out to no avail. I knocked it over and flaming alcohol spilled out over more carpet. Flames were at least a foot high. I beat at it and finally got it under control, but the damage was done. The carpet was black and smoking. “Shit.” I said calmly. I quickly packed up my gear and got the hell out of there ASAP, tip-toeing over the office, down the steps, and one building down to a café.
+
+As I sipped my coffee and wrote, I kept waiting for the motel owner to come looking for me. Afterall, in a small town one can’t run far. The café door would squeak open and I’d brace for confrontation, over and over again. “The cops are here for you”, I suddenly heard the barista tell a regular. I tensed. Maybe cops were turning into the motel parking lot, which the café shared, to hunt the fleeing vandal. And sure enough, three cops entered and stood by the door looking at me. “Can I help you officers?”, said the barista, and the officers sat down for a doughnut. I breathed out.
+
+Looking over my shoulder, I crossed the street to the grocery store. I spent $33 for almost a week’s worth of food. Then I got a ride to the Blueberry Patch Hostel where the owner, Gary Potteat, turned me down at the driveway. “We’re just not finished yet. Maybe tomorrow.” He said kinda sorely. He’s a good Christian man who’s taken in thousands of hikers for no gain but ministry, so if he was sore I think it was because he had to turn down a hiker in need.
+
+I had only 60 some dollars left, so another night at the motel was out of the question, even if I hadn’t fled the burned carpet that morning. I had no where to go.
+
+The kind folks who gave me a ride (out of their way) to Blueberry Patch Hostel dropped me off at a church at the junction where they returned to their route to Atlanta to see their sick mother. I’ve always wanted to test out the church as a place of unconditional refuge, so I walked up to the office and knocked on the door. No answer. Just before walking back out to the road to thumb to another church, I noticed a small house on the corner of the church property. A pick-up was out front. I walked up and knocked, and to my surprise a younger man opened the door. He was hip-looking, sharp, kinda like a Young Life leader. “Let me see what I can do. Come on in.” I knelt down to pet the lab. “You know, I’m a thru-hiker back in 1996”. I couldn’t believe it. But the magic didn’t stop there. He said, “Follow me” and we walked over to the church. He flicked on the light in a room, “Wait in there and I’m gonna try to pull some strings,” he said, then disappeared. I read a bible for about five minutes, when a gleaming middle-aged woman walked in. “I’m Lynn”, she said. “I’m Gary’s wife, at the Blueberry Patch. We’re gonna get you a room in town.” I couldn’t believe it. Lynn, the gleaming secretary at the church, at which I fortuitously knocked, was the wife of the woner of the hostel where I’d just stopped, wife of a man who’s Christian kindness spread his name all the way to Richmond. And this connection was dropped in my lap by a sympathetic thru-hiking pastor. “We’re going to get you a room at Mull’s Motel”, she said. My stomach dropped. The burned carpet. That’s where I left the burned carpet. “Let me drive you to Mull’s” said the young pastor. We pulled in and I prepared for impact upon entering the cramped motel office. Fortunately, the 86 year old lady was still there in her nightgown, just like I’d seen her the evening before. And, (thanks to her age, perhaps) she didn’t remember me. I couldn’t believe it. I was redeemed. “I really don’t know how to thank you, man,” I said. “It just works out, doesn’t it”, he said. I think from time to time God has fun and wires things. Redemption of unbelievable cause-and-effect complexity. Even miracles. No, it’s not in his nature. It’s not all like that. Jesus spent but a sliver of his hours dropping jaws with these unbelievable occurances. Most of his days were spent walking around in the dust, telling people that, yeah..reality can be really boring but it’s okay. The miracles almost never happen around town but it doesn’t matter because the real miracle is deep within. The real wonder is the heart and soul of man. So, I won’t walk to Maine looking for him to wink at me again. I’ll keep looking within.
+
+Snow fell that night in Hiawasee, about 2 inches. I ate my trail mix and wrote oa letter to the Potteats from the warmth of my motel room. After two nights of comfort, I was ready to hit the trail again.
+
+---
+
+# Sunday, February 14, 2010 — Blueberry Patch Hostel
+**Start Location:** Mull's Motel (Hiawasee, GA)
+**Miles Today:** 0
+**Trip Miles:** 78
+
+After a "zero day" off the trail, I awoke again in Mull's Motel and gathered my things. A lady saw me and asked if I needed any fuel of supplies. Yes, I said. I needed denatured alcohol for my stove. She pointed towards an outfitter down the street and told me to meet her there. "We got some for ya." She drove her truck around the corner, parked out front and opened the door and led me in. "It's free," she said, pointed towards some steel cans of alcohol. "Just leave a little something in the Kitty." I dropped a couple quarters in a cat-shaped container, thanked her, and hitched to the Blueberry Patch Hostel. The owner Gary Poteat still hadn't opened for the season, but I needed to pick up a package my parents had shipped there. Gary's house is off a 45 mph highway, miles from the city. It's easy to get a ride there from the city, but hitching away is difficult. A nice guy in a pick-up dropped me off there and drove away. Nobody was home so I waited, but I quickly realized it was too cold to hang around. Back to the trail was my only option. I left a note and walked out to the road. I stuck out my thumb and tried to look cold and miserable.The more cold and miserable you look, the more likely a car is to stop. I think.
+
+After almost 30 minutes, around the bend came a pickup. It was slowing and it's turn signal was on. It was Gary and his wife, Lynna, returning from town. They pulled in. "I know yall aren't open yet. I just need a package before I go," I quickly said as they got out. I wanted to make it clear that I just needed a package, not more charity. He said he had it and added, "You're welcome to stay the night." I pretended not to hear. If he really meant it, he'd repeat the offer. Sure enough, he did. "Yeah, I'd love to." This meant another day's delay, a second "zero", but I didn't care. This was an experience I wanted to have. Back in Richmond, I'd heard of Gary, his hostel, and even his hiker-famous blueberry pancakes. It was worth a day lost.
+
+We chatted as he lit the wood stove in the bunkhouse. Gary was a talker, and told me some of his story in his cool, Georgia-accented voice. He thru-hiked in the 90's and felt the Lord's voice. "Open a hostel of your own," he heard. "Minister to hikers." He married, moved back to Georgia and bought a parcel off the AT. Ever since, he's taken in ragamuffin hikers like myself. I was the first of his 18th year.
+
+The telephone rang and he walked over an answered it. Another hiker was on his way. Soon, a familiar face appeared at the door. Keven, the Canadian I'd met on Blue Mountain, walked in the door. He was thrilled to see me. I was glad to see him.
+
+That night we went into Hiawasee. We bought food for the next stretch to Fontana Dam, a tedious process of diving out calories on price. Keven convinced me to share food together over the next two weeks--breakfast, lunch, and dinner. Sounded like a good idea. I mean, why not? We also got some steaks and asparagus to take back to cook. I bought a crispy Fuji apple. Back at the hostel, we ate heartily and stayed up until 1:00 dividing ten days of food weight.
+
+---

--- a/tests/fixtures/pilot_journal_10_facts.txt
+++ b/tests/fixtures/pilot_journal_10_facts.txt
@@ -1,0 +1,271 @@
+# Thursday, January 21, 2010 — Pre-Hike Planning
+**Start Location:** Gear List
+**Miles Today:** 0
+**Trip Miles:** 0
+
+I'm loading my pack and thinking of Lewis & Clark. Hell, how do you pack for an 5,000-plus march into the unknown? Start with alot of meat, apparently: the Corps packed "a ton of dried pork." Maybe I should bring a baggy of deer jerky.
+
+Food, fuel, shoes, and H20 aside, here's my gear list so far. Keep in mind, I'm going "ultra-light", which basically means I'm trying really hard to keep my pack as light as possible. Duh, right? That's called "common sense", not "ultra-light". Either way, I've slashed significant poundage, leaving my total weight at a skimpy 13.8 lbs!
+
+Anyways, please, give me feedback! Too much? Too little? Missing something?
+
+I-The Big Stuff
+
+Pack (Gossamer Gear Gorilla): 23.3 oz.
+
+Sleeping bag (0-degree GoLite Women's): 45 oz.
+
+Poncho/shelter (Sea-to-Summit): 12.7 oz.
+
+Thermarest (Thermarest ProLite Rig): 16.2 oz.
+
+II-Non-Clothes
+
+Stove (homemade alcohol): 2.1 oz.
+
+Bowl (silicone, 16 fl. oz.): 2.3 oz.
+
+Spork (LightMyFire): 0.5 oz
+
+Tent stakes (4): 2.8 oz.
+
+Latrine digger (MSR): 0.7 oz.
+
+Knife (Gerber): 7.8 oz.
+
+Headlamp (Petzl): 0.7 oz.
+
+Bible (ESV): 9.2 oz.
+
+Journal:
+
+Toothbrush & Floss: 1.5 oz.
+
+Mini-lighter: 1 oz.
+
+First Aid kit (8 BandAids, needle & thread, clothespin, Anti-biotic ointment, .5" medical tape, 5 ft. duct tape, 8 Advil, Moleskin, Gauze): 3.5 oz.
+
+Water bladder (Platypus): 3.5 oz.
+
+50 ft. parachute cord: 2.8 oz.
+
+Harmonica: 2.1 oz.
+
+Pipe & Tobacco: 6 oz.
+
+ID, cash, etc.: 2 oz.
+
+Bags (garbage, zip-lock):
+
+Compass: 1 oz.
+
+1 liter water bottle (Dasani): 1.5 oz.
+
+III-Clothes
+
+Baclava (Seirus): 2.8 oz.
+
+Long underwear bottoms (SmartWool, Merino): 7.8 oz.
+
+Long underwear top (Icebreaker, Merino): 13.5 oz.
+
+Rain shell pants (Marmot Precip): 12 oz.
+
+Rain shell jacket (North Face Venture): 13.5 oz.
+
+Gloves (REI): 2.1 oz.
+
+Down jacket (MontBell Alpine): 11.3 oz.
+
+Wool socks (REI, 3 pairs): 8.5 oz.
+
+Down booties (North Face): 12 oz.
+
+Beanie (normal): 2.8 oz.
+
+Liner socks (1 pair, Merino wool):
+
+It's a long list, indeed. Yet amazingly, it only comes out to only 13.8 lbs! I've still got a couple pounds to add...but still! Technology these days.
+
+---
+
+# Saturday, February 06, 2010 — Hike Inn
+**Start Location:** Amicalola Falls State Park
+**Miles Today:** 0
+**Trip Miles:** 0
+
+In the darkness we trudged on without words. After a late start, at 3:45pm, the trail took us up Amicalola Falls and higher into Frosty Mountain as dusk drew near. And Frosty it was, thanks to an ice storm that blew in the previous night, leaving the forest glassy and white. The ices thawed, shattered down from the trees overhead, and buried the trail in 2 inches of shards. Rain had fallen below at Amicalola State Park HQ where we set off, but up here the world was gripped in ice. the foul weather slowed progress - not only did we have to march through ice but detour around splintered branches and trees fallen across the trail. So by nightfall, there I was. Trudging by flashlight along the blue-blazed "approach trail", feeling tired of walking even before the white blazes began.
+
+I expected a damp and dismal shelter that night, but we stumbled across a glowing refuge in the middle of the woods: The Hiker Inn. the situation that night was by no means an emergency, but with my Dad and Morgan it seemed like one for some reason. Morgan was having knee problems and looked on the verge of tears, branches and trees were falling all around us, my hands were numb and it was pitch black for a cloud-covered moon. Emergency or not, we saw a trail sign for The Hiker Inn and decided to pull off. I expected a cold night on the front porch or in an old shed. What I found was a lone innkeeper offering a lamp-lit dwelling warmed by woodstove. All's well that ends well.
+
+Let's go back to where it all begins, to my weeping mother by the car in front of the house. I forget sometimes, how much I mean to people. I forget that I have the power to bring great joy and great sadness, that me going actually matters to someone. So when I put my arms around my mother and she started to cry, I was filled with this incredible sense that I was home, the only place in the world where I really mean something. There I was crucial. I guess it all comes back to love, something I've never really been able to put into words. All I can do is point to my mother and father, my two best friends in the whole world, without whom I would just be a scared little boy. They've brought me here. They've made me a man. and although I didn't think any of this at the time, it was painted so perfectly as I held my weeping mother by the car.
+
+That night we drove to South Carolina and stayed at a hotel. I stayed up late that night reading Thoreau out of my sister's Lit book. He rambles alot, but I liked the marrow part: "When I would recreate myself, I seek the darkest wood and most interminable swamp, and enter it as a sacred place, a sanctum sanctorum. Three is strength, the marrow of nature." I'm about to enter a dark season on an interminable trail, I said to myself, so the suffering is all to shine on that marrow. there is the heart of God. We ate at Cracker Barrel at 6:30 the next morning and then drove to Springer Mountain, "Southern Terminus to the Applachian Trail". I fell asleep in the backseat and awoke to the Amicalola State Park HQ, gateway to the Springer Mountain trail. I registered, weighed my pack, and hit the blue-blazed approach trail to the Springer's summit. 8.8 miles. It was 3:45pm. the trail led into ice, night fell, and we ended up in The Hikers Inn warm log-cabin lobby. We met Stanley, the innkeeper and former A.T. thru-hiker himself, who started up the wood stove and offered me advice for my own hike. I was so fortunate to be there with my father and sister, really enjoying our time together. That was the only thing on my mind that night before I began my 2,000 mile trek to Maine.
+
+---
+
+# Sunday, February 07, 2010 — Hawk Mountain Shelter
+**Start Location:** Hike Inn
+**Miles Today:** 9
+**Trip Miles:** 9
+
+We parted ways at 10:00am. My father and sister walked out the door like I’ve seen them do so many times this past month, but this time I wouldn’t wee them return that evening. This was different. It was hard saying goodbye at what I knew was an exit from their lives for the next six months, before I’d go off and live my life and they’d go off and live theirs. As they walked out the door and out of view, I felt just about as lonely as I’d ever felt. I kind of wanted to chase them but that would be too embarrassing. So I sat there, trying to nap but unable. I think it was because I was alone now and knew it, making me uncomfortable and on edge. From here on out it’ll be like that, more or less, with my guard up full-time. I need to stop writing about this or it’ll get to me.
+
+By 10:30 I was at it, trudging through the aftermath of the ice storm, slipping and sliding in the snow and ice and trying not to yell curse words at the huge limbs blocking the trail. It was slow and painful to the summit of Springer Mountain, by 1:00 I was there, wiping snow off the plaque that read, “Southern Terminus of the Appalachian Trail”. It was too cold and windy to relish the moment, so I marched down to the gap for a break. From there to the shelter, elevation decreased and trail conditions improved. No more ice. No more debris to climb over. Just 2” of snow to stomp down. My spirits immediately brightened as well.
+
+At a shelter, I took a nap and ate. It was only 3:00 by then, so I decided to hoof it to the next shelter, 5.5 miles away. This leg turned out to be in perfect shape. I shot through at a steady 3 mph, descending into an amazing ravine of rhododendron and amazing old growth hemlocks. Some were 300 years old and 5 feet thick, I later learned.
+
+Walking through those holy trees was the highlight of my day. I reached Hawk Mountain shelter before sundown, totaling 9 miles that day. I ran down to the stream to get water, cooked, strung up a bear bag, and wrote for an hour by candlelight. I drifted off and had a strange demon dream where Satan was in my head and barking at me so I couldn’t think, and then I flooded him out by begging God to intervene and jerked awake. After that I was spooked and couldn’t drift off. The mice, in their audacious fashion, ran all over me and all over my stuff, flatly ignoring both my yells and the beams of my flashlight. I slept well that night.
+
+[First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/301866) [Next](https://www.trailjournals.com/journal/entry/301868) [Last](https://www.trailjournals.com/journal/entry/318948)
+
+---
+---
+date: '2010-02-08'
+title: Gooch Mountain Shelter
+start_location: Hawk Mountain Shelter
+destination: Gooch Mountain Shelter
+miles_hiked: 14.0
+total_miles: 23.0
+state: Georgia
+at_mile_start: 8.1
+at_mile_end: 15.8
+weather_high_f: 44.2
+weather_low_f: 27.2
+weather_precip_in: 0.0
+weather_conditions: Overcast
+weather_source: Open-Meteo archive
+trail_section_summary: Hawk Mountain Shelter (AT mile ~8) is an early overnight stop
+  in Georgia's Blue Ridge. Gooch Mountain Shelter (AT mile ~16) is a popular early
+  multi-day destination for northbound hikers.
+weather_summary: High 44°F, low 27°F. Overcast.
+facts_confidence: 0.9
+---
+# Monday, February 08, 2010 — Gooch Mountain Shelter
+**Start Location:** Hawk Mountain Shelter
+**Miles Today:** 14
+**Trip Miles:** 23
+
+I woke up at 8:30 and saw a huge red woodpecker which made me smile. By 9:15, I was on the trail strong and fast to my destination 20 miles away. The trail was gradual and I was happy to be on it, hoofing towards Maine. About an hour passed wuntil I realized I was going in the wrong direction. I cursed aloud. I cursed aloud again. And you know how I realized it? “Cool, that guy’s shoe tracks look just like mine. I wonder if he has the same ….oh shit.”
+
+So after logging a total of 6 idiot miles, I was once again back at the shelter. It was 11:15. I took a nap had breakfast, dressed a blister, then set off again towards the next shelter 8 miles away (I gave up on 20 miles after losing so much daylight). And this time I was going North.
+
+Still, the mountain was white out – all white in snow, fog, and sky – and the temperature was still 23F from that morning. But very quickly, the bad weather lifted. The sky cleared, temperatures rose, and somehow the trail was 100% cleared for the nearly all 8 miles. The sun out and surrounding mountains visible, I stopped for a second and though about how they chase the phrase “Appalachian Scenic Trail”: this was no forced march like I’d been treating it that day. It was a scenic route, carved for the likes of Thoreau’s saunterer traveling to the Holy Land. Then I thought of how fortunate I was to be there on that mountain. I could’ve been a lot of other places – like stuck at work or school, in a wheelchair, or in the twisted metal of a car on the side of River Road- like should’ve happened so many times. So here’s to a blessing. “I’m goin’ to Maine!” I said laughing. “I’m goin’ to Maine!”
+
+At dusk, at the shelter, I finished dinner and let the fire die down to dull embers. In his classic hiker’s manual, The Walker’s Handbook, Colin Fletcher let it die from time to time, to let the darkness surround you. There’s nothing as pure and powerful he said, as darkness deep in the woods. So I stood on the porch of the shelter and let everything go black around me. The wind blew in the trees and it was eerily quiet. “Say something” I said to God. I didn’t know whether to expect something good to happen or something bad, because I’ve found that he’s speaking all the time in the strangest ways, and he’s found in both the happy and the hard. I stood there for a long time, dreaming not thinking about all the blackness. It was addicting. It cozied the mind and numbed it over, like the way you cease when you finally arrive home. I was at home, in the wooded blackness. After half an hour, I retired to my sleeping bag and fell asleep.
+---
+
+# Tuesday, February 09, 2010 — Neel Gap Hostel
+**Start Location:** Gooch Mountain Shelter
+**Miles Today:** 15.50
+**Trip Miles:** 38.50
+
+In the morning, I awoke before 8:00 and prepared to leave. It was very cold, but off I went towards Neels Gap. After several hours I passed through Woody Gap, where I met a middle-aged couple on a geo mission. The man took my photo with his iphone and emailed it to my mom and dad. They lady kept looking at me like she wished she had a son of her own. My first run in with Trail Magic!
+
+It was 11:00 and I continued on up to the ominously titled Blood Mountain. Cherokee and Creek warriors met head to head on these slopes, leaving so many dead that the streams ran red with blood. On the way up, I passed homeless and unemployed, two 2001 thru-hikers on a stroll for the day. Two of the nicest hippies I’ve ever met. The man really wanted to give me tips and advice and the woman was beaming at me the whole time. I’m not entirely sure why, but that couple filled me up with so much positive energy.
+
+Down into the next gap, I began to micro-nap. I don’t know how long it lasted, but I continued to twist my ankle and walk off the trail, and even hallucinate (I saw my dad’s face in a poplar tree, even double-taking to make sure) until, at last, I threw down my pack and collapsed trailside for a deep, hour long nap.
+
+Blood Mountain wasn’t too difficult. It climbed up and over several false summits and finally wound up into a rocky, rhododendron covered peak. The wind was steady and snow was still on the ground. I Exploded off the trail and shot down the mountain (small birds for once played in the rhododendron). I found cougar tracks. An ornery, cantankerous skunk was said to occupy the mountaintop shelter, and a bear had reportedly been “hanging out” around the summit. To accentuate the sense of wildness was the narrow trail itself, which tunneled through the rhododendron and crawled over mossy rocks. On the summit’s main rocky outcrop, I saw the entire North Georgia Mountains rolling out and a pink and purple sunset over them. The CCC constructed shelter, a 2 room stone edifice complete with windows and a fireplace. Still, drafts of cold wind kept the shelter far from cozy, so I gambled on finding a free place to stay and moved on down the mountain to Neels Gap.
+
+I reached Neels Gap outfitter by 5 o’clock, closing time, but fortunately the Hiker Hostel was open. There were several men milling about, all with foot-long gray beards and long hair. A long beard means one thing in the mountains - experience- so, naturally, I was excited to spend a night with the experts. The price was only $15, said one bearded man, with the possibility of working it off. I sat down inside and wrote while another bearded man prepared tacos and rambled on about how “everything was going to shit” thanks to an enforcement of state ordinances. Two more bearded men walked in the door and dissappeared out the back. “Can you shoot a cougar?” I asked. “Sure, I don’t see why not. But if they catch you they’ll throw you in jail”, said one of the gnarliest of the bunch. Then he let out a long calm laugh and started talking to the cats. “Come get dinner,” he said after awhile, “or the cats’ll get to it. Actually, they already have.” He laughed at that.
+
+After dinner I boiled some tea and sat by the heater to write in my journal. In ten minutes I was curled up in the chair asleep. It was so nice being warm.
+
+---
+
+# Wednesday, February 10, 2010 — Low Gap Shelter
+**Start Location:** Neel Gap Hostel
+**Miles Today:** 11
+**Trip Miles:** 49.50
+
+In the morning I got up at 6:15 to get a hot shower before the others did, then sat by the heater and read a book about trees. At 9:00, I packed up, and walked up to the outfitters. I asked to do some work to pay off my stay, but the owner wasn’t there so I settled up to save time. I hit the trail just before 10, just as the rains came.
+
+That day was divided sharply between great and God-awful. The first half, the great part, flew past as I hoofed without stopping through the wind and rain. 6 miles over to Tesnatee Gap. I went hard and strong and felt like a champ. But after a short stop at Tesnatee, things fell apart. During the stop, I’d quickly lost all doby and hand heart and became a numb-fingered, shivering - and , not to mention, dripping wet – mess. My hands lost the benign feeling of numbness and began to hurt like someone was bending them back. Groaning aloud and cursing, I began to march. I won’t go into details because the next 4 hours was a drama of the most boring kind. I’ll just say it really sucked and skip to the moment with God, which occurred near the end of the ordeal. I was mouthing off at him again (aloud, mind you), not really making a case but just pissed at the day’s suffering. I had to yell at someone. I told h im to make it okay, or at least give me the big picture so I could at least calm down. All of the sudden, I said it aloud, “This is all part of it”. This is part of the Good, the adventure, the chase after an elusive Spirit. This very moment of numb hands, wet clothes and stabbing blisters was the very reason I set off. Because this is Thoreau’s “marrow of life”, and in it I will find my God.
+
+I went to sleep that night with no idea what to do about my blisters for the next day. The wind picked up and a fog rolled in and the night was all dense blackness and I thought to myself about the old proverb “When I saw I stumbled.”
+
+---
+---
+date: '2010-02-11'
+title: EconoLodge Motel (Helen, GA)
+start_location: Low Gap Shelter
+destination: EconoLodge Motel (Helen, GA)
+miles_hiked: 13.5
+total_miles: 63.0
+weather_high_f: 42.5
+weather_low_f: 24.5
+weather_precip_in: 0.0
+weather_conditions: Overcast
+weather_source: Open-Meteo archive
+trail_section_summary: Trail section from Low Gap Shelter to EconoLodge Motel (Helen,
+  GA).
+weather_summary: High 42°F, low 24°F. Overcast.
+facts_confidence: 0.5
+---
+# Thursday, February 11, 2010 — EconoLodge Motel (Helen, GA)
+**Start Location:** Low Gap Shelter
+**Miles Today:** 13.50
+**Trip Miles:** 63
+
+That was a rough night. The temperature plummeted, freezing to rock everything in the shelter I thought was safe – my water bottles, my boots, my clothes. Snow flurries blew in while I slept and covered my down sleeping bag, soaking into the goosedown inside and forming a shell of ice on the surface. As a result, my feet went numb. I awoke cold and discouraged. I fumbled with numb hands to gather my gear and apply my moleskin. My boots were too frozen to put on so I screamed at God in the ravine “What the hell am I supposed to do??” I put on my down booties and started walking.
+
+To my surprise, the down booties did an excellent job. By the time I reached the Blue Mountain Shelter, I had marched through 8 miles of snow and ice and my feet felt great. Close to the summit the wind blasted through the trees. It filled the ears like deafening static. “C’mon! C’mon!” I yelled exhilarated by the struggle against the elements. At the summit shelter, I found an old-timer with his dog and Kevin, a young thru-hiker. “Fire!”, I said, seeing the wind ripping smoke out of the fire pit. “How’d you pull that off?” Kevin was knelt by the fire. He grinned like it was no big deal. “Sticks and fire”. Then he laughed. “Respect”, I said, I asked for more details. The old-timer had a long beard and a weathered face. He was smoking a Backwoods cigar. As it were, the two were holed up in the shelter because the next peak on the trail, Tray Mountain, was demolished by a terrible ice storm. The trail was impassable, said the old-timer; he had tried. The company was nice, especially by two with more knowledge of mountain survival than I. “So where’d you learn to make a fire in the snow?”, I asked. Kevin had been a hunting guide in British Columbia for half of the year, for the past six years, and had “pulled out bodies” from the snow many times. I told him of the previous night’s problems and asked for advice, “The learning curve in the cold is steep, bro” he said grinning. He was really impressed by my light pack. “Hats off to you, mate. Especially in cold weather.”
+
+I gave Kevin some cheese, warmed my hands up by the fire, and marched on down to Unicoi Gap to hitch into town. Dry gear and a warm motel were in high demand. After a minute of thumbing a black car pulled over. Alex, a gay artist on his way to see his boyfriend, was glad to drive me around town to check various motel prices. He was “paying back a favor, or paying it forward, whichever one” He said in his hometown, Hayesville, NC, alcohol had just become legal last month. He had been a vocal advocate. His father, a Baptist minister, had led the opposition. I laughed. Alex said goodbye at the EconoLodge, and I fell asleep on my $30/night bed. I woke up, took a shower, called home, and ate some shrimp ramen with tuna and olive oil. Everyone seemed fine at home, like they’d moved on without me as I’m accustomed to them doing. When you’re away, all you can really say is “I love you” or “I miss you” but those words don’t mean much. It still kinda sucks. I thought about that while I ate my ramen. That night I watched a cheesy movie about aliens. I just didn’t feel like writing.
+---
+
+# Friday, February 12, 2010 — Mull's Motel (Hiawasee, GA)
+**Start Location:** EconoLodge Motel (Helen, GA)
+**Miles Today:** 15
+**Trip Miles:** 78
+
+At 6:15 the next morning, I was packing my gear up. It was all so warm and dry. I wrote until 7 o’clock then went to breakfast. Ron, the on-duty manager, was fiddling around with setting up breakfast. He rambled on about how dismal Richmond was for various reasons, including one story about two hookers begging him for crack money. Another story involved drug-running and leaving town after a 6’5” friend fooled around with some other guy’s girlfriend. “I gotta ask you something”, he said. “Are you carrying a gun?”
+
+After breakfast, I dressed my blisters. I bought moleskin at Randy’s pharmacy and the lady let me sit inside to apply it. Randy gave me free blister tape: Trail Magic! “Stay as long as you want, I’d let you lay out and take a nap if we still had those mattresses!”
+
+I walked out to the road and stuck out my thumb. Believe it or not, Ron pulled over. He rambled about me burning ukp all his gas money, running a homeless shelter, how “he don’t pay me shit” at his job and the yars he spent with black ops in Vietnam. “I help people like you out because of what I done to all them”, he said looking skyward. “You wouldn’t believe the sniper rifles they got these days,” he said next. Ron was a good man, a wreck but worth every penny. I’m glad I met him. “I can’t afford to burn all this gas,” he said. “But I need to get up into these mountains. It’s beautiful”. I got out and slammed the door at the trailhead. He rolled down his window and yelled for me. “Hey, hey…I’ve gotta ask you a question.” “Do you ever see things up there that you’d never see down here?” I said “Yes, you do.”
+
+That day on the trail was great. I passed one hiker after another, meeting and greeting and exchanging trail info. I first passed Ryan, another thru-hiker. He’d been laid off, but luckily gotten into law school, and, with his wife’s permission, took off on the A.T. during the layover. He had a nice North Carolina draw. “I’m one of those slow, deliberate people”, he said as I passed. “Yeah,” I laughed. “You’ll probably pass me napping in the next shelter”. Next, I passed three sturdy men moving in the opposite direction. They were older, yet were “tougher than your average weekenders” as they assured, and seemed it. They were impressed by my ultralight pack. On my way up Tray Mountain, I passed an older fellow coming down. Dave Herring was in his 60’s and still climbing Georgia’s mountains, meeting up with thru-hikers and helping them along the way. A full-time Trail Angel, you might say. Today, he escorted two thru-hikers up and over Tray Mountain (remember, the trail was all but wiped out by the storm). For two separate nights, Dave had brought the hikers homecooked dinner, a warm bed, and a place to watch the Super Bowl. For three days, he had brought in two thru-hikers for hot meals, beds, and a Super Bowl party while icy conditions on Tray Mountain improved. Today, he escorted them up and over the mountain. He used to be a big runner, he said, but had lost cartilage in his knee. Now, he was down to just day-hiking for he and his wife. I was overwhelmed with gratitude for this man and his wife, for people who give themselves so fully to the strangers passing through. I’m talking about the A.T.’s host of Angels, and they’re watching over our road north.
+
+After a long nap at the top of Tray, I passed two thru-hikers, Fauma and Second Stage, on the way down the mountain (when I say “down the mountain”, I’m referring t the many ups and downs between a summit and a gap. Rarely is there black-and-white ascent and descent on the AT). All day, I’d been tracking their prints through the snow and around the debris. Catching up to them was the climax of the day. “You hear about these hikers ahead of you and you read all their entries in the shelter journals. You start to paint a mental picture of them,” I told Fauma when I caught him. “It’s kinda like online dating.” He laughed, “Wow, guy”.
+
+My eyes were set on Dicks Creek Gap, still 5.5 miles away by dusk. I flicked on my headlamp, chugged some orange juice and kept trucking. My legs were tired and my feet sore from walking in my booties for 8 miles already. I made it by 7:30 and hitched a ride into Hiawasee by 8pm. I got a motel room for $50 despite efforts at bargaining. I walked across the street to Hardee’s for dinner. I wrote, took a hot shower, and fell asleep by 11:00 with the lights on.
+
+---
+
+# Saturday, February 13, 2010 — Mull's Motel (Hiawasee, GA)
+**Start Location:** Mull's Motel (Hiawasee, GA)
+**Miles Today:** 0
+**Trip Miles:** 78
+
+I woke up and caught the motel on fire. My alcohol stove liaks, you see, so when I placed it right outside the door of my second-story room it soaked the green carpet with alcohol. When I lit it, it exploded in a flame. I tried to blow it out to no avail. I knocked it over and flaming alcohol spilled out over more carpet. Flames were at least a foot high. I beat at it and finally got it under control, but the damage was done. The carpet was black and smoking. “Shit.” I said calmly. I quickly packed up my gear and got the hell out of there ASAP, tip-toeing over the office, down the steps, and one building down to a café.
+
+As I sipped my coffee and wrote, I kept waiting for the motel owner to come looking for me. Afterall, in a small town one can’t run far. The café door would squeak open and I’d brace for confrontation, over and over again. “The cops are here for you”, I suddenly heard the barista tell a regular. I tensed. Maybe cops were turning into the motel parking lot, which the café shared, to hunt the fleeing vandal. And sure enough, three cops entered and stood by the door looking at me. “Can I help you officers?”, said the barista, and the officers sat down for a doughnut. I breathed out.
+
+Looking over my shoulder, I crossed the street to the grocery store. I spent $33 for almost a week’s worth of food. Then I got a ride to the Blueberry Patch Hostel where the owner, Gary Potteat, turned me down at the driveway. “We’re just not finished yet. Maybe tomorrow.” He said kinda sorely. He’s a good Christian man who’s taken in thousands of hikers for no gain but ministry, so if he was sore I think it was because he had to turn down a hiker in need.
+
+I had only 60 some dollars left, so another night at the motel was out of the question, even if I hadn’t fled the burned carpet that morning. I had no where to go.
+
+The kind folks who gave me a ride (out of their way) to Blueberry Patch Hostel dropped me off at a church at the junction where they returned to their route to Atlanta to see their sick mother. I’ve always wanted to test out the church as a place of unconditional refuge, so I walked up to the office and knocked on the door. No answer. Just before walking back out to the road to thumb to another church, I noticed a small house on the corner of the church property. A pick-up was out front. I walked up and knocked, and to my surprise a younger man opened the door. He was hip-looking, sharp, kinda like a Young Life leader. “Let me see what I can do. Come on in.” I knelt down to pet the lab. “You know, I’m a thru-hiker back in 1996”. I couldn’t believe it. But the magic didn’t stop there. He said, “Follow me” and we walked over to the church. He flicked on the light in a room, “Wait in there and I’m gonna try to pull some strings,” he said, then disappeared. I read a bible for about five minutes, when a gleaming middle-aged woman walked in. “I’m Lynn”, she said. “I’m Gary’s wife, at the Blueberry Patch. We’re gonna get you a room in town.” I couldn’t believe it. Lynn, the gleaming secretary at the church, at which I fortuitously knocked, was the wife of the woner of the hostel where I’d just stopped, wife of a man who’s Christian kindness spread his name all the way to Richmond. And this connection was dropped in my lap by a sympathetic thru-hiking pastor. “We’re going to get you a room at Mull’s Motel”, she said. My stomach dropped. The burned carpet. That’s where I left the burned carpet. “Let me drive you to Mull’s” said the young pastor. We pulled in and I prepared for impact upon entering the cramped motel office. Fortunately, the 86 year old lady was still there in her nightgown, just like I’d seen her the evening before. And, (thanks to her age, perhaps) she didn’t remember me. I couldn’t believe it. I was redeemed. “I really don’t know how to thank you, man,” I said. “It just works out, doesn’t it”, he said. I think from time to time God has fun and wires things. Redemption of unbelievable cause-and-effect complexity. Even miracles. No, it’s not in his nature. It’s not all like that. Jesus spent but a sliver of his hours dropping jaws with these unbelievable occurances. Most of his days were spent walking around in the dust, telling people that, yeah..reality can be really boring but it’s okay. The miracles almost never happen around town but it doesn’t matter because the real miracle is deep within. The real wonder is the heart and soul of man. So, I won’t walk to Maine looking for him to wink at me again. I’ll keep looking within.
+
+Snow fell that night in Hiawasee, about 2 inches. I ate my trail mix and wrote oa letter to the Potteats from the warmth of my motel room. After two nights of comfort, I was ready to hit the trail again.
+
+---
+
+# Sunday, February 14, 2010 — Blueberry Patch Hostel
+**Start Location:** Mull's Motel (Hiawasee, GA)
+**Miles Today:** 0
+**Trip Miles:** 78
+
+After a "zero day" off the trail, I awoke again in Mull's Motel and gathered my things. A lady saw me and asked if I needed any fuel of supplies. Yes, I said. I needed denatured alcohol for my stove. She pointed towards an outfitter down the street and told me to meet her there. "We got some for ya." She drove her truck around the corner, parked out front and opened the door and led me in. "It's free," she said, pointed towards some steel cans of alcohol. "Just leave a little something in the Kitty." I dropped a couple quarters in a cat-shaped container, thanked her, and hitched to the Blueberry Patch Hostel. The owner Gary Poteat still hadn't opened for the season, but I needed to pick up a package my parents had shipped there. Gary's house is off a 45 mph highway, miles from the city. It's easy to get a ride there from the city, but hitching away is difficult. A nice guy in a pick-up dropped me off there and drove away. Nobody was home so I waited, but I quickly realized it was too cold to hang around. Back to the trail was my only option. I left a note and walked out to the road. I stuck out my thumb and tried to look cold and miserable.The more cold and miserable you look, the more likely a car is to stop. I think.
+
+After almost 30 minutes, around the bend came a pickup. It was slowing and it's turn signal was on. It was Gary and his wife, Lynna, returning from town. They pulled in. "I know yall aren't open yet. I just need a package before I go," I quickly said as they got out. I wanted to make it clear that I just needed a package, not more charity. He said he had it and added, "You're welcome to stay the night." I pretended not to hear. If he really meant it, he'd repeat the offer. Sure enough, he did. "Yeah, I'd love to." This meant another day's delay, a second "zero", but I didn't care. This was an experience I wanted to have. Back in Richmond, I'd heard of Gary, his hostel, and even his hiker-famous blueberry pancakes. It was worth a day lost.
+
+We chatted as he lit the wood stove in the bunkhouse. Gary was a talker, and told me some of his story in his cool, Georgia-accented voice. He thru-hiked in the 90's and felt the Lord's voice. "Open a hostel of your own," he heard. "Minister to hikers." He married, moved back to Georgia and bought a parcel off the AT. Ever since, he's taken in ragamuffin hikers like myself. I was the first of his 18th year.
+
+The telephone rang and he walked over an answered it. Another hiker was on his way. Soon, a familiar face appeared at the door. Keven, the Canadian I'd met on Blue Mountain, walked in the door. He was thrilled to see me. I was glad to see him.
+
+That night we went into Hiawasee. We bought food for the next stretch to Fontana Dam, a tedious process of diving out calories on price. Keven convinced me to share food together over the next two weeks--breakfast, lunch, and dinner. Sounded like a good idea. I mean, why not? We also got some steaks and asparagus to take back to cook. I bought a crispy Fuji apple. Back at the hostel, we ate heartily and stayed up until 1:00 dividing ten days of food weight.
+
+---

--- a/tests/fixtures/pilot_journal_10_facts.txt
+++ b/tests/fixtures/pilot_journal_10_facts.txt
@@ -1,3 +1,13 @@
+---
+date: '2010-01-21'
+start: Gear List
+destination: Pre-Hike Planning
+miles_today: 0.0
+trip_miles: 0.0
+facts:
+  trail_section: Trail section from Gear List to Pre-Hike Planning.
+  confidence: low
+---
 # Thursday, January 21, 2010 — Pre-Hike Planning
 **Start Location:** Gear List
 **Miles Today:** 0
@@ -86,9 +96,30 @@ Beanie (normal): 2.8 oz.
 Liner socks (1 pair, Merino wool):
 
 It's a long list, indeed. Yet amazingly, it only comes out to only 13.8 lbs! I've still got a couple pounds to add...but still! Technology these days.
-
 ---
-
+---
+date: '2010-02-06'
+start: Amicalola Falls State Park
+destination: Hike Inn
+miles_today: 0.0
+trip_miles: 0.0
+facts:
+  weather: High 39°F, low 34°F. Slight snow.
+  trail_section: Amicalola Falls State Park is the traditional starting gateway for
+    northbound AT thru-hikers. The 8.5-mile Approach Trail from Amicalola Falls gains
+    substantial elevation to reach Springer Mountain. Amicalola Falls at 729 feet
+    is one of the tallest cascading waterfalls in the eastern United States. The Hike
+    Inn is a backcountry eco-lodge accessible only on foot via a 5-mile trail near
+    Amicalola Falls. The Hike Inn sits within sight of the AT approach corridor through
+    classic Blue Ridge hardwood forest. The Georgia AT traverses the southern Blue
+    Ridge Mountains, crossing several 4,000-foot summits in ~76 miles. Georgia's AT
+    features rocky ridgelines alternating with dense hardwood forest typical of the
+    southern Appalachians.
+  confidence: high
+  sources:
+  - AT location database
+  - Open-Meteo archive
+---
 # Saturday, February 06, 2010 — Hike Inn
 **Start Location:** Amicalola Falls State Park
 **Miles Today:** 0
@@ -101,9 +132,28 @@ I expected a damp and dismal shelter that night, but we stumbled across a glowin
 Let's go back to where it all begins, to my weeping mother by the car in front of the house. I forget sometimes, how much I mean to people. I forget that I have the power to bring great joy and great sadness, that me going actually matters to someone. So when I put my arms around my mother and she started to cry, I was filled with this incredible sense that I was home, the only place in the world where I really mean something. There I was crucial. I guess it all comes back to love, something I've never really been able to put into words. All I can do is point to my mother and father, my two best friends in the whole world, without whom I would just be a scared little boy. They've brought me here. They've made me a man. and although I didn't think any of this at the time, it was painted so perfectly as I held my weeping mother by the car.
 
 That night we drove to South Carolina and stayed at a hotel. I stayed up late that night reading Thoreau out of my sister's Lit book. He rambles alot, but I liked the marrow part: "When I would recreate myself, I seek the darkest wood and most interminable swamp, and enter it as a sacred place, a sanctum sanctorum. Three is strength, the marrow of nature." I'm about to enter a dark season on an interminable trail, I said to myself, so the suffering is all to shine on that marrow. there is the heart of God. We ate at Cracker Barrel at 6:30 the next morning and then drove to Springer Mountain, "Southern Terminus to the Applachian Trail". I fell asleep in the backseat and awoke to the Amicalola State Park HQ, gateway to the Springer Mountain trail. I registered, weighed my pack, and hit the blue-blazed approach trail to the Springer's summit. 8.8 miles. It was 3:45pm. the trail led into ice, night fell, and we ended up in The Hikers Inn warm log-cabin lobby. We met Stanley, the innkeeper and former A.T. thru-hiker himself, who started up the wood stove and offered me advice for my own hike. I was so fortunate to be there with my father and sister, really enjoying our time together. That was the only thing on my mind that night before I began my 2,000 mile trek to Maine.
-
 ---
-
+---
+date: '2010-02-07'
+start: Hike Inn
+destination: Hawk Mountain Shelter
+miles_today: 9.0
+trip_miles: 9.0
+facts:
+  weather: High 40°F, low 23°F. Slight snow.
+  trail_section: The Hike Inn is a backcountry eco-lodge accessible only on foot via
+    a 5-mile trail near Amicalola Falls. The Hike Inn sits within sight of the AT
+    approach corridor through classic Blue Ridge hardwood forest. Hawk Mountain Shelter
+    sits at roughly AT mile 8 from Springer Mountain in the Georgia Blue Ridge. The
+    trail between Springer Mountain and Hawk Mountain traverses rocky ridgeline sections
+    through hardwood forest. The Georgia AT traverses the southern Blue Ridge Mountains,
+    crossing several 4,000-foot summits in ~76 miles. Georgia's AT features rocky
+    ridgelines alternating with dense hardwood forest typical of the southern Appalachians.
+  confidence: high
+  sources:
+  - AT location database
+  - Open-Meteo archive
+---
 # Sunday, February 07, 2010 — Hawk Mountain Shelter
 **Start Location:** Hike Inn
 **Miles Today:** 9
@@ -118,28 +168,29 @@ At a shelter, I took a nap and ate. It was only 3:00 by then, so I decided to ho
 Walking through those holy trees was the highlight of my day. I reached Hawk Mountain shelter before sundown, totaling 9 miles that day. I ran down to the stream to get water, cooked, strung up a bear bag, and wrote for an hour by candlelight. I drifted off and had a strange demon dream where Satan was in my head and barking at me so I couldn’t think, and then I flooded him out by begging God to intervene and jerked awake. After that I was spooked and couldn’t drift off. The mice, in their audacious fashion, ran all over me and all over my stuff, flatly ignoring both my yells and the beams of my flashlight. I slept well that night.
 
 [First](https://www.trailjournals.com/journal/entry/301865) [Previous](https://www.trailjournals.com/journal/entry/301866) [Next](https://www.trailjournals.com/journal/entry/301868) [Last](https://www.trailjournals.com/journal/entry/318948)
-
 ---
 ---
 date: '2010-02-08'
-title: Gooch Mountain Shelter
-start_location: Hawk Mountain Shelter
+start: Hawk Mountain Shelter
 destination: Gooch Mountain Shelter
-miles_hiked: 14.0
-total_miles: 23.0
-state: Georgia
-at_mile_start: 8.1
-at_mile_end: 15.8
-weather_high_f: 44.2
-weather_low_f: 27.2
-weather_precip_in: 0.0
-weather_conditions: Overcast
-weather_source: Open-Meteo archive
-trail_section_summary: Hawk Mountain Shelter (AT mile ~8) is an early overnight stop
-  in Georgia's Blue Ridge. Gooch Mountain Shelter (AT mile ~16) is a popular early
-  multi-day destination for northbound hikers.
-weather_summary: High 44°F, low 27°F. Overcast.
-facts_confidence: 0.9
+miles_today: 14.0
+trip_miles: 23.0
+facts:
+  weather: High 44°F, low 27°F. Overcast.
+  trail_section: Hawk Mountain Shelter sits at roughly AT mile 8 from Springer Mountain
+    in the Georgia Blue Ridge. The trail between Springer Mountain and Hawk Mountain
+    traverses rocky ridgeline sections through hardwood forest. Gooch Mountain Shelter
+    near AT mile 16 is a popular first multi-night destination for northbound thru-hikers.
+    The trail from Hawk Mountain to Gooch Mountain crosses Justus Creek and climbs
+    through mixed hardwood forest. The Gooch Mountain area receives heavy hiker traffic
+    in early spring during thru-hiking season. The Georgia AT traverses the southern
+    Blue Ridge Mountains, crossing several 4,000-foot summits in ~76 miles. Georgia's
+    AT features rocky ridgelines alternating with dense hardwood forest typical of
+    the southern Appalachians.
+  confidence: high
+  sources:
+  - AT location database
+  - Open-Meteo archive
 ---
 # Monday, February 08, 2010 — Gooch Mountain Shelter
 **Start Location:** Hawk Mountain Shelter
@@ -154,7 +205,26 @@ Still, the mountain was white out – all white in snow, fog, and sky – and th
 
 At dusk, at the shelter, I finished dinner and let the fire die down to dull embers. In his classic hiker’s manual, The Walker’s Handbook, Colin Fletcher let it die from time to time, to let the darkness surround you. There’s nothing as pure and powerful he said, as darkness deep in the woods. So I stood on the porch of the shelter and let everything go black around me. The wind blew in the trees and it was eerily quiet. “Say something” I said to God. I didn’t know whether to expect something good to happen or something bad, because I’ve found that he’s speaking all the time in the strangest ways, and he’s found in both the happy and the hard. I stood there for a long time, dreaming not thinking about all the blackness. It was addicting. It cozied the mind and numbed it over, like the way you cease when you finally arrive home. I was at home, in the wooded blackness. After half an hour, I retired to my sleeping bag and fell asleep.
 ---
-
+---
+date: '2010-02-09'
+start: Gooch Mountain Shelter
+destination: Neel Gap Hostel
+miles_today: 15.5
+trip_miles: 38.5
+facts:
+  weather: High 40°F, low 34°F. Slight rain.
+  trail_section: Gooch Mountain Shelter near AT mile 16 is a popular first multi-night
+    destination for northbound thru-hikers. The trail from Hawk Mountain to Gooch
+    Mountain crosses Justus Creek and climbs through mixed hardwood forest. The Gooch
+    Mountain area receives heavy hiker traffic in early spring during thru-hiking
+    season. The Georgia AT traverses the southern Blue Ridge Mountains, crossing several
+    4,000-foot summits in ~76 miles. Georgia's AT features rocky ridgelines alternating
+    with dense hardwood forest typical of the southern Appalachians.
+  confidence: high
+  sources:
+  - AT location database
+  - Open-Meteo archive
+---
 # Tuesday, February 09, 2010 — Neel Gap Hostel
 **Start Location:** Gooch Mountain Shelter
 **Miles Today:** 15.50
@@ -171,9 +241,20 @@ Blood Mountain wasn’t too difficult. It climbed up and over several false summ
 I reached Neels Gap outfitter by 5 o’clock, closing time, but fortunately the Hiker Hostel was open. There were several men milling about, all with foot-long gray beards and long hair. A long beard means one thing in the mountains - experience- so, naturally, I was excited to spend a night with the experts. The price was only $15, said one bearded man, with the possibility of working it off. I sat down inside and wrote while another bearded man prepared tacos and rambled on about how “everything was going to shit” thanks to an enforcement of state ordinances. Two more bearded men walked in the door and dissappeared out the back. “Can you shoot a cougar?” I asked. “Sure, I don’t see why not. But if they catch you they’ll throw you in jail”, said one of the gnarliest of the bunch. Then he let out a long calm laugh and started talking to the cats. “Come get dinner,” he said after awhile, “or the cats’ll get to it. Actually, they already have.” He laughed at that.
 
 After dinner I boiled some tea and sat by the heater to write in my journal. In ten minutes I was curled up in the chair asleep. It was so nice being warm.
-
 ---
-
+---
+date: '2010-02-10'
+start: Neel Gap Hostel
+destination: Low Gap Shelter
+miles_today: 11.0
+trip_miles: 49.5
+facts:
+  weather: High 38°F, low 20°F. Light drizzle.
+  trail_section: Trail section from Neel Gap Hostel to Low Gap Shelter.
+  confidence: medium
+  sources:
+  - Open-Meteo archive
+---
 # Wednesday, February 10, 2010 — Low Gap Shelter
 **Start Location:** Neel Gap Hostel
 **Miles Today:** 11
@@ -184,24 +265,19 @@ In the morning I got up at 6:15 to get a hot shower before the others did, then 
 That day was divided sharply between great and God-awful. The first half, the great part, flew past as I hoofed without stopping through the wind and rain. 6 miles over to Tesnatee Gap. I went hard and strong and felt like a champ. But after a short stop at Tesnatee, things fell apart. During the stop, I’d quickly lost all doby and hand heart and became a numb-fingered, shivering - and , not to mention, dripping wet – mess. My hands lost the benign feeling of numbness and began to hurt like someone was bending them back. Groaning aloud and cursing, I began to march. I won’t go into details because the next 4 hours was a drama of the most boring kind. I’ll just say it really sucked and skip to the moment with God, which occurred near the end of the ordeal. I was mouthing off at him again (aloud, mind you), not really making a case but just pissed at the day’s suffering. I had to yell at someone. I told h im to make it okay, or at least give me the big picture so I could at least calm down. All of the sudden, I said it aloud, “This is all part of it”. This is part of the Good, the adventure, the chase after an elusive Spirit. This very moment of numb hands, wet clothes and stabbing blisters was the very reason I set off. Because this is Thoreau’s “marrow of life”, and in it I will find my God.
 
 I went to sleep that night with no idea what to do about my blisters for the next day. The wind picked up and a fog rolled in and the night was all dense blackness and I thought to myself about the old proverb “When I saw I stumbled.”
-
 ---
 ---
 date: '2010-02-11'
-title: EconoLodge Motel (Helen, GA)
-start_location: Low Gap Shelter
+start: Low Gap Shelter
 destination: EconoLodge Motel (Helen, GA)
-miles_hiked: 13.5
-total_miles: 63.0
-weather_high_f: 42.5
-weather_low_f: 24.5
-weather_precip_in: 0.0
-weather_conditions: Overcast
-weather_source: Open-Meteo archive
-trail_section_summary: Trail section from Low Gap Shelter to EconoLodge Motel (Helen,
-  GA).
-weather_summary: High 42°F, low 24°F. Overcast.
-facts_confidence: 0.5
+miles_today: 13.5
+trip_miles: 63.0
+facts:
+  weather: High 42°F, low 24°F. Overcast.
+  trail_section: Trail section from Low Gap Shelter to EconoLodge Motel (Helen, GA).
+  confidence: medium
+  sources:
+  - Open-Meteo archive
 ---
 # Thursday, February 11, 2010 — EconoLodge Motel (Helen, GA)
 **Start Location:** Low Gap Shelter
@@ -214,7 +290,17 @@ To my surprise, the down booties did an excellent job. By the time I reached the
 
 I gave Kevin some cheese, warmed my hands up by the fire, and marched on down to Unicoi Gap to hitch into town. Dry gear and a warm motel were in high demand. After a minute of thumbing a black car pulled over. Alex, a gay artist on his way to see his boyfriend, was glad to drive me around town to check various motel prices. He was “paying back a favor, or paying it forward, whichever one” He said in his hometown, Hayesville, NC, alcohol had just become legal last month. He had been a vocal advocate. His father, a Baptist minister, had led the opposition. I laughed. Alex said goodbye at the EconoLodge, and I fell asleep on my $30/night bed. I woke up, took a shower, called home, and ate some shrimp ramen with tuna and olive oil. Everyone seemed fine at home, like they’d moved on without me as I’m accustomed to them doing. When you’re away, all you can really say is “I love you” or “I miss you” but those words don’t mean much. It still kinda sucks. I thought about that while I ate my ramen. That night I watched a cheesy movie about aliens. I just didn’t feel like writing.
 ---
-
+---
+date: '2010-02-12'
+start: EconoLodge Motel (Helen, GA)
+destination: Mull's Motel (Hiawasee, GA)
+miles_today: 15.0
+trip_miles: 78.0
+facts:
+  trail_section: Trail section from EconoLodge Motel (Helen, GA) to Mull's Motel (Hiawasee,
+    GA).
+  confidence: low
+---
 # Friday, February 12, 2010 — Mull's Motel (Hiawasee, GA)
 **Start Location:** EconoLodge Motel (Helen, GA)
 **Miles Today:** 15
@@ -231,9 +317,18 @@ That day on the trail was great. I passed one hiker after another, meeting and g
 After a long nap at the top of Tray, I passed two thru-hikers, Fauma and Second Stage, on the way down the mountain (when I say “down the mountain”, I’m referring t the many ups and downs between a summit and a gap. Rarely is there black-and-white ascent and descent on the AT). All day, I’d been tracking their prints through the snow and around the debris. Catching up to them was the climax of the day. “You hear about these hikers ahead of you and you read all their entries in the shelter journals. You start to paint a mental picture of them,” I told Fauma when I caught him. “It’s kinda like online dating.” He laughed, “Wow, guy”.
 
 My eyes were set on Dicks Creek Gap, still 5.5 miles away by dusk. I flicked on my headlamp, chugged some orange juice and kept trucking. My legs were tired and my feet sore from walking in my booties for 8 miles already. I made it by 7:30 and hitched a ride into Hiawasee by 8pm. I got a motel room for $50 despite efforts at bargaining. I walked across the street to Hardee’s for dinner. I wrote, took a hot shower, and fell asleep by 11:00 with the lights on.
-
 ---
-
+---
+date: '2010-02-13'
+start: Mull's Motel (Hiawasee, GA)
+destination: Mull's Motel (Hiawasee, GA)
+miles_today: 0.0
+trip_miles: 78.0
+facts:
+  trail_section: Trail section from Mull's Motel (Hiawasee, GA) to Mull's Motel (Hiawasee,
+    GA).
+  confidence: low
+---
 # Saturday, February 13, 2010 — Mull's Motel (Hiawasee, GA)
 **Start Location:** Mull's Motel (Hiawasee, GA)
 **Miles Today:** 0
@@ -250,9 +345,18 @@ I had only 60 some dollars left, so another night at the motel was out of the qu
 The kind folks who gave me a ride (out of their way) to Blueberry Patch Hostel dropped me off at a church at the junction where they returned to their route to Atlanta to see their sick mother. I’ve always wanted to test out the church as a place of unconditional refuge, so I walked up to the office and knocked on the door. No answer. Just before walking back out to the road to thumb to another church, I noticed a small house on the corner of the church property. A pick-up was out front. I walked up and knocked, and to my surprise a younger man opened the door. He was hip-looking, sharp, kinda like a Young Life leader. “Let me see what I can do. Come on in.” I knelt down to pet the lab. “You know, I’m a thru-hiker back in 1996”. I couldn’t believe it. But the magic didn’t stop there. He said, “Follow me” and we walked over to the church. He flicked on the light in a room, “Wait in there and I’m gonna try to pull some strings,” he said, then disappeared. I read a bible for about five minutes, when a gleaming middle-aged woman walked in. “I’m Lynn”, she said. “I’m Gary’s wife, at the Blueberry Patch. We’re gonna get you a room in town.” I couldn’t believe it. Lynn, the gleaming secretary at the church, at which I fortuitously knocked, was the wife of the woner of the hostel where I’d just stopped, wife of a man who’s Christian kindness spread his name all the way to Richmond. And this connection was dropped in my lap by a sympathetic thru-hiking pastor. “We’re going to get you a room at Mull’s Motel”, she said. My stomach dropped. The burned carpet. That’s where I left the burned carpet. “Let me drive you to Mull’s” said the young pastor. We pulled in and I prepared for impact upon entering the cramped motel office. Fortunately, the 86 year old lady was still there in her nightgown, just like I’d seen her the evening before. And, (thanks to her age, perhaps) she didn’t remember me. I couldn’t believe it. I was redeemed. “I really don’t know how to thank you, man,” I said. “It just works out, doesn’t it”, he said. I think from time to time God has fun and wires things. Redemption of unbelievable cause-and-effect complexity. Even miracles. No, it’s not in his nature. It’s not all like that. Jesus spent but a sliver of his hours dropping jaws with these unbelievable occurances. Most of his days were spent walking around in the dust, telling people that, yeah..reality can be really boring but it’s okay. The miracles almost never happen around town but it doesn’t matter because the real miracle is deep within. The real wonder is the heart and soul of man. So, I won’t walk to Maine looking for him to wink at me again. I’ll keep looking within.
 
 Snow fell that night in Hiawasee, about 2 inches. I ate my trail mix and wrote oa letter to the Potteats from the warmth of my motel room. After two nights of comfort, I was ready to hit the trail again.
-
 ---
-
+---
+date: '2010-02-14'
+start: Mull's Motel (Hiawasee, GA)
+destination: Blueberry Patch Hostel
+miles_today: 0.0
+trip_miles: 78.0
+facts:
+  trail_section: Trail section from Mull's Motel (Hiawasee, GA) to Blueberry Patch
+    Hostel.
+  confidence: low
+---
 # Sunday, February 14, 2010 — Blueberry Patch Hostel
 **Start Location:** Mull's Motel (Hiawasee, GA)
 **Miles Today:** 0
@@ -267,5 +371,4 @@ We chatted as he lit the wood stove in the bunkhouse. Gary was a talker, and tol
 The telephone rang and he walked over an answered it. Another hiker was on his way. Soon, a familiar face appeared at the door. Keven, the Canadian I'd met on Blue Mountain, walked in the door. He was thrilled to see me. I was glad to see him.
 
 That night we went into Hiawasee. We bought food for the next stretch to Fontana Dam, a tedious process of diving out calories on price. Keven convinced me to share food together over the next two weeks--breakfast, lunch, and dinner. Sounded like a good idea. I mean, why not? We also got some steaks and asparagus to take back to cook. I bought a crispy Fuji apple. Back at the hostel, we ate heartily and stayed up until 1:00 dividing ten days of food weight.
-
 ---

--- a/tests/fixtures/sample_weather_response.json
+++ b/tests/fixtures/sample_weather_response.json
@@ -1,0 +1,23 @@
+{
+  "latitude": 34.69,
+  "longitude": -84.154,
+  "generationtime_ms": 0.23,
+  "utc_offset_seconds": 0,
+  "timezone": "GMT",
+  "timezone_abbreviation": "GMT",
+  "elevation": 762.0,
+  "daily_units": {
+    "time": "iso8601",
+    "temperature_2m_max": "°F",
+    "temperature_2m_min": "°F",
+    "precipitation_sum": "inch",
+    "weathercode": "wmo code"
+  },
+  "daily": {
+    "time": ["2010-03-15"],
+    "temperature_2m_max": [52.3],
+    "temperature_2m_min": [38.1],
+    "precipitation_sum": [0.12],
+    "weathercode": [61]
+  }
+}

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -1,0 +1,221 @@
+"""Unit tests for scripts/facts/compiler.py."""
+import pytest
+
+from scripts.facts.models import (
+    Claim,
+    DraftFacts,
+    TownEventsResult,
+    ValidationResult,
+    VerifiedClaim,
+    WeatherFacts,
+)
+from scripts.facts.compiler import compile_facts, format_weather_str
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _claim(text: str, ctype: str = "landmark") -> Claim:
+    return Claim(type=ctype, text=text)
+
+
+def _vc(text: str, source: str = "AT location database", conf: float = 1.0) -> VerifiedClaim:
+    return VerifiedClaim(claim=_claim(text), source=source, confidence=conf)
+
+
+def _weather(high=55.0, low=32.0, cond="Partly cloudy") -> WeatherFacts:
+    return WeatherFacts(
+        high_f=high,
+        low_f=low,
+        precip_in=0.1,
+        conditions=cond,
+        source="Open-Meteo archive",
+        coords=(34.5, -84.2),
+    )
+
+
+def _draft(summary="Test section.", claims=None) -> DraftFacts:
+    return DraftFacts(
+        trail_section_summary=summary,
+        claims=claims or [],
+        at_mile_start=None,
+        at_mile_end=8.1,
+        state="Georgia",
+        nearest_town=None,
+    )
+
+
+def _meta():
+    return {
+        "date": "2010-02-07",
+        "destination": "Hawk Mountain Shelter",
+        "start_location": "Hike Inn",
+        "miles_hiked": 9.0,
+        "total_miles": 9.0,
+    }
+
+
+# ---------------------------------------------------------------------------
+# format_weather_str
+# ---------------------------------------------------------------------------
+
+class TestFormatWeatherStr:
+    def test_full_weather(self):
+        w = _weather(55.0, 32.0, "Partly cloudy")
+        s = format_weather_str(w)
+        assert "55" in s
+        assert "32" in s
+        assert "Partly cloudy" in s
+
+    def test_high_only(self):
+        w = WeatherFacts(high_f=60.0, low_f=None, precip_in=None,
+                         conditions=None, source="test", coords=None)
+        s = format_weather_str(w)
+        assert "60" in s
+        assert "low" not in s.lower()
+
+    def test_low_only(self):
+        w = WeatherFacts(high_f=None, low_f=28.0, precip_in=None,
+                         conditions=None, source="test", coords=None)
+        s = format_weather_str(w)
+        assert "28" in s
+
+    def test_none_weather(self):
+        assert format_weather_str(None) == ""
+
+    def test_no_temps_returns_empty(self):
+        w = WeatherFacts(high_f=None, low_f=None, precip_in=None,
+                         conditions="Sunny", source="test", coords=None)
+        assert format_weather_str(w) == ""
+
+    def test_conditions_period_not_doubled(self):
+        w = WeatherFacts(high_f=50.0, low_f=30.0, precip_in=None,
+                         conditions="Clear sky.", source="test", coords=None)
+        s = format_weather_str(w)
+        assert ".." not in s
+
+
+# ---------------------------------------------------------------------------
+# compile_facts — confidence levels
+# ---------------------------------------------------------------------------
+
+class TestCompileFactsConfidence:
+    def test_high_confidence_two_verified_plus_weather(self):
+        validation = ValidationResult(
+            verified=[_vc("Claim A"), _vc("Claim B")],
+            rejected=[],
+            corrections=[],
+        )
+        compiled = compile_facts(validation, _weather(), TownEventsResult(), _meta())
+        assert compiled.confidence >= 0.8
+
+    def test_medium_confidence_weather_only(self):
+        validation = ValidationResult(verified=[], rejected=[], corrections=[])
+        compiled = compile_facts(validation, _weather(), TownEventsResult(), _meta())
+        assert 0.3 <= compiled.confidence < 0.8
+
+    def test_low_confidence_no_weather_no_verified(self):
+        validation = ValidationResult(verified=[], rejected=[], corrections=[])
+        compiled = compile_facts(validation, None, TownEventsResult(), _meta())
+        assert compiled.confidence < 0.3
+
+    def test_one_verified_plus_weather_medium_not_high(self):
+        validation = ValidationResult(
+            verified=[_vc("Single claim")],
+            rejected=[],
+            corrections=[],
+        )
+        compiled = compile_facts(validation, _weather(), TownEventsResult(), _meta())
+        # One verified claim is < 2, so not high confidence
+        assert compiled.confidence < 0.8
+
+
+# ---------------------------------------------------------------------------
+# compile_facts — output structure
+# ---------------------------------------------------------------------------
+
+class TestCompileFactsOutput:
+    def test_weather_stored_when_present(self):
+        validation = ValidationResult(verified=[], rejected=[], corrections=[])
+        compiled = compile_facts(validation, _weather(), TownEventsResult(), _meta())
+        assert compiled.weather is not None
+        assert compiled.weather.high_f == 55.0
+
+    def test_weather_none_when_absent(self):
+        validation = ValidationResult(verified=[], rejected=[], corrections=[])
+        compiled = compile_facts(validation, None, TownEventsResult(), _meta())
+        assert compiled.weather is None
+
+    def test_weather_none_when_no_temps(self):
+        w = WeatherFacts(high_f=None, low_f=None, precip_in=None,
+                         conditions="Sunny", source="test", coords=None)
+        validation = ValidationResult(verified=[], rejected=[], corrections=[])
+        compiled = compile_facts(validation, w, TownEventsResult(), _meta())
+        assert compiled.weather is None
+
+    def test_trail_section_populated_from_draft(self):
+        claims = [_claim("Claim 1"), _claim("Claim 2")]
+        draft = _draft(claims=claims)
+        validation = ValidationResult(
+            verified=[_vc("Claim 1"), _vc("Claim 2")],
+            rejected=[],
+            corrections=[],
+        )
+        compiled = compile_facts(validation, _weather(), TownEventsResult(), _meta(), draft)
+        assert compiled.trail_section is not None
+        assert len(compiled.trail_section.claims) == 2
+        assert compiled.trail_section.state == "Georgia"
+
+    def test_trail_section_filters_to_verified_only(self):
+        c1, c2, c3 = _claim("Keep"), _claim("Keep too"), _claim("Reject")
+        draft = _draft(claims=[c1, c2, c3])
+        validation = ValidationResult(
+            verified=[_vc("Keep"), _vc("Keep too")],
+            rejected=[c3],
+            corrections=[],
+        )
+        compiled = compile_facts(validation, _weather(), TownEventsResult(), _meta(), draft)
+        texts = [c.text for c in compiled.trail_section.claims]
+        assert "Keep" in texts
+        assert "Keep too" in texts
+        assert "Reject" not in texts
+
+    def test_sources_collected(self):
+        validation = ValidationResult(
+            verified=[_vc("Claim", source="AT location database")],
+            rejected=[],
+            corrections=[],
+        )
+        compiled = compile_facts(validation, _weather(), TownEventsResult(), _meta())
+        assert "AT location database" in compiled.sources
+        assert "Open-Meteo archive" in compiled.sources
+
+    def test_sources_deduplicated(self):
+        validation = ValidationResult(
+            verified=[
+                _vc("C1", source="AT location database"),
+                _vc("C2", source="AT location database"),
+            ],
+            rejected=[],
+            corrections=[],
+        )
+        compiled = compile_facts(validation, _weather(), TownEventsResult(), _meta())
+        assert compiled.sources.count("AT location database") == 1
+
+    def test_town_events_stored(self):
+        te = TownEventsResult(event="Trail Days festival", source="web", confidence=0.8)
+        validation = ValidationResult(verified=[], rejected=[], corrections=[])
+        compiled = compile_facts(validation, None, te, _meta())
+        assert compiled.town_events is not None
+        assert compiled.town_events.event == "Trail Days festival"
+
+    def test_no_draft_reconstructs_from_verified(self):
+        validation = ValidationResult(
+            verified=[_vc("Lone claim")],
+            rejected=[],
+            corrections=[],
+        )
+        compiled = compile_facts(validation, None, TownEventsResult(), _meta())
+        assert compiled.trail_section is not None
+        assert compiled.trail_section.claims[0].text == "Lone claim"

--- a/tests/test_frontmatter.py
+++ b/tests/test_frontmatter.py
@@ -1,0 +1,213 @@
+"""Unit tests for scripts/facts/frontmatter.py."""
+import pytest
+import yaml
+
+from scripts.facts.models import (
+    Claim,
+    CompiledFacts,
+    DraftFacts,
+    TownEventsResult,
+    WeatherFacts,
+)
+from scripts.facts.frontmatter import (
+    build_frontmatter,
+    has_frontmatter,
+    inject_frontmatter,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _weather() -> WeatherFacts:
+    return WeatherFacts(
+        high_f=55.0,
+        low_f=32.0,
+        precip_in=0.0,
+        conditions="Partly cloudy",
+        source="Open-Meteo archive",
+        coords=(34.5, -84.2),
+    )
+
+
+def _draft() -> DraftFacts:
+    return DraftFacts(
+        trail_section_summary="From Hike Inn to Hawk Mountain through hardwood forest.",
+        claims=[Claim("terrain", "Rocky ridgeline hiking through the Georgia Blue Ridge.")],
+        at_mile_start=None,
+        at_mile_end=8.1,
+        state="Georgia",
+        nearest_town=None,
+    )
+
+
+def _compiled(with_weather=True, with_draft=True) -> CompiledFacts:
+    return CompiledFacts(
+        weather=_weather() if with_weather else None,
+        trail_section=_draft() if with_draft else None,
+        town_events=TownEventsResult(event=None),
+        confidence=0.9,
+        sources=["AT location database", "Open-Meteo archive"],
+    )
+
+
+def _metadata():
+    return {
+        "date": "2010-02-07",
+        "destination": "Hawk Mountain Shelter",
+        "start_location": "Hike Inn",
+        "miles_hiked": 9.0,
+        "total_miles": 9.0,
+    }
+
+
+# ---------------------------------------------------------------------------
+# has_frontmatter
+# ---------------------------------------------------------------------------
+
+class TestHasFrontmatter:
+    def test_returns_true_for_valid_frontmatter(self):
+        entry = "---\ndate: 2010-02-07\n---\n# Header"
+        assert has_frontmatter(entry) is True
+
+    def test_returns_false_for_plain_entry(self):
+        entry = "# Thursday, February 07, 2010 — Hawk Mountain Shelter\nBody"
+        assert has_frontmatter(entry) is False
+
+    def test_returns_false_for_empty_string(self):
+        assert has_frontmatter("") is False
+
+    def test_leading_whitespace_handled(self):
+        entry = "\n---\ndate: 2010-02-07\n---\n# Header"
+        assert has_frontmatter(entry) is True
+
+    def test_single_dash_line_not_frontmatter(self):
+        entry = "-\n# Header"
+        assert has_frontmatter(entry) is False
+
+
+# ---------------------------------------------------------------------------
+# build_frontmatter
+# ---------------------------------------------------------------------------
+
+class TestBuildFrontmatter:
+    def test_starts_and_ends_with_delimiters(self):
+        fm = build_frontmatter(_metadata(), _compiled())
+        assert fm.startswith("---\n")
+        assert fm.rstrip("\n").endswith("---")
+
+    def test_contains_date(self):
+        fm = build_frontmatter(_metadata(), _compiled())
+        assert "2010-02-07" in fm
+
+    def test_contains_destination(self):
+        fm = build_frontmatter(_metadata(), _compiled())
+        assert "Hawk Mountain Shelter" in fm
+
+    def test_contains_start_location(self):
+        fm = build_frontmatter(_metadata(), _compiled())
+        assert "Hike Inn" in fm
+
+    def test_contains_weather_fields(self):
+        fm = build_frontmatter(_metadata(), _compiled(with_weather=True))
+        assert "55" in fm
+        assert "32" in fm
+
+    def test_weather_summary_string(self):
+        fm = build_frontmatter(_metadata(), _compiled(with_weather=True))
+        assert "Partly cloudy" in fm
+
+    def test_omits_none_values(self):
+        fm = build_frontmatter(_metadata(), _compiled(with_weather=False, with_draft=False))
+        # Should not contain explicit 'null' or 'None' for omitted optional fields
+        assert "null" not in fm
+        assert ": None" not in fm
+
+    def test_valid_yaml(self):
+        fm = build_frontmatter(_metadata(), _compiled())
+        inner = fm.strip().lstrip("-").split("---")[0].strip()
+        parsed = yaml.safe_load(inner)
+        assert isinstance(parsed, dict)
+
+    def test_roundtrip_date_parseable(self):
+        fm = build_frontmatter(_metadata(), _compiled())
+        inner = fm.strip().lstrip("-").split("---")[0].strip()
+        parsed = yaml.safe_load(inner)
+        assert str(parsed.get("date", "")).startswith("2010")
+
+    def test_confidence_present(self):
+        fm = build_frontmatter(_metadata(), _compiled())
+        assert "facts_confidence" in fm
+
+    def test_state_included_when_present(self):
+        fm = build_frontmatter(_metadata(), _compiled(with_draft=True))
+        assert "Georgia" in fm
+
+    def test_at_mile_end_included(self):
+        fm = build_frontmatter(_metadata(), _compiled(with_draft=True))
+        assert "8.1" in fm or "8" in fm
+
+
+# ---------------------------------------------------------------------------
+# inject_frontmatter
+# ---------------------------------------------------------------------------
+
+class TestInjectFrontmatter:
+    _fm = "---\ndate: 2010-02-07\n---\n"
+    _entry = "# Thursday, February 07, 2010 — Hawk Mountain Shelter\n**Start Location:** Hike Inn\n\nBody text."
+
+    def test_result_starts_with_frontmatter(self):
+        result = inject_frontmatter(self._entry, self._fm)
+        assert result.startswith("---\n")
+
+    def test_header_appears_after_frontmatter(self):
+        result = inject_frontmatter(self._entry, self._fm)
+        assert result.index("# Thursday") > result.index("---")
+
+    def test_body_preserved(self):
+        result = inject_frontmatter(self._entry, self._fm)
+        assert "Body text." in result
+
+    def test_header_preserved(self):
+        result = inject_frontmatter(self._entry, self._fm)
+        assert "# Thursday, February 07, 2010" in result
+
+    def test_no_header_entry_prepended(self):
+        entry = "Just plain text without a header."
+        result = inject_frontmatter(entry, self._fm)
+        assert result.startswith("---\n")
+        assert "Just plain text" in result
+
+    def test_has_frontmatter_true_after_inject(self):
+        result = inject_frontmatter(self._entry, self._fm)
+        assert has_frontmatter(result)
+
+    def test_inject_idempotent_structure(self):
+        """Injecting into an entry without frontmatter produces one --- block at start."""
+        result = inject_frontmatter(self._entry, self._fm)
+        assert result.count("---") >= 2
+
+
+# ---------------------------------------------------------------------------
+# build + inject roundtrip
+# ---------------------------------------------------------------------------
+
+class TestRoundtrip:
+    def test_full_roundtrip(self):
+        meta = _metadata()
+        compiled = _compiled()
+        fm = build_frontmatter(meta, compiled)
+        entry = "# Thursday, February 07, 2010 — Hawk Mountain Shelter\n\nSome journal text."
+        result = inject_frontmatter(entry, fm)
+
+        assert has_frontmatter(result)
+        assert "# Thursday" in result
+        assert "journal text" in result
+
+    def test_parsed_yaml_has_expected_keys(self):
+        fm = build_frontmatter(_metadata(), _compiled())
+        inner = fm.strip().lstrip("-").split("---")[0].strip()
+        parsed = yaml.safe_load(inner)
+        for key in ("date", "destination", "start_location", "miles_hiked"):
+            assert key in parsed, f"Missing key: {key}"

--- a/tests/test_frontmatter.py
+++ b/tests/test_frontmatter.py
@@ -138,15 +138,13 @@ class TestBuildFrontmatter:
 
     def test_confidence_present(self):
         fm = build_frontmatter(_metadata(), _compiled())
-        assert "facts_confidence" in fm
+        assert "confidence:" in fm
+        assert "facts:" in fm
 
-    def test_state_included_when_present(self):
+    def test_trail_section_in_facts(self):
         fm = build_frontmatter(_metadata(), _compiled(with_draft=True))
-        assert "Georgia" in fm
-
-    def test_at_mile_end_included(self):
-        fm = build_frontmatter(_metadata(), _compiled(with_draft=True))
-        assert "8.1" in fm or "8" in fm
+        assert "trail_section:" in fm
+        assert "Georgia" in fm or "hardwood" in fm.lower()
 
 
 # ---------------------------------------------------------------------------
@@ -209,5 +207,5 @@ class TestRoundtrip:
         fm = build_frontmatter(_metadata(), _compiled())
         inner = fm.strip().lstrip("-").split("---")[0].strip()
         parsed = yaml.safe_load(inner)
-        for key in ("date", "destination", "start_location", "miles_hiked"):
+        for key in ("date", "destination", "start", "miles_today", "facts"):
             assert key in parsed, f"Missing key: {key}"

--- a/tests/test_location_resolver.py
+++ b/tests/test_location_resolver.py
@@ -100,19 +100,19 @@ class TestIsTownDay:
         meta = self._make_metadata(destination="EconoLodge Motel (Helen, GA)")
         assert is_town_day(meta) is True
 
-    def test_hostel_in_destination(self):
+    def test_hostel_trail_lodge_not_town(self):
         meta = self._make_metadata(destination="Neel Gap Hostel")
-        assert is_town_day(meta) is True
+        assert is_town_day(meta) is False
 
-    def test_inn_in_destination(self):
+    def test_inn_trail_lodge_not_town(self):
         meta = self._make_metadata(destination="Hike Inn")
-        assert is_town_day(meta) is True
+        assert is_town_day(meta) is False
 
     def test_hotel_in_destination(self):
         meta = self._make_metadata(destination="Holiday Hotel (Franklin, NC)")
         assert is_town_day(meta) is True
 
-    def test_lodge_in_start(self):
+    def test_lodge_with_town_in_start(self):
         meta = self._make_metadata(start_location="Mountain Lodge (Hiawassee, GA)")
         assert is_town_day(meta) is True
 
@@ -120,9 +120,9 @@ class TestIsTownDay:
         meta = self._make_metadata(destination="Some Place (Franklin, NC)")
         assert is_town_day(meta) is True
 
-    def test_zero_miles(self):
+    def test_zero_miles_shelter_not_town(self):
         meta = self._make_metadata(destination="Hawk Mountain Shelter", miles_hiked=0)
-        assert is_town_day(meta) is True
+        assert is_town_day(meta) is False
 
     def test_trail_shelter_not_town(self):
         meta = self._make_metadata(

--- a/tests/test_location_resolver.py
+++ b/tests/test_location_resolver.py
@@ -1,0 +1,159 @@
+import pytest
+from scripts.facts.models import EntryMetadata
+from scripts.facts.location_resolver import (
+    lookup,
+    normalize_name,
+    extract_town_from_location,
+    is_town_day,
+    resolve_coords,
+)
+
+
+class TestNormalizeName:
+    def test_lowercase(self):
+        assert normalize_name("Hawk Mountain Shelter") == "hawk mountain shelter"
+
+    def test_strips_parenthetical(self):
+        assert normalize_name("EconoLodge (Helen, GA)") == "econolodge"
+
+    def test_strips_whitespace(self):
+        assert normalize_name("  Low Gap Shelter  ") == "low gap shelter"
+
+    def test_parenthetical_with_inner_spaces(self):
+        assert normalize_name("Best Western (Hiawassee, GA)") == "best western"
+
+
+class TestLookup:
+    def test_hawk_mountain_shelter(self):
+        result = lookup("Hawk Mountain Shelter")
+        assert result is not None
+        assert abs(result["lat"] - 34.6899) < 0.01
+        assert abs(result["lon"] - -84.154) < 0.01
+        assert result["state"] == "GA"
+        assert result["at_mile"] == pytest.approx(8.1)
+        assert result["is_town"] is False
+
+    def test_gooch_mountain_shelter(self):
+        result = lookup("Gooch Mountain Shelter")
+        assert result is not None
+        assert result["state"] == "GA"
+        assert result["at_mile"] == pytest.approx(15.8)
+
+    def test_neel_gap_hostel(self):
+        result = lookup("Neel Gap Hostel")
+        assert result is not None
+        assert result["state"] == "GA"
+
+    def test_low_gap_shelter(self):
+        result = lookup("Low Gap Shelter")
+        assert result is not None
+        assert result["at_mile"] == pytest.approx(38.5)
+
+    def test_hiawassee_is_town(self):
+        result = lookup("Hiawassee GA")
+        assert result is not None
+        assert result["is_town"] is True
+
+    def test_helen_is_town(self):
+        result = lookup("Helen GA")
+        assert result is not None
+        assert result["is_town"] is True
+
+    def test_unknown_location_returns_none(self):
+        assert lookup("Nowhere Special Shelter") is None
+
+    def test_case_insensitive(self):
+        result = lookup("hawk mountain shelter")
+        assert result is not None
+
+    def test_parenthetical_stripped_before_lookup(self):
+        # "Neel Gap Hostel" should match with or without extra parens
+        result = lookup("Hawk Mountain Shelter (GA)")
+        assert result is not None
+
+
+class TestExtractTownFromLocation:
+    def test_extracts_town(self):
+        assert extract_town_from_location("EconoLodge Motel (Helen, GA)") == "Helen, GA"
+
+    def test_extracts_hiawassee(self):
+        assert extract_town_from_location("Budget Inn (Hiawassee, GA)") == "Hiawassee, GA"
+
+    def test_no_parenthetical_returns_none(self):
+        assert extract_town_from_location("Hawk Mountain Shelter") is None
+
+    def test_empty_string_returns_none(self):
+        assert extract_town_from_location("") is None
+
+
+class TestIsTownDay:
+    def _make_metadata(self, destination="", start_location="", miles_hiked=10.0):
+        return EntryMetadata(
+            date="2010-03-15",
+            start_location=start_location,
+            destination=destination,
+            miles_hiked=miles_hiked,
+            total_miles=50.0,
+        )
+
+    def test_motel_in_destination(self):
+        meta = self._make_metadata(destination="EconoLodge Motel (Helen, GA)")
+        assert is_town_day(meta) is True
+
+    def test_hostel_in_destination(self):
+        meta = self._make_metadata(destination="Neel Gap Hostel")
+        assert is_town_day(meta) is True
+
+    def test_inn_in_destination(self):
+        meta = self._make_metadata(destination="Hike Inn")
+        assert is_town_day(meta) is True
+
+    def test_hotel_in_destination(self):
+        meta = self._make_metadata(destination="Holiday Hotel (Franklin, NC)")
+        assert is_town_day(meta) is True
+
+    def test_lodge_in_start(self):
+        meta = self._make_metadata(start_location="Mountain Lodge (Hiawassee, GA)")
+        assert is_town_day(meta) is True
+
+    def test_parenthetical_state_in_destination(self):
+        meta = self._make_metadata(destination="Some Place (Franklin, NC)")
+        assert is_town_day(meta) is True
+
+    def test_zero_miles(self):
+        meta = self._make_metadata(destination="Hawk Mountain Shelter", miles_hiked=0)
+        assert is_town_day(meta) is True
+
+    def test_trail_shelter_not_town(self):
+        meta = self._make_metadata(
+            destination="Hawk Mountain Shelter",
+            start_location="Springer Mountain",
+            miles_hiked=8.1,
+        )
+        assert is_town_day(meta) is False
+
+    def test_normal_hiking_day(self):
+        meta = self._make_metadata(
+            destination="Gooch Mountain Shelter",
+            start_location="Hawk Mountain Shelter",
+            miles_hiked=7.7,
+        )
+        assert is_town_day(meta) is False
+
+
+class TestResolveCoords:
+    def test_both_known(self):
+        coords = resolve_coords("Hawk Mountain Shelter", "Gooch Mountain Shelter")
+        assert coords is not None
+        lat, lon = coords
+        assert 34.0 < lat < 35.5
+        assert -85.0 < lon < -83.0
+
+    def test_one_unknown_falls_back_to_known(self):
+        coords = resolve_coords("Hawk Mountain Shelter", "Nowhere Special")
+        assert coords is not None
+        lat, lon = coords
+        assert abs(lat - 34.6899) < 0.01
+
+    def test_both_unknown_returns_none(self):
+        assert resolve_coords("Nowhere A", "Nowhere B") is None

--- a/tests/test_segment_guide.py
+++ b/tests/test_segment_guide.py
@@ -1,0 +1,43 @@
+"""Tests for mile-range segment guide descriptions."""
+from scripts.facts.segment_guide import (
+    build_segment_description,
+    guides_overlapping,
+    resolve_mile_range,
+)
+
+
+def test_guides_overlapping_smokies_exit():
+    guides = guides_overlapping(260, 275)
+    names = [g["name"] for g in guides]
+    assert any("Smokies" in n or "Cherokee" in n or "balds" in n.lower() for n in names)
+
+
+def test_resolve_mile_range_from_trip_miles():
+    start, end = resolve_mile_range("Unknown", "Roaring Fork Shelter", 11.5, 274.8)
+    assert end == 274.8
+    assert start is not None
+    assert start < end
+
+
+def test_build_segment_description_has_rich_text():
+    summary, claims, meta = build_segment_description(
+        "Groundhog Creek Shelter",
+        "Roaring Fork Shelter",
+        11.5,
+        274.8,
+    )
+    assert summary
+    assert "AT miles" in summary
+    assert meta.get("segment_name")
+    assert len(claims) >= 2
+
+
+def test_build_segment_description_katahdin():
+    summary, _, meta = build_segment_description(
+        "The Birches Lean-tos",
+        "Baxter Peak, Mount Katahdin",
+        5.2,
+        2179.5,
+    )
+    assert "Katahdin" in summary or "Baxter" in summary
+    assert meta["at_mile_end"] >= 2150

--- a/tests/test_weather_agent.py
+++ b/tests/test_weather_agent.py
@@ -1,0 +1,143 @@
+import json
+import pytest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+from scripts.facts.weather_agent import fetch_weather, _wmo_to_conditions
+from scripts.facts.models import WeatherFacts
+
+FIXTURE_PATH = Path(__file__).parent / "fixtures" / "sample_weather_response.json"
+
+
+@pytest.fixture
+def sample_response_data():
+    with open(FIXTURE_PATH) as f:
+        return json.load(f)
+
+
+def _make_mock_response(data: dict, status_code: int = 200) -> MagicMock:
+    mock_resp = MagicMock()
+    mock_resp.status_code = status_code
+    mock_resp.json.return_value = data
+    mock_resp.raise_for_status = MagicMock()
+    return mock_resp
+
+
+class TestWmoToConditions:
+    def test_clear_sky(self):
+        assert _wmo_to_conditions(0) == "Clear sky"
+
+    def test_slight_rain(self):
+        assert _wmo_to_conditions(61) == "Slight rain"
+
+    def test_thunderstorm(self):
+        assert _wmo_to_conditions(95) == "Thunderstorm"
+
+    def test_heavy_snow(self):
+        assert _wmo_to_conditions(75) == "Heavy snow"
+
+    def test_unknown_code(self):
+        result = _wmo_to_conditions(999)
+        assert "999" in result
+
+
+class TestFetchWeather:
+    def test_returns_weather_facts_type(self, sample_response_data):
+        with patch("scripts.facts.weather_agent.requests.get") as mock_get:
+            mock_get.return_value = _make_mock_response(sample_response_data)
+            result = fetch_weather("2010-03-15", 34.69, -84.154)
+        assert isinstance(result, WeatherFacts)
+
+    def test_parses_temperature_high(self, sample_response_data):
+        with patch("scripts.facts.weather_agent.requests.get") as mock_get:
+            mock_get.return_value = _make_mock_response(sample_response_data)
+            result = fetch_weather("2010-03-15", 34.69, -84.154)
+        assert result.high_f == pytest.approx(52.3)
+
+    def test_parses_temperature_low(self, sample_response_data):
+        with patch("scripts.facts.weather_agent.requests.get") as mock_get:
+            mock_get.return_value = _make_mock_response(sample_response_data)
+            result = fetch_weather("2010-03-15", 34.69, -84.154)
+        assert result.low_f == pytest.approx(38.1)
+
+    def test_parses_precipitation(self, sample_response_data):
+        with patch("scripts.facts.weather_agent.requests.get") as mock_get:
+            mock_get.return_value = _make_mock_response(sample_response_data)
+            result = fetch_weather("2010-03-15", 34.69, -84.154)
+        assert result.precip_in == pytest.approx(0.12)
+
+    def test_parses_conditions_from_wmo_code(self, sample_response_data):
+        # Fixture has weathercode 61 → "Slight rain"
+        with patch("scripts.facts.weather_agent.requests.get") as mock_get:
+            mock_get.return_value = _make_mock_response(sample_response_data)
+            result = fetch_weather("2010-03-15", 34.69, -84.154)
+        assert result.conditions == "Slight rain"
+
+    def test_source_is_open_meteo(self, sample_response_data):
+        with patch("scripts.facts.weather_agent.requests.get") as mock_get:
+            mock_get.return_value = _make_mock_response(sample_response_data)
+            result = fetch_weather("2010-03-15", 34.69, -84.154)
+        assert "Open-Meteo" in result.source
+
+    def test_coords_match_input(self, sample_response_data):
+        with patch("scripts.facts.weather_agent.requests.get") as mock_get:
+            mock_get.return_value = _make_mock_response(sample_response_data)
+            result = fetch_weather("2010-03-15", 34.69, -84.154)
+        assert result.coords == (34.69, -84.154)
+
+    def test_no_caveat_on_success(self, sample_response_data):
+        with patch("scripts.facts.weather_agent.requests.get") as mock_get:
+            mock_get.return_value = _make_mock_response(sample_response_data)
+            result = fetch_weather("2010-03-15", 34.69, -84.154)
+        assert result.caveat is None
+
+    def test_request_exception_returns_caveat(self):
+        import requests as req_lib
+        with patch("scripts.facts.weather_agent.requests.get") as mock_get:
+            mock_get.side_effect = req_lib.exceptions.ConnectionError("Network error")
+            result = fetch_weather("2010-03-15", 34.69, -84.154)
+        assert result.caveat is not None
+        assert result.high_f is None
+        assert result.low_f is None
+
+    def test_timeout_returns_caveat(self):
+        import requests as req_lib
+        with patch("scripts.facts.weather_agent.requests.get") as mock_get:
+            mock_get.side_effect = req_lib.exceptions.Timeout()
+            result = fetch_weather("2010-03-15", 34.69, -84.154)
+        assert result.caveat is not None
+        assert "timed out" in result.caveat.lower()
+
+    def test_http_error_returns_caveat(self):
+        import requests as req_lib
+        with patch("scripts.facts.weather_agent.requests.get") as mock_get:
+            mock_resp = MagicMock()
+            mock_resp.raise_for_status.side_effect = req_lib.exceptions.HTTPError(
+                "500 Server Error"
+            )
+            mock_get.return_value = mock_resp
+            result = fetch_weather("2010-03-15", 34.69, -84.154)
+        assert result.caveat is not None
+
+    def test_malformed_json_returns_caveat(self):
+        with patch("scripts.facts.weather_agent.requests.get") as mock_get:
+            mock_resp = MagicMock()
+            mock_resp.raise_for_status = MagicMock()
+            mock_resp.json.side_effect = ValueError("No JSON")
+            mock_get.return_value = mock_resp
+            result = fetch_weather("2010-03-15", 34.69, -84.154)
+        assert result.caveat is not None
+
+    def test_missing_daily_key_returns_caveat(self):
+        with patch("scripts.facts.weather_agent.requests.get") as mock_get:
+            mock_get.return_value = _make_mock_response({"latitude": 34.69})
+            result = fetch_weather("2010-03-15", 34.69, -84.154)
+        assert result.caveat is not None
+        assert result.high_f is None
+
+    @pytest.mark.integration
+    def test_live_api_call(self):
+        """Calls the real Open-Meteo API. Excluded from normal test runs."""
+        result = fetch_weather("2010-03-15", 34.69, -84.154)
+        assert isinstance(result, WeatherFacts)
+        assert result.high_f is not None or result.caveat is not None


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements frontmatter facts enrichment with **per-segment AT mile guides**.

## Latest: rich segment detail (per section hiked)

Each entry now includes:
- `facts.segment` — named AT corridor (e.g. "Smokies exit to Hot Springs")
- `facts.at_mile_start` / `facts.at_mile_end` — mile range for that day's hike
- `facts.region` — state/region
- `facts.trail_section` — multi-sentence narrative: terrain, landmarks, section character

**132/133** entries now have segment detail (was 121 generic "Trail section from X to Y" fallbacks).

### Example (Mar 7, 2010 — Roaring Fork)
```yaml
facts:
  segment: Smokies exit to Hot Springs
  at_mile_start: 263.3
  at_mile_end: 274.8
  weather: High 44°F, low 23°F. Overcast.
  trail_section: 'Smokies exit to Hot Springs (AT miles 263–275): Northbound hikers leave the Smokies at Davenport Gap... Landmarks include Davenport Gap, Max Patch, Hot Springs.'
  confidence: high
```

## Uncle Frank example (`examples/uncle-frank/`)
- `journal.txt` — 133 raw entries
- `journal_facts.txt` — fully enriched with segment guides

## New files
- `data/at_segment_guides.json` — 27 mile-range section narratives
- `scripts/facts/segment_guide.py` — per-hike segment descriptions

92+ unit tests passing.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f486f-81b5-78b7-b770-f07342079bec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f486f-81b5-78b7-b770-f07342079bec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

